### PR TITLE
PLANET-4516: Gallery+Carousel Header block: Images get massively zoomed in for no reason

### DIFF
--- a/assets/src/styles/blocks/Gallery_carousel.scss
+++ b/assets/src/styles/blocks/Gallery_carousel.scss
@@ -36,7 +36,7 @@
     img {
       height: auto;
       width: 100%;
-      object-fit: none;
+      object-fit: cover;
 
       @include medium-and-up {
         height: 400px;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4516

Note: This simple fix addresses the main issues. You can run into scenarios that produce zoomed images, if you combine bad image sizes with weird aspect ratios, but those would be edge cases. 