### PR TITLE
PLANET-4009: Articles: showing the current post too

### DIFF
--- a/classes/blocks/class-articles.php
+++ b/classes/blocks/class-articles.php
@@ -137,7 +137,12 @@ class Articles extends Base_Block {
 		$options              = get_option( 'planet4_options' );
 		$article_title        = $options['articles_block_title'] ?? __( 'Related Articles', 'planet4-blocks' );
 		$article_button_title = $options['articles_block_button_title'] ?? __( 'READ ALL THE NEWS', 'planet4-blocks' );
-		$exclude_post_id      = (int) ( $fields['exclude_post_id'] ?? '' );
+		$post_type            = get_post_type();
+
+		if ( 'post' === $post_type ) {
+			$exclude_post_id           = get_the_ID();
+			$fields['exclude_post_id'] = $exclude_post_id;
+		}
 
 		$fields['title']          = $fields['title'] ?? $article_title;
 		$fields['read_more_text'] = $fields['read_more_text'] ?? $article_button_title;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4009

The current post was not being excluded from the Articles list when the block is rendered inside posts. 

Note: this change fixes the issue, however the Articles block is rendered inside Posts using a shortcode in the master theme, we may want to revisit that in the near future.