### PR TITLE
PLANET-4698 Add spreadsheet to BETA section in pages and posts

### DIFF
--- a/assets/src/blocks/Spreadsheet/SpreadsheetBlock.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetBlock.js
@@ -8,7 +8,7 @@ export class SpreadsheetBlock {
     registerBlockType( 'planet4-blocks/spreadsheet', {
       title: __( 'Spreadsheet', 'planet4-blocks-backend' ),
       icon: 'editor-table',
-      category: 'planet4-blocks',
+      category: 'planet4-blocks-beta',
       attributes: {
         url: {
           type: 'string',

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -446,6 +446,11 @@ final class Loader {
 			'title' => __( 'Planet 4 Blocks', 'planet4-blocks' ),
 		];
 
+		$categories[1] = [
+			'slug'  => 'planet4-blocks-beta',
+			'title' => __( 'Planet 4 Blocks - BETA', 'planet4-blocks' ),
+		];
+
 		return array_merge(
 			$common,
 			$categories

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -99,6 +99,7 @@ const POST_BLOCK_TYPES = [
 	'planet4-blocks/counter',
 	'planet4-blocks/gallery',
 	'planet4-blocks/take-action-boxout',
+	'planet4-blocks/spreadsheet',
 	'planet4-blocks/timeline',
 ];
 
@@ -115,6 +116,7 @@ const PAGE_BLOCK_TYPES = [
 	'planet4-blocks/media-video',
 	'planet4-blocks/social-media',
 	'planet4-blocks/split-two-columns',
+	'planet4-blocks/spreadsheet',
 	'planet4-blocks/submenu',
 	'planet4-blocks/take-action-boxout',
 	'planet4-blocks/timeline',


### PR DESCRIPTION
Adding block to BETA section required changing the category in the '*Block.js' file. So if we want to move it back to the non-beta section we have to change it there.

Ref: https://jira.greenpeace.org/browse/PLANET-4698

and also: https://jira.greenpeace.org/browse/PLANET-4699