### PR TITLE
PLANET-4567: #408845: Gallery block: navigation indicators are elongated

### DIFF
--- a/assets/src/styles/blocks/Gallery_carousel.scss
+++ b/assets/src/styles/blocks/Gallery_carousel.scss
@@ -108,7 +108,7 @@
     }
   }
 
-  .carousel-indicators {
+  ol.carousel-indicators {
     right: 25%;
     bottom: 80px;
     left: auto;
@@ -145,6 +145,7 @@
     }
 
     li {
+      padding-top: 0;
       width: 8px;
       height: 8px;
       margin: 0 8px;


### PR DESCRIPTION
This was being affected by this rule: 
https://github.com/greenpeace/planet4-master-theme/blob/develop/assets/src/scss/pages/post/_article-content.scss#L49

I increased the specificity of the selectors for the Gallery and set the padding to 0.

Ref: https://jira.greenpeace.org/browse/PLANET-4567