### PR TITLE
[No issue]: Fix image_data datatype in Gallery blocks

### DIFF
--- a/assets/src/blocks/Gallery/GalleryBlock.js
+++ b/assets/src/blocks/Gallery/GalleryBlock.js
@@ -75,8 +75,14 @@ export class GalleryBlock {
             type: 'string',
           },
           image_data: {
-            type: 'object',
-            default: []
+            type: 'array',
+            default: [
+              {
+                id: null,
+                url: null,
+                focalPoint: {},
+              }
+            ]
           },
         },
         edit: withSelect( ( select, props ) => {

--- a/classes/blocks/class-gallery.php
+++ b/classes/blocks/class-gallery.php
@@ -87,6 +87,24 @@ class Gallery extends Base_Block {
 					'gallery_block_focus_points' => [
 						'type' => 'string',
 					],
+					'image_data'                 => [
+						'type'    => 'array',
+						'default' => [],
+						'items'   => [
+							'type'       => 'object',
+							'properties' => [
+								'id'         => [
+									'type' => 'integer',
+								],
+								'url'        => [
+									'type' => 'string',
+								],
+								'focalPoint' => [
+									'type' => 'object',
+								],
+							],
+						],
+					],
 				],
 			]
 		);


### PR DESCRIPTION
There was a bug when editing a page via the Code Editor, reported by Poland and Netherlands on Skype, causing the Carousel Gallery to show only one image, the rest is blank (see: https://www.greenpeace.org/poland/aktualnosci/27595/prezydencie-trzaskowski-pila-nie-ochronisz-klimatu/).

Steps to reproduce:

- Create a new page
- Add a Gallery Block with 3 images
- Switch to the Code Editor
- Hit "Publish" or "Update" to save the page without leaving the Code Editor
- Refresh
---> You'll see the "image_data" attributes are lost

Please test! I think this solves the issue.