### PR TITLE
WYSIWYG Counter example

### DIFF
--- a/assets/src/blocks/Counter/Counter.js
+++ b/assets/src/blocks/Counter/Counter.js
@@ -1,14 +1,29 @@
 import {Component, Fragment} from '@wordpress/element';
-import {
-  TextControl as BaseTextControl,
-  TextareaControl as BaseTextareaControl,
-  ServerSideRender } from '@wordpress/components';
-import { LayoutSelector } from '../../components/LayoutSelector/LayoutSelector';
-import { Preview } from '../../components/Preview';
-import withCharacterCounter from '../../components/withCharacterCounter/withCharacterCounter';
 
-const TextControl = withCharacterCounter( BaseTextControl );
-const TextareaControl = withCharacterCounter( BaseTextareaControl );
+import {
+  SelectControl,
+  ServerSideRender,
+  TextControl,
+  TextareaControl
+} from '@wordpress/components';
+
+const { InspectorControls, RichText } = wp.editor;
+const { __ } = wp.i18n;
+
+const counterLayoutOptions = [
+  {
+    label: __('Progress Bar', 'p4ge'),
+    value: 'bar',
+  },
+  {
+    label: __('Progress Dial', 'p4ge'),
+    value: 'arc',
+  },
+  {
+    label: __('Progress bar inside EN Form', 'p4ge'),
+    value: 'en-forms-bar',
+  },
+];
 
 export class Counter extends Component {
   constructor(props) {
@@ -17,65 +32,78 @@ export class Counter extends Component {
 
   renderEdit() {
     const { __ } = wp.i18n;
+		const percentComplete = this.props.target > 0 ? Math.round( this.props.completed / this.props.target * 100 ) : 0;
+    const compiledText = this.props.text
+      .replace(/%completed%/g, this.props.completed)
+      .replace(/%remaining%/g, this.props.target - this.props.completed)
+      .replace(/%target%/g, this.props.target);
+    const arcLength = 31.5;
 
     return (
       <div>
-        <h3>{ __('What style of counter do you need?', 'p4ge') }</h3>
+        <section className={ `block container counter-block counter-style-${ this.props.style }` }>
+          <div className="container">
+            <header>
+              <RichText
+                tagName="h2"
+                className="page-section-header"
+                placeholder={ __('Enter title', 'p4ge') }
+                value={ this.props.title }
+                onChange={ this.props.onTitleChange }
+                keepPlaceholderOnFocus={ true }
+                withoutInteractiveFormatting
+                characterLimit={60}
+              />
+            </header>
+            <RichText
+              tagName="div"
+              className="page-section-description"
+              placeholder={ __('Enter description', 'p4ge') }
+              value={ this.props.description }
+              onChange={ this.props.onDescriptionChange }
+              keepPlaceholderOnFocus={ true }
+              multiline={ true }
+              withoutInteractiveFormatting
+              characterLimit={400}
+            />
+          </div>
+          <div className="content-counter">
+            {
+              (this.props.style == 'bar' || this.props.style == 'en-forms-bar')
+              ? <div className="progress-container">
+                  <div
+                    className={ `progress-bar ${ 'en-forms-bar' == this.props.style ? 'enform-progress-bar' : '' }` }
+                    style={{ width: percentComplete + '%', paddingRight: '20px' }}>
+                  </div>
+                </div>
+              : null
+            }
 
-        <div>
-          <LayoutSelector
-            selectedOption={ this.props.style }
-            onSelectedLayoutChange={ this.props.onSelectedLayoutChange }
-            options={[
-              {
-                label: __('Text Only', 'p4ge'),
-                image: window.p4ge_vars.home + 'images/counter_th_text.png',
-                value: 'plain',
-                help: __('Text to describe your progress', 'p4ge')
-              },
-              {
-                label: __('Progress Bar', 'p4ge'),
-                image: window.p4ge_vars.home + 'images/counter_th_bar.png',
-                value: 'bar',
-                help: __('A bar to visualise the progress.', 'p4ge'),
-              },
-              {
-                label: __('Progress Dial', 'p4ge'),
-                image: window.p4ge_vars.home + 'images/counter_th_arc.png',
-                value: 'arc',
-                help: __('A dial to visualise the progress.', 'p4ge')
-              },
-              {
-                label: __('Progress bar inside EN Form', 'p4ge'),
-                image: window.p4ge_vars.home + 'images/counter_th_bar.png',
-                value: 'en-forms-bar',
-                help: __('A bar inside an En Form. Select this only if you are adding an EN Form to the same page.', 'p4ge')
-              },
-            ]}
+            {
+              (this.props.style == 'arc')
+              ? <svg className="progress-arc" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 24 14">
+                <path className="background" d="M 2 12 A 1 1 0 1 1 22 12"/>
+                <path className="foreground" d="M 2 12 A 1 1 0 1 1 22 12"
+                    stroke-dasharray={ arcLength }
+                    stroke-dashoffset={ `${ (1 - percentComplete / 100 ) * arcLength }` } />
+                </svg>
+              : null
+            }
+
+            <p className={ `counter-text ${ 100 <= percentComplete ? 'counter-text-goal_reached' : '' }` }>
+              {/* <div className="counter-target">{ this.props.completed }</div> */}
+              { compiledText }
+            </p>
+          </div>
+        </section>
+
+        <InspectorControls>
+          <SelectControl
+            label={ __('What style of counter do you need?', 'p4ge') }
+            value={ this.props.style }
+            options={ counterLayoutOptions }
+            onChange={ this.props.onSelectedLayoutChange }
           />
-        </div>
-
-        <div>
-          <TextControl
-            label= { __('Title', 'p4ge') }
-            placeholder= { __('Enter title', 'p4ge') }
-            value={ this.props.title }
-            onChange={ this.props.onTitleChange }
-            characterLimit={60}
-          />
-        </div>
-
-        <div>
-          <TextareaControl
-            label= { __('Description', 'p4ge') }
-            placeholder= { __('Enter description', 'p4ge') }
-            value={ this.props.description }
-            onChange={ this.props.onDescriptionChange }
-            characterLimit={400}
-          />
-        </div>
-
-        <div>
           <TextControl
             label= { __('Completed', 'p4ge') }
             placeholder= { __('e.g. number of signatures', 'p4ge') }
@@ -83,18 +111,12 @@ export class Counter extends Component {
             value={ this.props.completed }
             onChange={ this.props.onCompletedChange }
           />
-        </div>
-
-        <div>
           <TextControl
             label= { __('Completed API URL', 'p4ge') }
             placeholder= { __('API URL of completed number. If filled in will overide the \'Completed\' field', 'p4ge') }
             value={ this.props.completed_api }
             onChange={ this.props.onCompletedAPIChange }
           />
-        </div>
-
-        <div>
           <TextControl
             label= { __('Target', 'p4ge') }
             placeholder= { __('e.g. target no. of signatures', 'p4ge') }
@@ -102,9 +124,6 @@ export class Counter extends Component {
             value={ this.props.target }
             onChange={ this.props.onTargetChange }
           />
-        </div>
-
-        <div>
           <TextareaControl
             label= { __('Text', 'p4ge') }
             placeholder= { __('e.g. "signatures collected of %target%"', 'p4ge') }
@@ -112,10 +131,28 @@ export class Counter extends Component {
             onChange={ this.props.onTextChange }
           />
           <p className='FieldHelp'>These placeholders can be used: <code>%completed%</code>, <code>%target%</code>, <code>%remaining%</code> </p>
-        </div>
-
+        </InspectorControls>
       </div>
     );
+  }
+
+  renderView() {
+    // TODO: Possibly remove ServerSideRender,
+    // as not having it gives pretty much the same result
+    return (
+      <ServerSideRender
+        block={ 'planet4-blocks/counter' }
+        attributes={{
+          title: this.props.title,
+          description: this.props.description,
+          style: this.props.style,
+          completed: this.props.completed,
+          completed_api: this.props.completed_api,
+          target: this.props.target,
+          text: this.props.text,
+        }}>
+      </ServerSideRender>
+    )
   }
 
   render() {
@@ -124,22 +161,8 @@ export class Counter extends Component {
         {
           this.props.isSelected
             ? this.renderEdit()
-            : null
+            : this.renderView()
         }
-        <Preview showBar={ this.props.isSelected }>
-          <ServerSideRender
-            block={ 'planet4-blocks/counter' }
-            attributes={{
-              title: this.props.title,
-              description: this.props.description,
-              style: this.props.style,
-              completed: this.props.completed,
-              completed_api: this.props.completed_api,
-              target: this.props.target,
-              text: this.props.text,
-            }}>
-          </ServerSideRender>
-        </Preview>
       </div>
     );
   }

--- a/assets/src/blocks/Counter/CounterBlock.js
+++ b/assets/src/blocks/Counter/CounterBlock.js
@@ -65,15 +65,18 @@ export class CounterBlock {
         },
         completed: {
           type: 'integer',
+          default: 0
         },
         completed_api: {
           type: 'string',
         },
         target: {
           type: 'integer',
+          default: 0
         },
         text: {
           type: 'string',
+          default: ''
         }
       },
       // withSelect is a "Higher Order Component", it works as


### PR DESCRIPTION
For more context, see the docs in this ticket's comments: https://jira.greenpeace.org/browse/PLANET-4205

This is an example for improving the UX of a block's editing UI by converting it to a WYSIWYG approach, the effort is:

- Copying the Twig template into JSX, converting `class` to `className` and copying the Twig logic into JS.
- Convert some elements to RichText editor
- Show the WYSIWYG editor on focus and the ServerSideRender on blur.
- Move some elements from the UI to the Sidebar using `InspectorControls`

![counter-wysiwyg](https://user-images.githubusercontent.com/340766/69867178-d793eb80-1284-11ea-91cf-87defe294be1.gif)
