### PR TITLE
PLANET-4650: JS Error on Gallery - Slider renders block unusable

### DIFF
--- a/assets/src/blocks/Gallery/GalleryBlock.js
+++ b/assets/src/blocks/Gallery/GalleryBlock.js
@@ -117,7 +117,7 @@ export class GalleryBlock {
             for (const img_id in image_urls_array) {
 
               let x,y;
-              if ($.isEmptyObject(focal_points_json)) {
+              if ($.isEmptyObject(focal_points_json) || !focal_points_json[img_id]) {
                 [x,y] = [50,50];
               } else {
                 [x,y] = focal_points_json[img_id].replace(/\%/g, '').split(' ');


### PR DESCRIPTION
This was happening because of a focal point missing in one of the images (the focal points array and the image ids array didn't match), which I couldn't reproduce by clicking, only using the code editor. It looks like it's an edge case, but I guess it makes sense to prepare for it.

Ref: https://jira.greenpeace.org/browse/PLANET-4650