### PR TITLE
PLANET-4540 Fix facebook share and remove unused code

### DIFF
--- a/assets/src/blocks/SocialMediaCards/SocialMediaCards.js
+++ b/assets/src/blocks/SocialMediaCards/SocialMediaCards.js
@@ -3,8 +3,6 @@ import { Preview } from '../../components/Preview';
 
 
 import {
-  MediaPlaceholder,
-  InspectorControls,
   BlockControls,
   MediaUpload,
   MediaUploadCheck
@@ -15,9 +13,6 @@ import {
   TextareaControl,
   ServerSideRender,
   FocalPointPicker,
-  ToggleControl,
-  RangeControl,
-  PanelBody,
   Button,
   Toolbar,
   IconButton
@@ -33,17 +28,7 @@ export class SocialMediaCards extends Component {
 
     const dimensions = { width: 212, height: 212 };
 
-    const { focus_image, id, multiple_image, image_data } = this.props;
-
-    let focal_point_params = { x: '', y: '' };
-
-    if (focus_image) {
-      let focus_image_str = focus_image.replace(/%/g, '');
-      let [x, y] = focus_image_str.split(' ');
-      focal_point_params = { x: x / 100, y: y / 100 };
-    } else {
-      focal_point_params = { x: 0.5, y: 0.5 };
-    }
+    const { multiple_image, image_data } = this.props;
 
     const getImageOrButton = (openEvent) => {
       if (0 < this.props.image_data.length) {

--- a/assets/src/blocks/SocialMediaCards/SocialMediaCardsBlock.js
+++ b/assets/src/blocks/SocialMediaCards/SocialMediaCardsBlock.js
@@ -10,53 +10,6 @@ export class SocialMediaCardsBlock {
       title: __('Social Media Cards', 'p4ge'),
       icon: 'format-image',
       category: 'planet4-blocks',
-
-      /**
-       * Transforms old 'shortcake' shortcode to new gutenberg block.
-       */
-      transforms: {
-        from: [
-          {
-            type: 'shortcode',
-            // Shortcode tag can also be an array of shortcode aliases
-            tag: 'shortcake_socail_share',
-            attributes: {
-              title: {
-                type: 'string',
-                shortcode: function (attributes) {
-                  return attributes.named.title;
-                }
-              },
-              description: {
-                type: 'string',
-                shortcode: function (attributes) {
-                  return attributes.named.description;
-                }
-              },
-              id: {
-                type: 'integer',
-                shortcode: ({ named: { id = '' } }) => id,
-              },
-              multiple_image: {
-                type: 'string',
-                shortcode: ({ named: { multiple_image = '' } }) => multiple_image,
-              },
-              gallery_block_focus_points: {
-                type: 'string',
-                shortcode: ({ named: { gallery_block_focus_points = '' } }) => gallery_block_focus_points,
-              },
-              messages: {
-                type: 'string',
-                shortcode: ({ named: { messages = '' } }) => messages,
-              },
-              urls: {
-                type: 'string',
-                shortcode: ({ named: { urls = '' } }) => urls,
-              },
-            },
-          },
-        ]
-      },
       attributes: {
         title: {
           type: 'string',
@@ -80,9 +33,6 @@ export class SocialMediaCardsBlock {
         gallery_block_focus_points: {
           type: 'string',
         },
-        messages: {
-          type: 'string',
-        },
         urls: {
           type: 'string',
         },
@@ -98,9 +48,9 @@ export class SocialMediaCardsBlock {
           let image_id_array = multiple_image.split(',');
 
           $.each(image_id_array, function (index, img_id) {
-            let img_url = select('core').getMedia(img_id);
-            if (img_url) {
-              image_urls_array[img_id] = img_url.media_details.sizes.medium.source_url;
+            let img_details = select('core').getMedia(img_id);
+            if (img_details) {
+              image_urls_array[img_id] = img_details.source_url;
             }
           });
         }
@@ -122,7 +72,6 @@ export class SocialMediaCardsBlock {
           let new_image_data = [];
           let focal_points_json = gallery_block_focus_points ? JSON.parse(gallery_block_focus_points) : {};
           let messages_json = messages ? JSON.parse(messages) : {};
-          debugger;
           let urlss_json = urls ? JSON.parse(urls) : {};
           for (const img_id in image_urls_array) {
 

--- a/classes/blocks/class-socialmediacards.php
+++ b/classes/blocks/class-socialmediacards.php
@@ -44,12 +44,6 @@ class SocialMediaCards extends Base_Block {
 					'gallery_block_focus_points' => [
 						'type' => 'string',
 					],
-					'urls'                       => [
-						'type' => 'string',
-					],
-					'messages'                   => [
-						'type' => 'string',
-					],
 					'multiple_image'             => [
 						'type' => 'string',
 					],
@@ -85,22 +79,6 @@ class SocialMediaCards extends Base_Block {
 			$img_focus_points = [];
 		}
 
-		if ( isset( $fields['messages'] ) ) {
-			$messages = json_decode( str_replace( "'", '"', $fields['messages'] ), true );
-		} else {
-			$messages = [];
-		}
-
-		if ( isset( $fields['urls'] ) ) {
-			$urls = json_decode( str_replace( "'", '"', $fields['urls'] ), true );
-		} else {
-			$urls = [];
-		}
-
-		$images_dimensions = [];
-
-		$fields['id'] = $fields['id'] ?? '';
-
 		$count = 0;
 		foreach ( $exploded_images as $image_id ) {
 			$image_size = 'retina-large';
@@ -124,21 +102,14 @@ class SocialMediaCards extends Base_Block {
 				}
 			}
 
-			if ( count( (array) $image_data_array ) >= 3 ) {
-				$images_dimensions[] = $image_data_array[1];
-				$images_dimensions[] = $image_data_array[2];
-			}
-
 			$images[] = $image_data;
 			$count++;
 		}
-		$fields['title']       = '' !== $fields['title'] ? $fields['title'] : '';
-		$fields['description'] = '' !== $fields['description'] ? $fields['description'] : '';
-		$data                  = [
-			'fields' => $fields,
-			'images' => $images,
-		];
 
-		return $data;
+		return [
+			'post_url' => get_permalink(),
+			'fields'   => $fields,
+			'images'   => $images,
+		];
 	}
 }

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -243,7 +243,7 @@ function empty_string_to_false_in_link_new_tab_in_columns_blocks( $block ): arra
 	// Yes, that's right, WordPress doesn't follow its own rules here so we have a camel among snakes.
 	if ( 'planet4-blocks/columns' === $block['blockName'] ?? null ) {
 		foreach ( $block['attrs']['columns'] ?? [] as $key => $column ) {
-			if ( true !== $column['link_new_tab'] ) {
+			if ( isset( $column['link_new_tab'] ) && true !== $column['link_new_tab'] ) {
 				$block['attrs']['columns'][ $key ]['link_new_tab'] = false;
 			}
 		}

--- a/public/js/social_media_cards.js
+++ b/public/js/social_media_cards.js
@@ -1,44 +1,35 @@
 document.addEventListener( 'DOMContentLoaded', () => {
 
+  function openPopup(url) {
+    let popup = window.open(
+      url,
+      'popup',
+      'height=350,width=600'
+    );
+
+    if ( popup.focus ) {
+      popup.focus();
+    }
+  }
+
   document.querySelectorAll( 'a.twitter-share' ).forEach( ( link ) => {
     link.addEventListener( 'click', ( event ) => {
-
       event.preventDefault();
-
-      let popup = window.open(
-        'https://twitter.com/intent/tweet'
-        + `?text=${ encodeURIComponent( link.dataset.text ) }`
-        + `&url=${ encodeURIComponent( link.dataset.socialUrl ) }`,
-        'twitter-popup',
-        'height=350,width=600'
+      openPopup(
+        `https://twitter.com/intent/tweet?text=${ encodeURIComponent( link.dataset.text ) }&url=${ encodeURIComponent( link.dataset.socialUrl ) }`
       );
-
-      if ( popup.focus ) {
-        popup.focus();
-      }
 
       return false;
     } );
   } );
 
-  // function toDataURL( url ) {
-  //   return fetch( url )
-  //     .then( ( response ) => response.blob() )
-  //     .then( ( blob ) => URL.createObjectURL( blob ) );
-  // }
-  //
-  // // Force the download button to always download the file instead of showing it in browser, even cross origin.
-  // document.querySelectorAll( 'a.link-should-download' ).forEach( ( link ) => {
-  //   link.addEventListener( 'click', ( event ) => {
-  //     event.preventDefault();
-  //     let a = document.createElement( 'a' );
-  //     toDataURL( link.href ).then( ( url ) => {
-  //       a.href = url;
-  //       a.download = '';
-  //       document.body.appendChild( a );
-  //       a.click();
-  //       document.body.removeChild( a );
-  //     } );
-  //   } );
-  // } );
+  document.querySelectorAll( 'a.facebook-share' ).forEach( ( link ) => {
+    link.addEventListener('click', ( event ) => {
+      event.preventDefault();
+
+      openPopup( link.href );
+
+      return false;
+    });
+  });
 } );

--- a/templates/blocks/social_media_cards.twig
+++ b/templates/blocks/social_media_cards.twig
@@ -23,24 +23,24 @@
 								alt="{{ single_image.alt_text }}">
 
 							<div class="share-strip">
-								<a href="https://www.facebook.com/sharer/sharer.php?u={{ single_image.social_url }}"
+								<a href="https://www.facebook.com/share.php?u={{ single_image.social_url|url_encode|default(post_url) }}&quote={{ single_image.message|url_encode }}"
 								   title="{{ __('Share on Facebook') }}"
-									onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Facebook', 'eventLabel': '{{ single_image.social_url }}'});"
+									onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Facebook', 'eventLabel': '{{ single_image.social_url|default(post_url) }}'});"
 									target="_blank" class="facebook-share">
 									{{ "facebook"|svgicon }}
 								</a>
-								<a href="https://twitter.com/intent/tweet?url={{ single_image.social_url }}&text={{ single_image.message|url_encode }}"
+								<a href="https://twitter.com/intent/tweet?url={{ single_image.social_url|url_encode|default(post_url) }}&text={{ single_image.message|url_encode }}"
 								   data-text="{{ single_image.message }}"
-								   data-social-url="{{ single_image.social_url }}"
+								   data-social-url="{{ single_image.social_url|default(post_url) }}"
 								   title="{{ __('Share on Twitter') }}"
-									onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Twitter', 'eventLabel': '{{ single_image.social_url }}'});"
+									onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Twitter', 'eventLabel': '{{ single_image.social_url|default(post_url) }}'});"
 									target="_blank" class="twitter-share">
 									{{ "twitter"|svgicon }}
 								</a>
 								<a href="{{ single_image.image_src }}" download
 								   target="_blank"
 								   title="{{ __('Download image') }}"
-									onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Download', 'eventLabel': '{{ single_image.social_url }}'});"
+									onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Download', 'eventLabel': '{{ single_image.social_url|default(post_url) }}'});"
 									class="download-share link-should-download">
 									{{ "download"|svgicon }}
 								</a>


### PR DESCRIPTION
* Facebook share now opens in new tab, providing the
social_media_message as quoted text
* All SocialMediaCards code was initially copied from the Gallery
block as a starting point, however this was never cleaned up. This
removes some of it, except for the focal points, which don't work but it
is not clear whether it should be removed or the functionality should be
implemented.
* Remove the conversion from shortcode.
* Prevent notices for the link_new_tab fix