### PR TITLE
[No ticket] - Minor block fixes

### DIFF
--- a/classes/blocks/class-counter.php
+++ b/classes/blocks/class-counter.php
@@ -105,7 +105,7 @@ class Counter extends Base_Block {
 		}
 		$target = floatval( $fields['target'] );
 
-		if ( array_key_exists( 'completed_api', $fields ) ) {
+		if ( array_key_exists( 'completed_api', $fields ) && $fields['completed_api'] ) {
 			$response_api  = wp_safe_remote_get( $fields['completed_api'] );
 			$response_body = json_decode( $response_api['body'], true );
 			if ( is_array( $response_body ) && array_key_exists( 'unique_count', $response_body ) && is_int( $response_body['unique_count'] ) ) {

--- a/classes/blocks/class-covers.php
+++ b/classes/blocks/class-covers.php
@@ -43,8 +43,6 @@ class Covers extends Base_Block {
 			'shortcake_newcovers'
 		);
 
-		$attributes['tags'] = explode( ',', $attributes['tags'] );
-
 		return $this->render( $attributes );
 	}
 

--- a/classes/blocks/class-splittwocolumns.php
+++ b/classes/blocks/class-splittwocolumns.php
@@ -129,12 +129,8 @@ class SplitTwoColumns extends Base_Block {
 		$campaign_image_id = $fields['tag_image'] ? $fields['tag_image'] : get_term_meta( $tag_id, 'tag_attachment_id', true );
 		$issue_image_id    = $fields['issue_image'] ? $fields['issue_image'] : get_post_thumbnail_id( $issue_id );
 
-		$issue_title       = $fields['title']
-			? $fields['title']
-			: ( $issue_meta_data['p4_title'][0] ?? get_the_title( $issue_id ) );
-		$issue_description = $fields['issue_description']
-			? $fields['issue_description']
-		  : ( $issue_meta_data['p4_description'][0] ?? '' );
+		$issue_title       = $fields['title'] ? $fields['title'] : ( $issue_meta_data['p4_title'][0] ?? get_the_title( $issue_id ) );
+		$issue_description = $fields['issue_description'] ? $fields['issue_description'] : ( $issue_meta_data['p4_description'][0] ?? '' );
 		$issue_link_text   = $fields['issue_link_text'] ? $fields['issue_link_text'] : __( 'Learn more about this issue', 'planet4-blocks' );
 		$issue_link_path   = $fields['issue_link_path'] ? $fields['issue_link_path'] : get_permalink( $issue_id );
 

--- a/classes/blocks/class-splittwocolumns.php
+++ b/classes/blocks/class-splittwocolumns.php
@@ -124,15 +124,19 @@ class SplitTwoColumns extends Base_Block {
 		$issue_id        = absint( $fields['select_issue'] ?? '' );
 		$issue_meta_data = get_post_meta( $issue_id );
 
-		$tag_id            = absint( $fields['select_tag'] ?? '' );
+		$tag_id            = absint( $fields['select_tag'] ? $fields['select_tag'] : '' );
 		$tag               = get_term( $tag_id );
-		$campaign_image_id = $fields['tag_image'] ?? get_term_meta( $tag_id, 'tag_attachment_id', true );
-		$issue_image_id    = $fields['issue_image'] ?? get_post_thumbnail_id( $issue_id );
+		$campaign_image_id = $fields['tag_image'] ? $fields['tag_image'] : get_term_meta( $tag_id, 'tag_attachment_id', true );
+		$issue_image_id    = $fields['issue_image'] ? $fields['issue_image'] : get_post_thumbnail_id( $issue_id );
 
-		$issue_title       = $fields['title'] ?? ( $issue_meta_data['p4_title'][0] ?? get_the_title( $issue_id ) );
-		$issue_description = $fields['issue_description'] ?? ( $issue_meta_data['p4_description'][0] ?? '' );
-		$issue_link_text   = $fields['issue_link_text'] ?? __( 'Learn more about this issue', 'planet4-blocks' );
-		$issue_link_path   = $fields['issue_link_path'] ?? get_permalink( $issue_id );
+		$issue_title       = $fields['title']
+			? $fields['title']
+			: ( $issue_meta_data['p4_title'][0] ?? get_the_title( $issue_id ) );
+		$issue_description = $fields['issue_description']
+			? $fields['issue_description']
+		  : ( $issue_meta_data['p4_description'][0] ?? '' );
+		$issue_link_text   = $fields['issue_link_text'] ? $fields['issue_link_text'] : __( 'Learn more about this issue', 'planet4-blocks' );
+		$issue_link_path   = $fields['issue_link_path'] ? $fields['issue_link_path'] : get_permalink( $issue_id );
 
 		$data = [
 			'issue'    => [
@@ -143,7 +147,7 @@ class SplitTwoColumns extends Base_Block {
 				'image_alt'   => get_post_meta( $issue_image_id, '_wp_attachment_image_alt', true ),
 				'link_text'   => $issue_link_text,
 				'link_url'    => $issue_link_path,
-				'focus'       => $fields['focus_issue_image'] ?? '',
+				'focus'       => $fields['focus_issue_image'] ? $fields['focus_issue_image'] : '',
 			],
 			'campaign' => [
 				'image'       => wp_get_attachment_url( $campaign_image_id ),
@@ -151,10 +155,10 @@ class SplitTwoColumns extends Base_Block {
 				'image_alt'   => get_post_meta( $campaign_image_id, '_wp_attachment_image_alt', true ),
 				'name'        => $tag instanceof \WP_Error ? '' : html_entity_decode( $tag->name ),
 				'link'        => get_tag_link( $tag ),
-				'description' => $fields['tag_description'] ?? ( $tag instanceof \WP_Error ? '' : $tag->description ),
-				'button_text' => $fields['button_text'] ?? __( 'Get Involved', 'planet4-blocks' ),
-				'button_link' => $fields['button_link'] ?? get_tag_link( $tag ),
-				'focus'       => $fields['focus_tag_image'] ?? '',
+				'description' => $fields['tag_description'] ? $fields['tag_description'] : ( $tag instanceof \WP_Error ? '' : $tag->description ),
+				'button_text' => $fields['button_text'] ? $fields['button_text'] : __( 'Get Involved', 'planet4-blocks' ),
+				'button_link' => $fields['button_link'] ? $fields['button_link'] : get_tag_link( $tag ),
+				'focus'       => $fields['focus_tag_image'] ? $fields['focus_tag_image'] : '',
 			],
 		];
 


### PR DESCRIPTION
I needed to change a few null coalescing operators (`??`) to simple ternaries (`? :`) because in the Shortcake versions of `prepare_data`, the unset `fields` were not present in the array, in the Gutenberg side, those are empty strings, which are taken as valid by `??`.

It has three commits, I could squash them but I already merged the first two into the PLANET-4054 branch to be able to test the blocks correctly 😬 