### PR TITLE
PLANET-4298 Articles block - Add check on tag exist

### DIFF
--- a/classes/blocks/class-articles.php
+++ b/classes/blocks/class-articles.php
@@ -420,7 +420,15 @@ class Articles extends Base_Block {
 		}
 
 		if ( ! empty( $tags ) ) {
-			$args['tag__in'] = $tags;
+			$filtered_tag = [];
+			foreach ( $tags as $tag_id ) {
+				$tag = get_tag( $tag_id );
+				// Check if tag exist or not.
+				if ( $tag instanceof \WP_Term ) {
+					$filtered_tag[] = $tag_id;
+				}
+			}
+			$args['tag__in'] = $filtered_tag;
 		}
 
 		return $args;


### PR DESCRIPTION
[JIRA 4298](https://jira.greenpeace.org/browse/PLANET-4298)

This issue is not related to transforms script. If tags does not exists the Gutenberg  articles block was showing empty block. To fix this issue I added a check on tag id.