### PR TITLE
Add missing functions for cookies

### DIFF
--- a/public/js/blocks_wide.js
+++ b/public/js/blocks_wide.js
@@ -1,5 +1,5 @@
 // Force wide blocks outside the container
-$(document).ready(function() {
+jQuery(function ($) {
   'use strict';
 
   const $wideblocks = $('.block-wide');

--- a/public/js/cookies.js
+++ b/public/js/cookies.js
@@ -1,9 +1,29 @@
-/* global createCookie, readCookie */
+function createCookie(name, value, days) {
+  let date = new Date();
+  date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+  document.cookie = encodeURI(name) + '=' + encodeURI(value) + ';domain=.' + document.domain + ';path=/;' + '; expires=' + date.toGMTString();
+}
+
+function readCookie(name) {
+  const nameEQ = name + '=';
+  const ca = document.cookie.split(';');
+  let c;
+  for (let i = 0; i < ca.length; i++) {
+    c = ca[i];
+    while (c.charAt(0) === ' ') {
+      c = c.substring(1, c.length);
+    }
+    if (c.indexOf(nameEQ) === 0) {
+      return c.substring(nameEQ.length, c.length);
+    }
+  }
+  return null;
+}
+
 jQuery(function ($) {
   'use strict';
 
-  function setNoTrackCookie()
-  {
+  function setNoTrackCookie() {
     if ($('#necessary_cookies').is(':checked') || $('#all_cookies').is(':checked')) {
       // Remove the 'no_track' cookie, if user accept the cookies consent.
       createCookie('no_track', 'true', -1);

--- a/public/js/submenu.js
+++ b/public/js/submenu.js
@@ -1,6 +1,6 @@
 /* global submenu */
 
-$(document).ready(function () {
+jQuery(function ($) {
   'use strict';
 
   // Parse submenu object passed to a variable from server-side.


### PR DESCRIPTION
Cookie function don't seem to be inherited from master-theme. You can check that on the inspector on the [Privacy page](https://k8s.p4.greenpeace.org/gutenberg/privacy-and-cookies/) by (un-)clickinh the cookies checkbox.