### PR TITLE
PLANET-4182 Fix PHPCS errors

### DIFF
--- a/assets/src/styles/blocks/ColumnsEditor.scss
+++ b/assets/src/styles/blocks/ColumnsEditor.scss
@@ -3,12 +3,13 @@
   display: inline-block;
   font-size: 0;
 }
+
 .img-wrap .close {
   position: absolute;
   top: 4px;
   right: 4px;
   z-index: 100;
-  background-color: #FFF;
+  background-color: #fff;
   padding: 6px 3px 4px;
   color: red;
   font-weight: bold;
@@ -19,6 +20,7 @@
   line-height: 12px;
   border-radius: 50%;
 }
+
 .img-wrap:hover .close {
   opacity: 1;
 }

--- a/classes/blocks/class-counter.php
+++ b/classes/blocks/class-counter.php
@@ -116,7 +116,7 @@ class Counter extends Base_Block {
 		$fields['completed'] = $completed;
 		$fields['percent']   = $target > 0 ? round( $completed / $target * 100 ) : 0;
 
-		$remaining = $target > $completed ? $target - $completed : 0;
+		$remaining           = $target > $completed ? $target - $completed : 0;
 		$fields['remaining'] = floatval( $remaining );
 
 		// Enqueue js for the frontend.


### PR DESCRIPTION

(119:20) - /home/circleci/project/classes/blocks/class-counter.php
`Equals sign not aligned with surrounding assignments; expected 11 spaces but found 1 space`

```
stylelint $HOME/project/assets/src/styles/**/*.scss

assets/src/styles/blocks/ColumnsEditor.scss
  6:1   ✖  Expected empty line before rule   rule-empty-line-before
 11:21  ✖  Expected "#FFF" to be "#fff"      color-hex-case        
 22:1   ✖  Expected empty line before rule   rule-empty-line-before

Exited with code 2
```

ref. https://circleci.com/gh/greenpeace/planet4-plugin-gutenberg-blocks/1242?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link