### PR TITLE
PLANET-4710 Use flexbox to align column CTAs

### DIFF
--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -59,16 +59,13 @@
     }
 
     .column-wrap {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
       margin-top: $space-xl;
 
       @include large-and-up {
         margin-top: 0;
-      }
-
-      &.has-cta {
-        @include medium-and-up {
-          padding-bottom: $space-xl; // Leave enough room for the CTA button
-        }
       }
 
       h3 {
@@ -90,9 +87,9 @@
       }
 
       p {
+        flex-grow: 1;
         font-size: $font-size-sm;
         line-height: 1.6;
-        margin-bottom: $space-lg;
         color: $dark-shade-black;
 
         @include medium-and-up {
@@ -100,7 +97,6 @@
         }
 
         @include large-and-up {
-          margin-bottom: $space-xxl;
           font-size: $font-size-xxs;
           width: 82%;
         }
@@ -109,20 +105,11 @@
           font-size: $font-size-xs;
           width: 76%;
         }
-
-        &:last-child {
-          margin-bottom: 0;
-        }
       }
 
       .btn {
         position: relative;
         margin-bottom: 0;
-
-        @include medium-and-up {
-          position: absolute;
-          bottom: 0;
-        }
       }
     }
   }
@@ -138,16 +125,13 @@
     }
 
     .column-wrap {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
       margin-bottom: $space-xl;
 
       @include large-and-up {
         margin-bottom: 0;
-      }
-
-      &.has-cta {
-        @include large-and-up {
-          padding-bottom: $space-md; // Leave enough room for the CTA link
-        }
       }
 
       h3,
@@ -182,6 +166,7 @@
       }
 
       p {
+        flex-grow: 1;
         font-size: $font-size-sm;
         line-height: 1.6;
         color: $dark-shade-black;
@@ -550,12 +535,6 @@
         margin-bottom: 0;
       }
 
-      &.has-cta {
-        @include large-and-up {
-          padding-bottom: $space-md; // Leave enough room for the CTA link
-        }
-      }
-
       h3,
       .icon-container {
         text-align: center;
@@ -632,11 +611,6 @@
 
         &.call-to-action-link {
           position: relative;
-
-          @include medium-and-up {
-            position: absolute;
-            bottom: 0;
-          }
         }
       }
 
@@ -708,12 +682,6 @@
         img {
           @include x-large-and-up {
             margin-bottom: 0;
-          }
-        }
-
-        &.has-cta {
-          @include large-and-up {
-            padding-bottom: 0; // Leave enough room for the CTA link
           }
         }
       }

--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -541,6 +541,9 @@
 
   &.block-style-image {
     .column-wrap {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
       margin-bottom: $space-lg;
 
       @include large-and-up {
@@ -585,6 +588,7 @@
       }
 
       p {
+        flex-grow: 1;
         font-size: $font-size-sm;
         line-height: 1.6;
         color: $dark-shade-black;

--- a/templates/blocks/columns.twig
+++ b/templates/blocks/columns.twig
@@ -18,7 +18,7 @@
 
 					<div class="row">
 						{% for col in fields.columns %}
-							<div class="col-md-6 col-lg column-wrap {% if col.cta_text and col.cta_link %}has-cta{% endif %}">
+							<div class="col-md-6 col-lg column-wrap">
 								{% if col.attachment and fields.columns_block_style != 'no_image' %}
 									<div class="attachment-container">
 										{% if col.cta_link %}


### PR DESCRIPTION
Flex display and justify-content:space-between on the column wrapper,
combined with flex-grow: 1 on only the p tag results in only the p tag
growing to provide the additional spacing and the buttons lining up
neatly at the bottom of the wrapper.

This might need some additional css changes elsewhere, though until now I haven't seen anything breaking because of it.