### PR TITLE
PLANET-4753: [Philippines] Featured image not showing in Latest Updates

### DIFF
--- a/assets/src/styles/blocks/Articles.scss
+++ b/assets/src/styles/blocks/Articles.scss
@@ -155,10 +155,6 @@
     width: auto;
   }
 
-  img[data-src] {
-    opacity: 0;
-  }
-
   @include small-and-up {
     img {
       max-height: 340px;


### PR DESCRIPTION
The opacity declaration removed was vestigial from an old lazy loading feature in the Articles block.

Ref: https://jira.greenpeace.org/browse/PLANET-4753