### PR TITLE
PLANET-4441 Fix broken image alignment

### DIFF
--- a/assets/src/styles/blocks/SubmenuEditor.scss
+++ b/assets/src/styles/blocks/SubmenuEditor.scss
@@ -11,3 +11,7 @@
     margin-bottom: 13px;
   }
 }
+
+[data-type="planet4-blocks/submenu"] {
+  clear: both;
+}

--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -39,7 +39,7 @@
   }
 
   figcaption {
-    display: table-caption;
+    display: block;
     caption-side: bottom;
     font-size: 0.8125rem;
     margin: 0;

--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -1,12 +1,6 @@
 .wp-block-image.caption-style-blue-overlay {
-	position: relative;
-  display: table;
-  margin-left: 0;
-  margin-right: 0;
-  overflow: hidden;
 
-  .alignleft,
-  .alignright {
+  figure {
     position: relative;
   }
 
@@ -82,16 +76,5 @@ figcaption {
 
   .caption-alignment-right & {
     text-align: right;
-  }
-}
-
-.wp-block-image.caption-style-medium {
-  display: table;
-  margin-left: 0;
-  margin-right: 0;
-
-  figcaption {
-    display: table-caption;
-    caption-side: bottom;
   }
 }


### PR DESCRIPTION
Some of the customizations for the image captions broke image
alignment options.
* Remove the table display on figure, this should be on the outer
element.
* Use `position: relative` on figure so that figcaption has right width.
* Clear the submenu block in the editor.