### PR TITLE
[No Ticket] Add missing 'add_shortcode()' function in blocks

### DIFF
--- a/classes/blocks/class-columns.php
+++ b/classes/blocks/class-columns.php
@@ -32,9 +32,51 @@ class Columns extends Base_Block {
 	const MAX_COLUMNS     = 4;
 
 	/**
+	 * Register shortcake shortcode.
+	 *
+	 * @param array  $attributes Shortcode attributes.
+	 * @param string $content   Content.
+	 *
+	 * @return mixed
+	 */
+	public function add_block_shortcode( $attributes, $content ) {
+		$columns = [];
+		for ( $i = 1; $i <= static::MAX_COLUMNS; $i++ ) {
+			if ( ! empty( $attributes[ 'title_' . $i ] ) ) {
+				$column = [
+					'title'        => $attributes[ 'title_' . $i ] ?? '',
+					'description'  => $attributes[ 'description_' . $i ] ?? '',
+					'attachment'   => $attributes[ 'attachment_' . $i ] ?? '',
+					'cta_text'     => $attributes[ 'cta_text_' . $i ] ?? '',
+					'cta_link'     => $attributes[ 'link_' . $i ] ?? '',
+					'link_new_tab' => $attributes[ 'link_new_tab_' . $i ] ?? '',
+				];
+
+				array_push( $columns, $column );
+			}
+		}
+
+		$attributes['columns'] = $columns;
+
+		$attributes = shortcode_atts(
+			[
+				'columns_block_style' => '',
+				'columns_title'       => '',
+				'columns_description' => '',
+				'columns'             => [],
+			],
+			$attributes,
+			'shortcake_columns'
+		);
+
+		return $this->render( $attributes );
+	}
+
+	/**
 	 * Columns constructor.
 	 */
 	public function __construct() {
+		add_shortcode( 'shortcake_columns', [ $this, 'add_block_shortcode' ] );
 
 		register_block_type(
 			'planet4-blocks/columns',

--- a/classes/blocks/class-gallery.php
+++ b/classes/blocks/class-gallery.php
@@ -35,9 +35,35 @@ class Gallery extends Base_Block {
 	const LAYOUT_GRID          = 3;
 
 	/**
+	 * Register shortcake shortcode.
+	 *
+	 * @param array  $attributes Shortcode attributes.
+	 * @param string $content   Content.
+	 *
+	 * @return mixed
+	 */
+	public function add_block_shortcode( $attributes, $content ) {
+
+		$attributes = shortcode_atts(
+			[
+				'gallery_block_style'        => '',
+				'gallery_block_title'        => '',
+				'gallery_block_description'  => '',
+				'multiple_image'             => '',
+				'gallery_block_focus_points' => '',
+			],
+			$attributes,
+			'shortcake_gallery'
+		);
+
+		return $this->render( $attributes );
+	}
+
+	/**
 	 * Gallery constructor.
 	 */
 	public function __construct() {
+		add_shortcode( 'shortcake_gallery', [ $this, 'add_block_shortcode' ] );
 
 		register_block_type(
 			'planet4-blocks/gallery',

--- a/classes/blocks/class-happypoint.php
+++ b/classes/blocks/class-happypoint.php
@@ -24,9 +24,37 @@ class Happypoint extends Base_Block {
 	const BLOCK_NAME = 'happy_point';
 
 	/**
+	 * Register shortcake shortcode.
+	 *
+	 * @param array  $attributes Shortcode attributes.
+	 * @param string $content   Content.
+	 *
+	 * @return mixed
+	 */
+	public function add_block_shortcode( $attributes, $content ) {
+
+		$attributes['id'] = $attributes['background'];
+
+		$attributes = shortcode_atts(
+			[
+				'id'                  => '',
+				'focus_image'         => '',
+				'opacity'             => '',
+				'mailing_list_iframe' => '',
+				'iframe_url'          => '',
+			],
+			$attributes,
+			'shortcake_happy_point'
+		);
+
+		return $this->render( $attributes );
+	}
+
+	/**
 	 * Happypoint constructor.
 	 */
 	public function __construct() {
+		add_shortcode( 'shortcake_happy_point', [ $this, 'add_block_shortcode' ] );
 
 		register_block_type(
 			'planet4-blocks/happypoint',

--- a/classes/blocks/class-media.php
+++ b/classes/blocks/class-media.php
@@ -24,9 +24,34 @@ class Media extends Base_Block {
 	const BLOCK_NAME = 'media_video';
 
 	/**
+	 * Register shortcake shortcode.
+	 *
+	 * @param array  $attributes Shortcode attributes.
+	 * @param string $content   Content.
+	 *
+	 * @return mixed
+	 */
+	public function add_block_shortcode( $attributes, $content ) {
+
+		$attributes = shortcode_atts(
+			[
+				'video_title'      => '',
+				'description'      => '',
+				'youtube_id'       => '',
+				'video_poster_img' => '',
+			],
+			$attributes,
+			'shortcake_media_video'
+		);
+
+		return $this->render( $attributes );
+	}
+
+	/**
 	 * Media constructor.
 	 */
 	public function __construct() {
+		add_shortcode( 'shortcake_media_video', [ $this, 'add_block_shortcode' ] );
 
 		register_block_type(
 			'planet4-blocks/media-video',

--- a/classes/blocks/class-splittwocolumns.php
+++ b/classes/blocks/class-splittwocolumns.php
@@ -24,9 +24,44 @@ class SplitTwoColumns extends Base_Block {
 	const BLOCK_NAME = 'split_two_columns';
 
 	/**
+	 * Register shortcake shortcode.
+	 *
+	 * @param array  $attributes Shortcode attributes.
+	 * @param string $content   Content.
+	 *
+	 * @return mixed
+	 */
+	public function add_block_shortcode( $attributes, $content ) {
+
+		$attributes = shortcode_atts(
+			[
+				'select_issue'      => '',
+				'title'             => '',
+				'issue_description' => '',
+				'issue_link_text'   => '',
+				'issue_link_path'   => '',
+				'issue_image'       => '',
+				'focus_issue_image' => '',
+				'select_tag'        => '',
+				'tag_description'   => '',
+				'button_text'       => '',
+				'button_link'       => '',
+				'tag_image'         => '',
+				'focus_tag_image'   => '',
+			],
+			$attributes,
+			'shortcake_split_two_columns'
+		);
+
+		return $this->render( $attributes );
+	}
+
+
+	/**
 	 * SplitTwoColumns constructor.
 	 */
 	public function __construct() {
+		add_shortcode( 'shortcake_split_two_columns', [ $this, 'add_block_shortcode' ] );
 
 		register_block_type(
 			'planet4-blocks/split-two-columns',

--- a/classes/blocks/class-submenu.php
+++ b/classes/blocks/class-submenu.php
@@ -26,11 +26,55 @@ class Submenu extends Base_Block {
 	const EMPTY_MESSAGE = 'The submenu block produces no output on the editor.';
 
 	/**
+	 * Register shortcake shortcode.
+	 *
+	 * @param array  $attributes Shortcode attributes.
+	 * @param string $content   Content.
+	 *
+	 * @return mixed
+	 */
+	public function add_block_shortcode( $attributes, $content ) {
+
+		$levels = [];
+		for ( $i = 1; $i <= 3; $i++ ) {
+			if ( ! empty( $attributes[ 'heading' . $i ] ) ) {
+				$level = [
+					'heading' => $attributes[ 'heading' . $i ] ?? '',
+					'link'    => $attributes[ 'link' . $i ] ?? '',
+					'style'   => $attributes[ 'style' . $i ] ?? '',
+				];
+
+				array_push( $levels, $level );
+			}
+		}
+
+		$attributes['levels'] = $levels;
+
+		$attributes = shortcode_atts(
+			[
+				'submenu_style' => '',
+				'title'         => '',
+				'levels'        => [
+					[
+						'heading' => '',
+						'link'    => '',
+						'style'   => '',
+					],
+				],
+			],
+			$attributes,
+			'shortcake_submenu'
+		);
+
+		return $this->render( $attributes );
+	}
+
+	/**
 	 * Submenu constructor.
 	 */
 	public function __construct() {
-		// - Register the block for the editor
-		// in the PHP side.
+		add_shortcode( 'shortcake_submenu', [ $this, 'add_block_shortcode' ] );
+
 		register_block_type(
 			'planet4-blocks/submenu',
 			[


### PR DESCRIPTION
The `add_shortcode()` function was missing in below blocks,

- Columns block
- Gallery block
- Happy point block
- Media block
- Split_two_columns block
- Submenu block