### PR TITLE
Planet 4438 Add NRO custom blocks

### DIFF
--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -236,30 +236,5 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 
 			return array_merge( $p4_block_types, $core_block_types );
 		}
-
-		/**
-		 * Validates the settings input.
-		 *
-		 * @param array $settings The associative array with the settings that are registered for the plugin.
-		 *
-		 * @return bool
-		 */
-		public function validate( $settings ) : bool {
-			$has_errors = false;
-			return ! $has_errors;
-		}
-
-		/**
-		 * Sanitizes the settings input.
-		 *
-		 * @param array $settings The associative array with the settings that are registered for the plugin.
-		 */
-		public function sanitize( &$settings ) {
-			if ( $settings ) {
-				foreach ( $settings as $name => $setting ) {
-					$settings[ $name ] = sanitize_text_field( $setting );
-				}
-			}
-		}
 	}
 }

--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -16,6 +16,13 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 	 * Class Blocks_Usage_Controller
 	 */
 	class Blocks_Usage_Controller extends Controller {
+		/**
+		 * @var string[] Possible prefixes for planet4 blocks.
+		 */
+		private const PLANET4_PREFIXES = [
+			'planet4',
+			'p4',
+		];
 
 		/**
 		 * Create menu/submenu entry.
@@ -200,8 +207,6 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 				echo '<td><a href="term.php?taxonomy=post_tag&tag_ID=' . $result->term_id . '" >' . $result->name . '</a></td></tr>';
 			}
 			echo '</table>';
-
-
 			// phpcs:enable
 		}
 
@@ -214,7 +219,14 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 			$p4_block_types = array_filter(
 				$registered_block_types,
 				static function ( \WP_Block_Type $block_type ) {
-					return strpos( $block_type->name, 'planet4-blocks/' ) === 0;
+					// even though the blocks in this repo all use namespace "planet4-blocks", NRO developed blocks
+					// can have a different namespace. They do all start with "planet4-".
+					foreach ( self::PLANET4_PREFIXES as $prefix ) {
+						if ( strpos( $block_type->name, $prefix ) === 0 ) {
+							return true;
+						}
+					}
+					return false;
 				}
 			);
 			// we only need the name.

--- a/classes/controller/menu/class-controller.php
+++ b/classes/controller/menu/class-controller.php
@@ -26,7 +26,6 @@ if ( ! class_exists( 'Controller' ) ) {
 		 */
 		protected $view;
 
-
 		/**
 		 * Creates the plugin's controller object.
 		 * Avoid putting hooks inside the constructor, to make testing easier.
@@ -43,37 +42,5 @@ if ( ! class_exists( 'Controller' ) ) {
 		public function load() {
 			add_action( 'admin_menu', array( $this, 'create_admin_menu' ) );
 		}
-
-		/**
-		 * Validates and sanitizes the settings input.
-		 *
-		 * @param array $settings The associative array with the settings that are registered for the plugin.
-		 *
-		 * @return mixed Array if validation is ok, false if validation fails.
-		 */
-		public function valitize( $settings ) {
-			if ( $this->validate( $settings ) ) {
-				$this->sanitize( $settings );
-				return $settings;
-			} else {
-				return $settings;
-			}
-		}
-
-		/**
-		 * Validates the settings input.
-		 *
-		 * @param array $settings The associative array with the settings that are registered for the plugin.
-		 *
-		 * @return bool
-		 */
-		abstract public function validate( $settings ) : bool;
-
-		/**
-		 * Sanitizes the settings input.
-		 *
-		 * @param array $settings The associative array with the settings that are registered for the plugin (Call by Reference).
-		 */
-		abstract public function sanitize( &$settings );
 	}
 }

--- a/classes/controller/menu/class-reusable-blocks-controller.php
+++ b/classes/controller/menu/class-reusable-blocks-controller.php
@@ -37,30 +37,5 @@ if ( ! class_exists( 'Reusable_Blocks_Controller' ) ) {
 				);
 			}
 		}
-
-		/**
-		 * Validates the settings input.
-		 *
-		 * @param array $settings The associative array with the settings that are registered for the plugin.
-		 *
-		 * @return bool
-		 */
-		public function validate( $settings ) : bool {
-			$has_errors = false;
-			return ! $has_errors;
-		}
-
-		/**
-		 * Sanitizes the settings input.
-		 *
-		 * @param array $settings The associative array with the settings that are registered for the plugin.
-		 */
-		public function sanitize( &$settings ) {
-			if ( $settings ) {
-				foreach ( $settings as $name => $setting ) {
-					$settings[ $name ] = sanitize_text_field( $setting );
-				}
-			}
-		}
 	}
 }

--- a/classes/controller/menu/class-settings-controller.php
+++ b/classes/controller/menu/class-settings-controller.php
@@ -8,8 +8,6 @@
 
 namespace P4GBKS\Controllers\Menu;
 
-use P4GBKS\Command\Shortcode_To_Gutenberg;
-
 if ( ! class_exists( 'Settings_Controller' ) ) {
 
 	/**
@@ -33,31 +31,6 @@ if ( ! class_exists( 'Settings_Controller' ) ) {
 					null,
 					'dashicons-layout'
 				);
-			}
-		}
-
-		/**
-		 * Validates the settings input.
-		 *
-		 * @param array $settings The associative array with the settings that are registered for the plugin.
-		 *
-		 * @return bool
-		 */
-		public function validate( $settings ) : bool {
-			$has_errors = false;
-			return ! $has_errors;
-		}
-
-		/**
-		 * Sanitizes the settings input.
-		 *
-		 * @param array $settings The associative array with the settings that are registered for the plugin.
-		 */
-		public function sanitize( &$settings ) {
-			if ( $settings ) {
-				foreach ( $settings as $name => $setting ) {
-					$settings[ $name ] = sanitize_text_field( $setting );
-				}
 			}
 		}
 	}

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -234,11 +234,9 @@ P4GBKS\Loader::get_instance(
 		// --- Add here your own Block Controller ---
 		// DEPRECATED: Blocks could be registered inside Loader class
 		// 'P4GBKS\Controllers\Blocks\NewCovers_Controller'
-		'P4GBKS\Controllers\Menu\Settings_Controller',
-		'P4GBKS\Controllers\Menu\Blocks_Usage_Controller',
-		'P4GBKS\Controllers\Menu\Reusable_Blocks_Controller',
+		\P4GBKS\Controllers\Menu\Settings_Controller::class,
+		\P4GBKS\Controllers\Menu\Blocks_Usage_Controller::class,
+		\P4GBKS\Controllers\Menu\Reusable_Blocks_Controller::class,
 	],
-	'P4GBKS\Views\View',
-	'P4GBKS\Command\Shortcode_To_Gutenberg',
-	'P4GBKS\Command\Controller'
+	\P4GBKS\Views\View::class
 );


### PR DESCRIPTION
I initially started for a broader reworking of the report page, so I started with a cleanup commit to remove some boilerplate code. The scope of the ticket then narrowed to only include making the report also include NRO developed blocks. However it makes sense to already include the cleanup commits as it only removes things (+ small change to use ::class instead of string class names). I kept both commits separate as they do different things.