### PR TITLE
[NO TICKET]: Add plugins to remove unneeded files and add them to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,12 @@ Thumbs.db
 #######################
 .idea
 reports
-react-blocks/build/*.deps.json
+
+# Webpack leftovers from SASS entry points #
+############################################
+react-blocks/build/editorStyle.js
+react-blocks/build/editorStyle.js.map
+react-blocks/build/editorStyle.deps.json
+react-blocks/build/style.js
+react-blocks/build/style.js.map
+react-blocks/build/style.deps.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -6451,8 +6451,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -6473,14 +6472,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -6495,20 +6492,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -6625,8 +6619,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -6638,7 +6631,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -6653,7 +6645,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -6661,14 +6652,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -6687,7 +6676,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -6768,8 +6756,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -6781,7 +6768,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -6867,8 +6853,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -6904,7 +6889,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -6924,7 +6908,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -6968,14 +6951,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -13239,6 +13220,11 @@
 				"through2": "^2.0.3"
 			}
 		},
+		"remove-files-webpack-plugin": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/remove-files-webpack-plugin/-/remove-files-webpack-plugin-1.1.3.tgz",
+			"integrity": "sha512-r53wQ/IlTkmcv11wri71CZ27S+GhFI5SjHbTbaAJbisPC3qGwg87vlA2C5Z1PuVA+aMI8SgimnE4SqI+ZYzu6Q=="
+		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -16951,6 +16937,12 @@
 					}
 				}
 			}
+		},
+		"webpack-fix-style-only-entries": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/webpack-fix-style-only-entries/-/webpack-fix-style-only-entries-0.3.1.tgz",
+			"integrity": "sha512-B9fTBquTxEw5FAKO6PaIgCDFmkeZAdIg4Npoq7S2MPf12/doQT3KTzhBXjnOb+kBq1zgMumxluqMBUXbzm+OnA==",
+			"dev": true
 		},
 		"webpack-livereload-plugin": {
 			"version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -34,11 +34,13 @@
 		"sass-loader": "^7.1.0",
 		"stylelint": "^10.1.0",
 		"terser-webpack-plugin": "^1.3.0",
-		"url-loader": "^2.1.0"
+		"url-loader": "^2.1.0",
+		"webpack-fix-style-only-entries": "^0.3.1"
 	},
 	"dependencies": {
 		"@wordpress/components": "^8.0.0",
 		"@wordpress/data": "^4.6.0",
+		"remove-files-webpack-plugin": "^1.1.3",
 		"three": "^0.105.2",
 		"three-fbx-loader": "^1.0.3"
 	}

--- a/react-blocks/build/editorIndex.deps.json
+++ b/react-blocks/build/editorIndex.deps.json
@@ -1,0 +1,1 @@
+["react","wp-components","wp-editor","wp-element","wp-polyfill"]

--- a/react-blocks/build/frontendIndex.deps.json
+++ b/react-blocks/build/frontendIndex.deps.json
@@ -1,0 +1,1 @@
+["wp-polyfill"]


### PR DESCRIPTION
Note: I had to use both the [fix style-only entries](https://github.com/fqborges/webpack-fix-style-only-entries) and this [simple file remover](https://www.npmjs.com/package/remove-files-webpack-plugin) because the first one only removes the `.js` and `.js.map` files generated for style entry points.

As for the `.deps.json` files, I think they are generated by this plugin: 
https://www.npmjs.com/package/@wordpress/dependency-extraction-webpack-plugin

Which is a dependency of `@wordpress/scripts`, so, to remove those two extra assets, I had to use the file remover plugin.