### PR TITLE
PLANET-4439 Populate Articles override suggestions with all posts

### DIFF
--- a/assets/src/blocks/Articles/ArticlesBlock.js
+++ b/assets/src/blocks/Articles/ArticlesBlock.js
@@ -169,7 +169,7 @@ export class ArticlesBlock {
         }
 
         // TO-DO: Check for posts types and posts too...
-        if ((tagsList && tagsList.length === 0) || (postTypesList && postTypesList.length === 0)) {
+        if ((tagsList && tagsList.length === 0) && (postTypesList && postTypesList.length === 0)) {
           return "Populating block's fields...";
         }
 

--- a/classes/rest/class-rest-api.php
+++ b/classes/rest/class-rest-api.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @package P4GBKS\Rest
+ */
+
+namespace P4GBKS\Rest;
+
+use WP_REST_Server;
+
+/**
+ * This class is just a place for add_endpoints to live.
+ */
+class Rest_Api {
+	private const REST_NAMESPACE = 'planet4/v1';
+
+	/**
+	 * Add custom endpoints.
+	 */
+	public static function add_endpoints(): void {
+		add_action(
+			'rest_api_init',
+			static function () {
+				/**
+				 * A lightweight endpoint to get all posts with only id and title.
+				 */
+				register_rest_route(
+					self::REST_NAMESPACE,
+					'/all-published-posts',
+					[
+						[
+							'methods'  => WP_REST_Server::READABLE,
+							'callback' => static function () {
+								global $wpdb;
+
+								if ( is_plugin_active( 'sitepress-multilingual-cms/sitepress.php' ) ) {
+									// This is public data, no nonce needed.
+									// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+									if ( ! isset( $_GET['post_language'] ) ) {
+										return new \WP_REST_Response(
+											'WPML is active so you need to query posts with the `post_language` query parameter.',
+											400
+										);
+									}
+									// This is public data, no nonce needed.
+									// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+									$query = self::get_wpml_posts_query( $_GET['post_language'] );
+								} else {
+									$query = "SELECT id, post_title FROM wp_posts WHERE post_status = 'publish' AND post_type = 'post'";
+								}
+								// The query is prepared, just not in this line.
+								// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+								$result = $wpdb->get_results( $query );
+
+								return rest_ensure_response( $result );
+							},
+						],
+					]
+				);
+			}
+		);
+	}
+
+	/**
+	 * Create a query for all posts with a certain language code.
+	 *
+	 * @param string $language_code Return posts with this language code.
+	 * @return string The prepared query.
+	 */
+	private static function get_wpml_posts_query( string $language_code ): string {
+		global $wpdb;
+
+		return $wpdb->prepare(
+			"SELECT p.id,p.post_title
+				FROM wp_posts p
+         		JOIN wp_icl_translations t
+              		ON p.ID = t.element_id AND t.element_type = 'post_post'
+				WHERE p.post_type = 'post'
+  					AND p.post_status = 'publish'
+  					AND t.language_code = %s
+				ORDER BY p.post_date DESC; ",
+			$language_code
+		);
+	}
+}

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -269,3 +269,4 @@ P4GBKS\Loader::get_instance(
 	],
 	\P4GBKS\Views\View::class
 );
+\P4GBKS\Rest\Rest_Api::add_endpoints();


### PR DESCRIPTION
* Add an endpoint that just returns all published posts and their ids.
If wpml is active this endpoint requires the language of the posts.
* Use that endpoint instead of the `/wp/v2/posts`, which was a huge
overkill in response time and payload size for this use case.
* Fetch the suggestions once when the override field is focused for the
first time, instead of on every input. There is absolutely no need to
perform an API request as this behavior is already handled by the
FormToken component if you provide it with all the options.