### PR TITLE
PLANET-4602: Spacer element in blogs doesn't work correctly

### DIFF
--- a/assets/src/styles/blocks/core-overrides/Spacer.scss
+++ b/assets/src/styles/blocks/core-overrides/Spacer.scss
@@ -1,0 +1,5 @@
+.wp-block-spacer {
+	// Wordpress 5.3.2 introduced a 'clear: both' style
+	// for this element, which broke the take action boxout (see: https://jira.greenpeace.org/browse/PLANET-4602)
+	clear: none;
+}

--- a/assets/src/styles/style.scss
+++ b/assets/src/styles/style.scss
@@ -28,3 +28,4 @@
 
 // Native Blocks
 @import "blocks/core-overrides/Image";
+@import "blocks/core-overrides/Spacer";


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4602

This is a patch to fix the above issue, I'll create a follow-up ticket to restore the `clear: both` rule added by WP 5.3.2 (I guess it makes sense on a spacer...), so we can remove this override, and maybe find a different way of positioning the boxout. 