### PR TITLE
PLANET-4387 Fix articles block ignore categories setting and selected…

### DIFF
--- a/classes/blocks/class-articles.php
+++ b/classes/blocks/class-articles.php
@@ -366,7 +366,6 @@ class Articles extends Base_Block {
 
 		$exclude_post_id   = (int) ( $fields['exclude_post_id'] ?? '' );
 		$ignore_categories = $fields['ignore_categories'];
-		$options           = get_option( 'planet4_options' );
 
 		// Get page categories.
 		$post_categories   = get_the_category();
@@ -381,8 +380,16 @@ class Articles extends Base_Block {
 		// Get user defined tags from backend.
 		$tags = $fields['tags'] ?? [];
 
+		// Validate tag ids.
+		$tags = array_filter(
+			$tags,
+			function( $tag_id ) {
+				return get_tag( $tag_id ) instanceof \WP_Term;
+			}
+		);
+
 		// If user has not provided any tag, use post's tags.
-		if ( empty( $tags ) && $exclude_post_id ) {
+		if ( empty( $tags ) ) {
 			// Get page/post tags.
 			$tags = get_the_tags();
 
@@ -397,7 +404,7 @@ class Articles extends Base_Block {
 		// Get all posts with arguments.
 		$args = self::DEFAULT_POST_ARGS;
 
-		if ( $ignore_categories ) {
+		if ( true !== $ignore_categories ) {
 			if ( $category_id_array ) {
 				$args['category__in'] = $category_id_array;
 			}


### PR DESCRIPTION
… tags issue

[JIRA 4387](https://jira.greenpeace.org/browse/PLANET-4387)

Observations :
1. Issue found for non-existing tags - added validation on tag ids
    1. In case of non-existing tags/no tags selected - show articles post on the basis of current page/post tags (same as old articles block)
2. Issue found for ignore category setting(The ignore category setting not working as expected) - issue fixed

Issue tested on local env -
Before changes -
![image](https://user-images.githubusercontent.com/5357471/68584333-4ca1ab80-04a5-11ea-833e-c26961634760.png)

After changes -
![image](https://user-images.githubusercontent.com/5357471/68584363-617e3f00-04a5-11ea-8367-28b348beac1f.png)
