### PR TITLE
[No ticket] Fix articles block for exclude post id

### DIFF
--- a/classes/blocks/class-articles.php
+++ b/classes/blocks/class-articles.php
@@ -378,9 +378,16 @@ class Articles extends Base_Block {
 		$tags = $fields['tags'] ?? [];
 
 		// If user has not provided any tag, use post's tags.
-		if ( empty( $tags ) ) {
+		if ( empty( $tags ) && $exclude_post_id ) {
 			// Get page/post tags.
 			$tags = get_the_tags();
+
+			$tags = ! is_array( $tags ) ? [] : array_map(
+				function ( $tag ) {
+					return $tag->term_id;
+				},
+				$tags
+			);
 		}
 
 		// Get all posts with arguments.


### PR DESCRIPTION
Wp query expects an array of tag ids here:
https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/fix-articles-exclude-id/classes/blocks/class-articles.php#L418-L421