### PR TITLE
PLANET-4658 trim heading text so it matches menu item

### DIFF
--- a/public/js/submenu.js
+++ b/public/js/submenu.js
@@ -23,7 +23,8 @@ $(document).ready(function () {
 
       for (let j = 0; j < $headings.length; j++) {
         let $heading = $($headings[j]);
-        if ($heading.text().replace(/\u2010|\u2011|\u2013/, '') === menu.text.replace('-', '')) {
+        const headingText = $heading.text().replace(/\u2010|\u2011|\u2013/, '').trim();
+        if (headingText === menu.text.replace('-', '')) {
           $heading.prepend('<a id="' + menu.id + '" data-hash-target="' + menu.hash + '"></a>');
         }
       }


### PR DESCRIPTION
When an external icon was on the link then the text of the heading would
have whitespace at the end, so trimming is needed to make the script
match it up with the submenu link text.

ref: https://jira.greenpeace.org/browse/PLANET-4658