### PR TITLE
PLANET-4603 Introduce campaign sidebar

### DIFF
--- a/assets/src/components/ColorPaletteControl/ColorPaletteControl.js
+++ b/assets/src/components/ColorPaletteControl/ColorPaletteControl.js
@@ -1,0 +1,23 @@
+import { isEmpty } from 'lodash';
+import classnames from 'classnames';
+import { withInstanceId } from '@wordpress/compose';
+import { BaseControl } from '@wordpress/components';
+import { ColorPalette } from '@wordpress/components';
+
+function ColorPaletteControl( { label, className, value, help, instanceId, onChange, options = [], ...passThroughProps } ) {
+  const id = `inspector-color-palette-control-${ instanceId }`;
+
+  return !isEmpty( options ) && (
+    <BaseControl label={ label } id={ id } help={ help }
+                 className={ classnames( className, 'components-color-palette-control' ) }>
+      <ColorPalette
+        value={ value }
+        onChange={ onChange }
+        colors={ options }
+        { ...passThroughProps }
+      />
+    </BaseControl>
+  );
+}
+
+export default withInstanceId( ColorPaletteControl );

--- a/assets/src/components/PostMeta/withPostMeta.js
+++ b/assets/src/components/PostMeta/withPostMeta.js
@@ -1,0 +1,64 @@
+import { withSelect, withDispatch } from "@wordpress/data";
+import { RadioControl } from "@wordpress/components";
+import { compose } from '@wordpress/compose';
+import { Component } from '@wordpress/element';
+
+const getValuePropName = ( Component ) => {
+  switch ( Component ) {
+    case RadioControl:
+      return 'selected';
+  }
+
+  return 'value';
+};
+
+export function withPostMeta( WrappedComponent ) {
+
+  class WrappingComponent extends Component {
+    constructor( props ) {
+      super( props );
+      this.handleChange = this.handleChange.bind( this );
+      this.valuePropName = getValuePropName( WrappedComponent );
+    }
+
+    handleChange( metaKey, value ) {
+      this.props.writeMeta( metaKey, value );
+    }
+
+    render() {
+      const { metaKey, postMeta, writeMeta, onChange, ...ownProps } = this.props;
+
+      return <WrappedComponent
+        { ...{
+          [ this.valuePropName ]: postMeta[ metaKey ],
+          onChange: ( value ) => {
+            this.handleChange( metaKey, value || '' );
+            if ( onChange ) {
+              onChange( value );
+            }
+          }
+        } }
+        { ...ownProps }
+      />;
+    }
+  }
+
+  return compose(
+    withSelect(
+      ( select ) => {
+        return {
+          postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' )
+        };
+      }
+    ),
+    withDispatch(
+      ( dispatch ) => {
+        return {
+          writeMeta: ( metaKey, value ) => {
+            dispatch( 'core/editor' ).editPost( { meta: { [ metaKey ]: value } } );
+          }
+        };
+      }
+    )
+  )( WrappingComponent );
+}

--- a/assets/src/components/Sidebar/CampaignSidebar.js
+++ b/assets/src/components/Sidebar/CampaignSidebar.js
@@ -1,0 +1,225 @@
+import { PluginSidebar, PluginSidebarMoreMenuItem } from "@wordpress/edit-post";
+import { Component } from '@wordpress/element';
+import { PanelBody, RadioControl, SelectControl } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
+import ColorPaletteControl from '../ColorPaletteControl/ColorPaletteControl';
+import { withPostMeta } from '../PostMeta/withPostMeta';
+import { __ } from '@wordpress/i18n';
+import { fromThemeOptions } from '../fromThemeOptions/fromThemeOptions';
+
+const themeOptions = [
+  {
+    value: '',
+    label: 'Default',
+  },
+  {
+    value: 'antarctic',
+    label: 'Antarctic',
+  },
+  {
+    value: 'arctic',
+    label: 'Arctic',
+  },
+  {
+    value: 'climate',
+    label: 'Climate Emergency',
+  },
+  {
+    value: 'forest',
+    label: 'Forest',
+  },
+  {
+    value: 'oceans',
+    label: 'Oceans',
+  },
+  {
+    value: 'oil',
+    label: 'Oil',
+  },
+  {
+    value: 'plastic',
+    label: 'Plastics',
+  },
+
+];
+
+const ThemeSelect = withPostMeta( SelectControl );
+
+const Select = compose(
+  fromThemeOptions,
+  withPostMeta,
+)( SelectControl );
+
+const Radio = compose(
+  fromThemeOptions,
+  withPostMeta,
+)( RadioControl );
+
+const ColorPalette = compose(
+  fromThemeOptions,
+  withPostMeta,
+)( ColorPaletteControl );
+
+
+export class CampaignSidebar extends Component {
+  static getId() {
+    return 'planet4-campaign-sidebar';
+  }
+
+  static getIcon() {
+    return 'admin-appearance';
+  }
+
+  constructor( props ) {
+    super( props );
+    this.state = {
+      theme: null,
+    };
+    this.handleThemeChange = this.handleThemeChange.bind( this );
+  }
+
+  componentDidMount() {
+    const meta = wp.data.select( 'core/editor' ).getEditedPostAttribute( 'meta' );
+    if (meta) {
+      const theme = meta[ 'theme' ];
+      this.loadTheme( theme );
+    }
+  }
+
+  handleThemeChange( value ) {
+    this.loadTheme( value );
+  }
+
+  loadTheme( value ) {
+    if ( value === '' || !value ) {
+      value = 'default';
+    }
+    const baseUrl = window.location.href.split( '/wp-admin' )[ 0 ];
+    const themeJsonUrl = `${ baseUrl }/wp-content/themes/planet4-master-theme/campaign_themes/${ value }.json`;
+    fetch( themeJsonUrl )
+      .then( response => response.json() )
+      .then( json => {
+        this.setState( prevState => {
+          return {
+            theme: json,
+          };
+        } );
+      } );
+  }
+
+  render() {
+    return (
+      <>
+        <PluginSidebarMoreMenuItem
+          target={ CampaignSidebar.getId() }
+          icon={ CampaignSidebar.getIcon()}>
+          Campaign Options
+        </PluginSidebarMoreMenuItem>
+        <PluginSidebar
+          name={ CampaignSidebar.getId() }
+          title={ __( 'Campaign Options', 'planet4-blocks-backend' ) }
+        >
+          <div className="components-panel__body is-opened">
+            <ThemeSelect
+              metaKey='theme'
+              label={ __( 'Campaign template', 'planet4-blocks-backend' ) }
+              onChange={ this.handleThemeChange }
+              options={ themeOptions }
+            />
+          </div>
+          <PanelBody
+            title={ __( "Navigation", 'planet4-blocks-backend' ) }
+            initialOpen={ true }
+          >
+            <Radio
+              metaKey='campaign_nav_type'
+              theme={ this.state.theme }
+            />
+            <ColorPalette
+              metaKey='campaign_nav_color'
+              label={ __( 'Navigation Background Color', 'planet4-blocks-backend' ) }
+              disableCustomColors
+              clearable={ false }
+              theme={ this.state.theme }
+            />
+            <Radio
+              metaKey='campaign_nav_border'
+              label={ __( 'Navigation bottom border', 'planet4-blocks-backend' ) }
+              theme={ this.state.theme }
+            />
+            {
+              <Select
+                metaKey='campaign_logo'
+                label={ __( 'Logo', 'planet4-blocks-backend' ) }
+                theme={ this.state.theme }
+              />
+            }
+            <Radio
+              metaKey='campaign_logo_color'
+              label={ __( 'Logo Color', 'planet4-blocks-backend' ) }
+              help={ __( 'Change the campaign logo color (if not default)', 'planet4-blocks-backend' ) }
+              theme={ this.state.theme }
+            />
+          </PanelBody>
+          {/*<PanelBody*/}
+          {/*  title={ __( "Colors", 'planet4-blocks-backend' ) }*/}
+          {/*  initialOpen={ true }*/}
+          {/*>*/}
+          {/*  <ColorPalette*/}
+          {/*    metaKey='campaign_header_color'*/}
+          {/*    label={ __( 'Header Text Color', 'planet4-blocks-backend' ) }*/}
+          {/*    disableCustomColors*/}
+          {/*    clearable={ false }*/}
+          {/*    theme={ this.state.theme }*/}
+          {/*  />*/}
+          {/*  <ColorPalette*/}
+          {/*    metaKey='campaign_primary_color'*/}
+          {/*    label={ __( 'Primary Button Color', 'planet4-blocks-backend' ) }*/}
+          {/*    disableCustomColors*/}
+          {/*    clearable={ false }*/}
+          {/*    theme={ this.state.theme }*/}
+          {/*  />*/}
+          {/*  <ColorPalette*/}
+          {/*    metaKey='campaign_secondary_color'*/}
+          {/*    label={ __( 'Secondary Button Color and Link Text Color', 'planet4-blocks-backend' ) }*/}
+          {/*    disableCustomColors*/}
+          {/*    theme={ this.state.theme }*/}
+          {/*  />*/}
+          {/*</PanelBody>*/}
+          <PanelBody
+            title={ __( "Fonts", 'planet4-blocks-backend' ) }
+            initialOpen={ true }
+          >
+            <Select
+              metaKey='campaign_header_primary'
+              label={ __( 'Header Primary Font', 'planet4-blocks-backend' ) }
+              theme={ this.state.theme }
+            />
+            <Radio
+              metaKey='campaign_body_font'
+              label={ __( 'Body Font', 'planet4-blocks-backend' ) }
+              theme={ this.state.theme }
+            />
+          </PanelBody>
+          <PanelBody
+            title={ __( "Footer", 'planet4-blocks-backend' ) }
+            initialOpen={ true }
+          >
+            <Radio
+              metaKey='campaign_footer_theme'
+              label={ __( 'Footer Theme', 'planet4-blocks-backend' ) }
+              theme={ this.state.theme }
+            />
+            <ColorPalette
+              metaKey='footer_links_color'
+              label={ __( 'Footer links color', 'planet4-blocks-backend' ) }
+              disableCustomColors
+              clearable={ false }
+              theme={ this.state.theme }
+            />
+          </PanelBody>
+        </PluginSidebar>
+      </>
+    );
+  }
+}

--- a/assets/src/components/fromThemeOptions/fromThemeOptions.js
+++ b/assets/src/components/fromThemeOptions/fromThemeOptions.js
@@ -1,0 +1,29 @@
+import { Component } from '@wordpress/element';
+
+const getFieldFromTheme = ( theme, fieldName ) => {
+  if ( !theme ) {
+    return null;
+  }
+  return theme.fields.find( field => field.id === fieldName );
+};
+
+export function fromThemeOptions( WrappedComponent ) {
+
+  return class extends Component {
+    render() {
+      const { theme, ...ownProps } = this.props;
+
+      if ( !theme ) {
+        return <WrappedComponent { ...ownProps }/>
+      }
+
+      const field = getFieldFromTheme( theme, ownProps.metaKey );
+
+      if ( !field || !field.options ) {
+        return null;
+      }
+
+      return <WrappedComponent defaultValue={ field.default } options={ field.options } { ...ownProps } />;
+    }
+  };
+}

--- a/assets/src/connectCssVariables.js
+++ b/assets/src/connectCssVariables.js
@@ -1,0 +1,94 @@
+const root = document.documentElement;
+
+const readCssVariable = name => root.style.getPropertyValue( name );
+
+const setCssVariable = ( name, value ) => {
+  root.style.setProperty( name, value );
+};
+
+const getMeta = () => {
+  return wp.data.select( 'core/editor' ).getEditedPostAttribute( 'meta' );
+};
+
+const metaToVariableMapping = [
+  {
+    metaKey: 'campaign_body_font',
+    cssVariable: '--body-font',
+    transform( value ) {
+      if ( value !== 'campaign' ) {
+        return value;
+      }
+
+      const campaignFonts = {
+        default: 'lora',
+        antarctic: 'sanctuary',
+        arctic: 'Save the Arctic',
+        climate: 'Jost',
+        forest: 'Kanit',
+        oceans: 'Montserrat',
+        oil: 'Anton',
+        plastic: 'Montserrat',
+      };
+
+      return campaignFonts[ getMeta()[ 'theme' ] || 'default' ];
+    }
+  },
+  {
+    metaKey: 'campaign_header_primary',
+    cssVariable: '--header-primary-font',
+    transform( value ) {
+      if ( value === 'Montserrat_Light' ) {
+        return 'Montserrat';
+      }
+
+      if ( value ) {
+        return value;
+      }
+
+      const campaignDefaults = {
+        default: '"Roboto", sans-serif',
+        antarctic: '"Sanctuary", sans-serif',
+        arctic: '"Save the Arctic", sans-serif',
+        climate: '"Jost", sans-serif',
+        forest: '"Kanit", sans-serif',
+        oceans: '"Montserrat", sans-serif',
+        oil: '"Anton", sans-serif',
+        plastic: '"Montserrat", sans-serif',
+      };
+
+      return campaignDefaults[ getMeta()[ 'theme' ] || 'default' ];
+    }
+  },
+];
+
+export const setUpCssVariables = () => {
+  document.addEventListener( 'DOMContentLoaded', ( event ) => {
+    const postType = wp.data.select( 'core/editor' ).getCurrentPostType();
+
+    if ( postType !== 'campaign' ) {
+      return;
+    }
+
+    metaToVariableMapping.forEach( mapping => {
+      wp.data.subscribe( () => {
+        const postMeta = getMeta();
+
+        // wp.data starts dispatching before meta is available.
+        if ( !postMeta ) {
+          return;
+        }
+
+        const transform = mapping.transform || (value => value);
+
+        const metaValue = transform( postMeta[ mapping.metaKey ] );
+
+        const currentValue = readCssVariable( mapping.cssVariable );
+
+        if ( currentValue !== metaValue ) {
+          setCssVariable( mapping.cssVariable, metaValue );
+          console.log( `Set css variable "${ mapping.cssVariable }" to "${ metaValue }"` );
+        }
+      } );
+    } );
+  } );
+};

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -13,14 +13,14 @@ import { SplittwocolumnsBlock } from './blocks/Splittwocolumns/SplittwocolumnsBl
 import { SubmenuBlock } from './blocks/Submenu/SubmenuBlock';
 import { TakeactionboxoutBlock } from './blocks/Takeactionboxout/TakeactionboxoutBlock';
 import { TimelineBlock } from './blocks/Timeline/TimelineBlock';
-
-//Filters
 import { addBlockFilters } from './BlockFilters';
 import { setupImageBlockExtension } from './ImageBlockExtension';
-import { replaceTaxonomyTermSelectors } from "./replaceTaxonomyTermSelectors"
+import { replaceTaxonomyTermSelectors } from "./replaceTaxonomyTermSelectors";
 import { addSubAndSuperscript } from './RichTextEnhancements';
 import { SpreadsheetBlock } from "./blocks/Spreadsheet/SpreadsheetBlock"
 import { addButtonLinkPasteWarning } from './addButtonLinkPasteWarning';
+import { setupCustomSidebar } from "./setupCustomSidebar";
+import { setUpCssVariables } from './connectCssVariables';
 
 new ArticlesBlock();
 new CarouselHeaderBlock();
@@ -42,5 +42,7 @@ new TimelineBlock();
 addBlockFilters();
 addSubAndSuperscript( window.wp );
 setupImageBlockExtension();
-replaceTaxonomyTermSelectors()
 addButtonLinkPasteWarning();
+replaceTaxonomyTermSelectors();
+setupCustomSidebar();
+setUpCssVariables();

--- a/assets/src/setupCustomSidebar.js
+++ b/assets/src/setupCustomSidebar.js
@@ -1,0 +1,34 @@
+import { registerPlugin } from "@wordpress/plugins";
+import { CampaignSidebar } from './components/Sidebar/CampaignSidebar';
+
+const sidebarForPostType = ( postType ) => {
+  switch ( postType ) {
+    case 'campaign':
+      return CampaignSidebar;
+    default:
+      return null;
+  }
+};
+
+export const setupCustomSidebar = () => {
+  // `wp.data.select( 'core/editor' ).getCurrentPostType()` will return null a few times
+  // before it actually starts working.
+  let currentPostType = null;
+  wp.data.subscribe( () => {
+    const newPostType = wp.data.select( 'core/editor' ).getCurrentPostType();
+
+    if ( newPostType === currentPostType ) {
+      return;
+    }
+    currentPostType = newPostType;
+
+    const sidebarComponent = sidebarForPostType( newPostType );
+
+    if ( sidebarComponent ) {
+      registerPlugin( sidebarComponent.getId(), {
+        icon: sidebarComponent.getIcon(),
+        render: sidebarComponent
+      } );
+    }
+  } );
+};

--- a/assets/src/styles/editorOverrides.scss
+++ b/assets/src/styles/editorOverrides.scss
@@ -1,5 +1,5 @@
 .editor-post-title__block textarea.editor-post-title__input {
-  font-family: $roboto;
+  font-family: var(--header-primary-font, $roboto);
   font-size: $font-size-xl;
   line-height: 1.225;
   margin-bottom: 30px;
@@ -142,4 +142,33 @@
   .wp-picker-input-wrap label {
     display: none !important;
   }
+}
+// By default the selected color is barely visible because of the white circle with check mark covering it.
+.components-color-palette__item.is-active {
+  box-shadow: inset 0 0 0 6px;
+}
+
+.edit-post-sidebar {
+
+  // By default all but the first .component-base-control have margin-bottom, causing weird spacing.
+  .components-base-control {
+    margin-bottom: 0;
+
+    .components-base-control__label {
+      font-weight: bold;
+    }
+  }
+}
+
+.edit-post-visual-editor .editor-block-list__block-edit,
+.edit-post-visual-editor {
+  font-family: var(--body-font, 'Noto Serif');
+
+  h1, h2, h3, h4, h5 {
+    font-family: var(--header-primary-font, $roboto);
+  }
+}
+
+.edit-post-sidebar-header > .components-icon-button.is-toggled {
+  display: none !important;
 }

--- a/assets/src/styles/editorStyle.scss
+++ b/assets/src/styles/editorStyle.scss
@@ -48,5 +48,6 @@
 @import "components/EmptyMessage";
 @import "components/Preview";
 @import "components/CharacterCounter";
+@import "campaigns/base/fonts";
 
 @import "editorOverrides";

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -384,9 +384,9 @@ final class Loader {
 
 			$post = get_post();
 
-			$campaign_theme = $post->custom['_campaign_page_template'];
+			$campaign_theme = $post->theme ?? $post->custom['_campaign_page_template'];
 
-			if ( is_string( $campaign_theme ) ) {
+			if ( is_string( $campaign_theme ) && ! empty( $campaign_theme ) ) {
 
 				$css_theme_creation = filectime( P4GBKS_PLUGIN_DIR . "/assets/build/theme_$campaign_theme.min.css" );
 


### PR DESCRIPTION
This requires the following changes in master-theme: https://github.com/greenpeace/planet4-master-theme/pull/984

* Register a sidebar with campaign settings.
* Add HOC function for creating post-meta controls.
* Use new meta field without underscore for campaign_page_template, as
the underscore prevents API usage. In usages fall back to old field if
the new doesn't exist yet.
* Add ColorPaletteControl that wraps around ColorPalette and functions
similarly to other input controls. This is currently missing in
wordpress, but should it be added there then this can go.