### PR TITLE
PLANET-4532: Perf: Investigate lazy-loading solution across P4 (incl. all browsers)

### DIFF
--- a/assets/src/blocks/Carouselheader/FullWidthCarouselHeader.js
+++ b/assets/src/blocks/Carouselheader/FullWidthCarouselHeader.js
@@ -1,4 +1,4 @@
-/* global Hammer */
+/* global Hammer, LazyLoad */
 
 export const FullWidthCarouselHeader = {
   /**
@@ -61,6 +61,18 @@ export const FullWidthCarouselHeader = {
 
       // Convert the provided image tag into background image styles.
       const $img = $slide.find('img');
+
+      // Images after the first slide are preloaded
+      // on initialization
+      if ($img.hasClass('preload')) {
+        if (!window.lazyLoad) {
+          window.lazyLoad = new LazyLoad({
+            elements_selector: '.lazyload'
+          });
+        }
+        window.lazyLoad.load($img[0]);
+      }
+
       const img_src = $img.get(0).currentSrc || $img.attr('src');
       $slide.find('.background-holder')
         .css('background-image', 'url(' + img_src + ')')

--- a/classes/blocks/class-carouselheader.php
+++ b/classes/blocks/class-carouselheader.php
@@ -136,12 +136,14 @@ class CarouselHeader extends Base_Block {
 		// Enqueue js for the frontend.
 		if ( ! $this->is_rest_request() ) {
 			wp_enqueue_script( 'hammer', 'https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js', [], '2.0.8', true );
+			wp_register_script( 'lazyload', 'https://cdnjs.cloudflare.com/ajax/libs/vanilla-lazyload/12.3.0/lazyload.min.js', [], '12.3.0', true );
 			wp_enqueue_script(
 				'carousel-header',
 				P4GBKS_PLUGIN_URL . 'assets/build/carouselHeaderFrontIndex.js',
 				[
 					'jquery',
 					'hammer',
+					'lazyload',
 				],
 				'0.3',
 				true

--- a/templates/blocks/carousel_header_full-width-classic.twig
+++ b/templates/blocks/carousel_header_full-width-classic.twig
@@ -25,10 +25,19 @@
 						<div class="carousel-item-mask">
 							<div class="background-holder">
 								{% if slide.image %}
-									<img src="{{ slide.image }}"
-										data-background-position="{{ slide.focus_image }}"
+									<img
+										{% if ( loop.first ) %}
+										src="{{ slide.image }}"
 										srcset="{{ slide.image_srcset }}"
 										sizes="{{ slide.image_sizes }}"
+										{% else %}
+										data-src="{{ slide.image }}"
+										data-srcset="{{ slide.image_srcset }}"
+										data-sizes="{{ slide.image_sizes }}"
+										class="preload"
+										{% endif %}
+										data-background-position="{{ slide.focus_image }}"
+
 										alt="{{ slide.image_alt  }}">
 
 									<div class="carousel-caption">

--- a/templates/blocks/gallery.twig
+++ b/templates/blocks/gallery.twig
@@ -35,10 +35,18 @@
 
 						{% for key,single_image in images %}
 							<div class="carousel-item {% if key == 0 %}active{% endif %}">
-								<img src="{{ single_image.image_src }}"
+								<img
+									{% if ( loop.first ) %}
+										src="{{ single_image.image_src }}"
+									 	srcset="{{ single_image.image_srcset }}"
+									 	sizes="{{ single_image.image_sizes }}"
+									{% else %}
+										data-src="{{ single_image.image_src }}"
+									 	data-srcset="{{ single_image.image_srcset }}"
+									 	data-sizes="{{ single_image.image_sizes }}"
+										class="preload"
+									{% endif %}
 									 style="object-position: {{ single_image.focus_image }}"
-									 srcset="{{ single_image.image_srcset }}"
-									 sizes="{{ single_image.image_sizes }}"
 									 alt="{{ single_image.alt_text }}">
 
 								{% if ( single_image.caption or single_image.credits ) %}
@@ -90,11 +98,19 @@
 							<div class="col">
 								<div class="{{ ordinals[key] }}-column split-image">
 									{% if ( single_image.image_src ) %}
-										<img src="{{ single_image.image_src }}"
-											 srcset="{{ single_image.image_srcset }}"
-											 sizes="{{ single_image.image_sizes }}"
-											 style="object-position:{{ single_image.focus_image }};"
-											 alt="{{ single_image.alt_text }}" class="img_{{ post_type }}">
+										<img
+											{% if ( loop.first ) %}
+												src="{{ single_image.image_src }}"
+												srcset="{{ single_image.image_srcset }}"
+												sizes="{{ single_image.image_sizes }}"
+											{% else %}
+												data-src="{{ single_image.image_src }}"
+												data-srcset="{{ single_image.image_srcset }}"
+												data-sizes="{{ single_image.image_sizes }}"
+												class="lazyload"
+											{% endif %}
+											style="object-position:{{ single_image.focus_image }};"
+											alt="{{ single_image.alt_text }}" class="img_{{ post_type }}">
 									{% endif %}
 								</div>
 							</div>
@@ -124,7 +140,15 @@
 					<div class="grid-row">
 						{% for single_image in images %}
 							<div class="grid-item">
-								<img src="{{ single_image.image_src }}" style="object-position: {{ single_image.focus_image }};" alt="{{ single_image.alt_text }}">
+								<img
+									{% if ( loop.first ) %}
+										src="{{ single_image.image_src }}"
+									{% else %}
+										data-src="{{ single_image.image_src }}"
+										class="lazyload"
+									{% endif %}
+									style="object-position: {{ single_image.focus_image }};"
+									alt="{{ single_image.alt_text }}">
 							</div>
 						{% endfor %}
 					</div>

--- a/templates/blocks/tease-articles.twig
+++ b/templates/blocks/tease-articles.twig
@@ -3,14 +3,16 @@
 		<div class="article-list-item-image">
 			<div class="article-image-holder">
 				<a href="{{ recent_post.link }}">
-					<img class="d-flex topicwise-article-image" src="{{ fn('get_the_post_thumbnail_url', recent_post.ID, 'articles-medium-large' ) }}" alt="{{ recent_post.alt_text }}">
+					<img class="d-flex topicwise-article-image lazyload"
+						data-src="{{ fn('get_the_post_thumbnail_url', recent_post.ID, 'articles-medium-large' ) }}" alt="{{ recent_post.alt_text }}">
 				</a>
 			</div>
 		</div>
 	{% else %}
 		<div class="article-list-item-image article-list-item-image-max-width">
 			<a href="{{ recent_post.link }}">
-				<img class="d-flex topicwise-article-image" src="{{ fn('get_the_post_thumbnail_url', recent_post.ID, 'articles-medium-large' )  }}" alt="{{ recent_post.alt_text }}">
+				<img class="d-flex topicwise-article-image lazyload"
+				  data-src="{{ fn('get_the_post_thumbnail_url', recent_post.ID, 'articles-medium-large' )  }}" alt="{{ recent_post.alt_text }}">
 			</a>
 		</div>
 	{% endif %}

--- a/templates/teasers/tease-articles.twig
+++ b/templates/teasers/tease-articles.twig
@@ -3,14 +3,18 @@
 		<div class="article-list-item-image">
 			<div class="article-image-holder">
 				<a href="{{ recent_post.link }}">
-					<img class="d-flex topicwise-article-image" src="{{ fn('get_the_post_thumbnail_url', recent_post.ID, 'articles-medium-large' ) }}" alt="{{ recent_post.alt_text }}">
+					<img class="d-flex topicwise-article-image lazyload"
+						data-src="{{ fn('get_the_post_thumbnail_url', recent_post.ID, 'articles-medium-large' ) }}"
+						alt="{{ recent_post.alt_text }}">
 				</a>
 			</div>
 		</div>
 	{% else %}
 		<div class="article-list-item-image article-list-item-image-max-width">
 			<a href="{{ recent_post.link }}">
-				<img class="d-flex topicwise-article-image" src="{{ fn('get_the_post_thumbnail_url', recent_post.ID, 'articles-medium-large' )  }}" alt="{{ recent_post.alt_text }}">
+				<img class="d-flex topicwise-article-image lazyload"
+					data-src="{{ fn('get_the_post_thumbnail_url', recent_post.ID, 'articles-medium-large' )  }}"
+					alt="{{ recent_post.alt_text }}">
 			</a>
 		</div>
 	{% endif %}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4532

Notes: 

- I included a vanilla JS lazy-loading lib, from a CDN, here and in the `master-theme`. This is what we currently do with things like jQuery. This same lib could be installed using `npm install`, but I couldn't find a way to install it only on the `master-theme`, and get the plugin's JS to load after the `master-theme`'s JS. We can address that separately in the future.

- These changes basically seem to improve some critical path metrics: DOM Content Loaded, First Paint, First meaningful paint..., running on my local instance, these are the results on `develop`:

<img width="1178" alt="Captura de pantalla 2019-12-19 a la(s) 11 00 42" src="https://user-images.githubusercontent.com/340766/71180334-b5bcd180-2250-11ea-8ba9-de4677ed8ee8.png">

<img width="1173" alt="Captura de pantalla 2019-12-19 a la(s) 11 01 49" src="https://user-images.githubusercontent.com/340766/71180305-a6d61f00-2250-11ea-86f2-a52a3ca95d58.png">

Same audit in this branch:

<img width="1228" alt="Captura de pantalla 2019-12-19 a la(s) 10 58 47" src="https://user-images.githubusercontent.com/340766/71180354-c10ffd00-2250-11ea-9a20-60fec282a81d.png">

<img width="1063" alt="Captura de pantalla 2019-12-19 a la(s) 10 59 28" src="https://user-images.githubusercontent.com/340766/71180408-e6047000-2250-11ea-8e99-7b70ee03fe43.png">


These results can vary a little, as the total number of milliseconds shown below (which are bigger in this branch), but it looks like the FMP (First meaningful paint) event is now happening before the DCL (DOMContentLoaded).

A few more audits with more content will get better results.
