### PR TITLE
PLANET-4301: Covers - content block: wrong column width when less than 4 columns

### DIFF
--- a/classes/blocks/class-covers.php
+++ b/classes/blocks/class-covers.php
@@ -123,6 +123,7 @@ class Covers extends Base_Block {
 		// Enqueue js for the frontend.
 		if ( ! $this->is_rest_request() ) {
 			wp_enqueue_script( 'covers', P4GBKS_PLUGIN_URL . 'public/js/load_more.js', [ 'jquery' ], '0.1', true );
+			wp_enqueue_script( 'pubslider', P4GBKS_PLUGIN_URL . 'public/js/pubslider.js', [ 'jquery' ], '0.1', true );
 		}
 
 		$data = [

--- a/public/js/pubslider.js
+++ b/public/js/pubslider.js
@@ -1,0 +1,41 @@
+jQuery(function ($) {
+  'use strict';
+
+  // convert an element to slider using slick js
+  function slickify(element) {
+    $(element).slick({
+      infinite:       false,
+      mobileFirst:    true,
+      slidesToShow:   2.2,
+      slidesToScroll: 1,
+      arrows:         false,
+      dots:           false,
+      responsive: [
+        {
+          breakpoint: 992,
+          settings: { slidesToShow: 4 }
+        },
+        {
+          breakpoint: 768,
+          settings: { slidesToShow: 3 }
+        },
+        {
+          breakpoint: 576,
+          settings: { slidesToShow: 2 }
+        }
+      ]
+    });
+  }
+
+  // Handle slick functionality for each Content Four Column blocks.
+  $('.four-column-content').each( function() {
+    const pubSlidesNum = $('.publications-slider .post-column', $(this)).length;
+
+    if (pubSlidesNum > 3 && $(window).width() < 768) {
+      slickify('.publications-slider');
+    }
+    if (pubSlidesNum < 4 && $(window).width() > 768) {
+      $('.post-column', $(this)).removeClass('col-lg-3').removeClass('col-md-4').addClass('col-md');
+    }
+  });
+});


### PR DESCRIPTION
This script was present in the old plugin but missing in the new one. Refer to the comments in the ticket for background.

Ref: https://jira.greenpeace.org/browse/PLANET-4301