### PR TITLE
PLANET-4290 Fix covers view attribute in covers templates

### DIFF
--- a/templates/blocks/campaign_thumbnail.twig
+++ b/templates/blocks/campaign_thumbnail.twig
@@ -42,7 +42,7 @@
 
 				{% if ( covers_view is defined ) %}
 					{% if ( ( fields.tags|length > 3 and covers_view == '1' ) or
-						( fields.tags|length > 6 and covers_view == '3' ) ) %}
+						( fields.tags|length > 6 and covers_view == '2' ) ) %}
 						<div class="row">
 							<div class="col-md-12 col-lg-5 col-xl-5 mt-3 load-more-campaigns-button-div">
 								<button class="btn btn-block btn-secondary btn-load-more-campaigns-click">

--- a/templates/blocks/old_covers.twig
+++ b/templates/blocks/old_covers.twig
@@ -46,13 +46,13 @@
 				{% if ( fields.button_text ) %}
 					<div class="row">
 						{% if ( ( covers|length > 3 and covers_view == '1' ) or
-								( covers|length > 6 and covers_view == '3' ) ) %}
+								( covers|length > 6 and covers_view == '2' ) ) %}
 							<div class="col-lg-5 col-md-12 load-more-covers-button-div">
 								<button class="btn btn-block btn-secondary btn-load-more-covers-click">{{ fields.button_text }}</button>
 							</div>
 						{% elseif ( ( covers|length == 3 and covers_view == '1' ) or
-									( covers|length in [5,6] and covers_view == '3' ) or
-									( covers|length > 4 and covers_view == '2' )) %}
+									( covers|length in [5,6] and covers_view == '2' ) or
+									( covers|length > 4 and covers_view == '3' )) %}
 							<div class="col-lg-5 col-md-12 load-more-covers-button-div d-lg-none">
 								<button class="btn btn-block btn-secondary btn-load-more-covers-click">{{ fields.button_text }}</button>
 							</div>


### PR DESCRIPTION
Fix covers view attribute in campaign thumbnail and old covers templates

based on this mapping
https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/develop/classes/command/converters/class-conversion-functions.php#L146-L152