### PR TITLE
Hotfix: Apply color only on primary button, not secondary

### DIFF
--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -4,8 +4,11 @@
     font-weight: inherit;
     color: $dark-blue;
 
-    &.btn-primary, &.btn-secondary {
+    &.btn-primary {
       color: $white;
+    }
+
+    &.btn-primary, &.btn-secondary {
       text-decoration: none !important;
     }
   }


### PR DESCRIPTION
Fix for an issue in GPI:

![image](https://user-images.githubusercontent.com/340766/75353888-df1a5f00-588a-11ea-9349-7d77ad5f955c.png)

I can't actually test it because the Gutenberg editor just crashed environment, it's timing out. 