### PR TITLE
PLANET-4538 Force SocialMediaCards images to download and PLANET-4539 improve twitter

### DIFF
--- a/classes/blocks/class-socialmediacards.php
+++ b/classes/blocks/class-socialmediacards.php
@@ -66,6 +66,10 @@ class SocialMediaCards extends Base_Block {
 	 * @return array The data to be passed in the View.
 	 */
 	public function prepare_data( $fields ): array {
+		// Enqueue js for the frontend.
+		if ( ! $this->is_rest_request() ) {
+			wp_enqueue_script( 'social-media-cards', P4GBKS_PLUGIN_URL . 'public/js/social_media_cards.js', [], '0.1', true );
+		}
 
 		$images = [];
 

--- a/public/js/social_media_cards.js
+++ b/public/js/social_media_cards.js
@@ -1,17 +1,36 @@
 document.addEventListener( 'DOMContentLoaded', () => {
 
-  function toDataURL( url ) {
-    return fetch( url ).then( ( response ) => {
-      return response.blob();
-    } ).then( blob => {
-      return URL.createObjectURL( blob );
+  document.querySelectorAll( 'a.twitter-share' ).forEach( ( link ) => {
+    link.addEventListener( 'click', ( event ) => {
+
+      event.preventDefault();
+
+      let popup = window.open(
+        'https://twitter.com/intent/tweet'
+        + `?text=${ encodeURIComponent( link.dataset.text ) }`
+        + `&url=${ encodeURIComponent( link.dataset.socialUrl ) }`,
+        'twitter-popup',
+        'height=350,width=600'
+      );
+
+      if ( popup.focus ) {
+        popup.focus();
+      }
+
+      return false;
     } );
+  } );
+
+  function toDataURL( url ) {
+    return fetch( url )
+      .then( ( response ) => response.blob() )
+      .then( ( blob ) => URL.createObjectURL( blob ) );
   }
 
-  // Force the download button to always download instead of showing in browser, even cross origin
+  // Force the download button to always download the file instead of showing it in browser, even cross origin.
   document.querySelectorAll( 'a.link-should-download' ).forEach( ( link ) => {
-    link.addEventListener( 'click', ( e ) => {
-      e.preventDefault();
+    link.addEventListener( 'click', ( event ) => {
+      event.preventDefault();
       let a = document.createElement( 'a' );
       toDataURL( link.href ).then( ( url ) => {
         a.href = url;

--- a/public/js/social_media_cards.js
+++ b/public/js/social_media_cards.js
@@ -1,0 +1,25 @@
+document.addEventListener( 'DOMContentLoaded', () => {
+
+  function toDataURL( url ) {
+    return fetch( url ).then( ( response ) => {
+      return response.blob();
+    } ).then( blob => {
+      return URL.createObjectURL( blob );
+    } );
+  }
+
+  // Force the download button to always download instead of showing in browser, even cross origin
+  document.querySelectorAll( 'a.link-should-download' ).forEach( ( link ) => {
+    link.addEventListener( 'click', ( e ) => {
+      e.preventDefault();
+      let a = document.createElement( 'a' );
+      toDataURL( link.href ).then( ( url ) => {
+        a.href = url;
+        a.download = '';
+        document.body.appendChild( a );
+        a.click();
+        document.body.removeChild( a );
+      } );
+    } );
+  } );
+} );

--- a/templates/blocks/social_media_cards.twig
+++ b/templates/blocks/social_media_cards.twig
@@ -24,16 +24,21 @@
 
 							<div class="share-strip">
 								<a href="https://www.facebook.com/sharer/sharer.php?u={{ single_image.social_url }}"
+								   title="{{ __('Share on Facebook') }}"
 									onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Facebook', 'eventLabel': '{{ single_image.social_url }}'});"
 									target="_blank" class="facebook-share">
 									{{ "facebook"|svgicon }}
 								</a>
-								<a href="https://twitter.com/intent/tweet?url={{ single_image.social_url }}&text={{ single_image.message }}"
+								<a href="https://twitter.com/intent/tweet?url={{ single_image.social_url }}&text={{ single_image.message|url_encode }}"
+								   data-text="{{ single_image.message }}"
+								   data-social-url="{{ single_image.social_url }}"
+								   title="{{ __('Share on Twitter') }}"
 									onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Twitter', 'eventLabel': '{{ single_image.social_url }}'});"
 									target="_blank" class="twitter-share">
 									{{ "twitter"|svgicon }}
 								</a>
 								<a href="{{ single_image.image_src }}" download
+								   title="{{ __('Download image') }}"
 									onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Download', 'eventLabel': '{{ single_image.social_url }}'});"
 									class="download-share link-should-download">
 									{{ "download"|svgicon }}

--- a/templates/blocks/social_media_cards.twig
+++ b/templates/blocks/social_media_cards.twig
@@ -35,7 +35,7 @@
 								</a>
 								<a href="{{ single_image.image_src }}" download
 									onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Download', 'eventLabel': '{{ single_image.social_url }}'});"
-									class="downlaod-share">
+									class="download-share link-should-download">
 									{{ "download"|svgicon }}
 								</a>
 							</div>


### PR DESCRIPTION
* Add a title on all buttons (not in ticket but discussed with Will and can be included here)

https://jira.greenpeace.org/browse/PLANET-4538
* Force SocialMediaCards image download button to always download instead of showing in browser

https://jira.greenpeace.org/browse/PLANET-4539
* Make tweet open in popup instead of new tab
* keep the original href as fallback, though it's not used by js
* Url encode to make hashtags work
