### PR TITLE
PLANET-4441: Image caption alignment fixes

### DIFF
--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -1,4 +1,5 @@
 .wp-block-image.caption-style-blue-overlay {
+  position: relative;
 
   figure {
     position: relative;


### PR DESCRIPTION
This fixes an inconsistency we found, `figure` may have a wrapper `div` or not.

Ref: https://jira.greenpeace.org/browse/PLANET-4441