### PR TITLE
Restrict Social Share block to Campaigns

### DIFF
--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -118,7 +118,6 @@ const PAGE_BLOCK_TYPES = [
 	'planet4-blocks/submenu',
 	'planet4-blocks/take-action-boxout',
 	'planet4-blocks/timeline',
-	'planet4-blocks/socialshare',
 ];
 
 // campaigns allow all block types.
@@ -133,10 +132,10 @@ const CAMPAIGN_BLOCK_TYPES = [
 	'planet4-blocks/happypoint',
 	'planet4-blocks/media',
 	'planet4-blocks/social-media',
+	'planet4-blocks/socialshare',
 	'planet4-blocks/split-two-columns',
 	'planet4-blocks/submenu',
 	'planet4-blocks/timeline',
-	'planet4-blocks/socialshare',
 ];
 
 /**


### PR DESCRIPTION
This is opened against master, so we can quickly get it to production. I'll cherry-pick it on develop afterwards.