### PR TITLE
PLANET-3427 Save any changes to post meta to the autosave.

### DIFF
--- a/assets/src/components/PostMeta/withPostMeta.js
+++ b/assets/src/components/PostMeta/withPostMeta.js
@@ -12,6 +12,8 @@ const getValuePropName = ( Component ) => {
   return 'value';
 };
 
+const { apiFetch } = wp;
+
 export function withPostMeta( WrappedComponent ) {
 
   class WrappingComponent extends Component {
@@ -22,7 +24,22 @@ export function withPostMeta( WrappedComponent ) {
     }
 
     handleChange( metaKey, value ) {
+      const { getEditedPostAttribute, getCurrentPostId } = wp.data.select( 'core/editor' );
       this.props.writeMeta( metaKey, value );
+
+      if ( !['draft', 'auto-draft'].includes( getEditedPostAttribute( 'status' ) ) ) {
+        apiFetch( {
+          path: `/planet4/v1/save-preview-meta`,
+          method: 'POST',
+          data: {
+            post_id: getCurrentPostId(),
+            meta: {
+              ...this.props.postMeta,
+              [metaKey]: value,
+            }
+          },
+        } );
+      }
     }
 
     render() {

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -22,6 +22,7 @@ import { addButtonLinkPasteWarning } from './addButtonLinkPasteWarning';
 import { setupCustomSidebar } from "./setupCustomSidebar";
 import { setUpCssVariables } from './connectCssVariables';
 import { SubPagesBlock } from './blocks/SubPages/SubPagesBlock';
+import { saveMetaToPreview } from './saveMetaToPreview';
 
 new ArticlesBlock();
 new CarouselHeaderBlock();
@@ -48,3 +49,4 @@ addButtonLinkPasteWarning();
 replaceTaxonomyTermSelectors();
 setupCustomSidebar();
 setUpCssVariables();
+saveMetaToPreview();

--- a/assets/src/saveMetaToPreview.js
+++ b/assets/src/saveMetaToPreview.js
@@ -1,0 +1,19 @@
+// Save the current state of the post meta fields to the user's preview, so that any old values are invalidated.
+export const saveMetaToPreview = () => {
+  document.addEventListener('DOMContentLoaded', (event) => {
+    const { apiFetch } = wp;
+    const { getEditedPostAttribute, getCurrentPostId } = wp.data.select( 'core/editor' );
+
+    if ( !['draft', 'auto-draft'].includes( getEditedPostAttribute( 'status' ) ) ) {
+      apiFetch( {
+        path: `/planet4/v1/save-preview-meta`,
+        method: 'POST',
+        data: {
+          post_id: getCurrentPostId(),
+          meta: getEditedPostAttribute('meta')
+        },
+      } );
+    }
+
+  })
+};

--- a/assets/src/setupCustomSidebar.js
+++ b/assets/src/setupCustomSidebar.js
@@ -11,24 +11,25 @@ const sidebarForPostType = ( postType ) => {
 };
 
 export const setupCustomSidebar = () => {
-  // `wp.data.select( 'core/editor' ).getCurrentPostType()` will return null a few times
-  // before it actually starts working.
   let currentPostType = null;
-  wp.data.subscribe( () => {
-    const newPostType = wp.data.select( 'core/editor' ).getCurrentPostType();
+  // Only subscribing after DOMContentLoaded avoids the troubles originating from wp.data emitting null values before that point.
+  document.addEventListener( 'DOMContentLoaded', event => {
+    wp.data.subscribe( () => {
+      const newPostType = wp.data.select( 'core/editor' ).getCurrentPostType();
 
-    if ( newPostType === currentPostType ) {
-      return;
-    }
-    currentPostType = newPostType;
+      if ( newPostType === currentPostType ) {
+        return;
+      }
+      currentPostType = newPostType;
 
-    const sidebarComponent = sidebarForPostType( newPostType );
+      const sidebarComponent = sidebarForPostType( newPostType );
 
-    if ( sidebarComponent ) {
-      registerPlugin( sidebarComponent.getId(), {
-        icon: sidebarComponent.getIcon(),
-        render: sidebarComponent
-      } );
-    }
+      if ( sidebarComponent ) {
+        registerPlugin( sidebarComponent.getId(), {
+          icon: sidebarComponent.getIcon(),
+          render: sidebarComponent
+        } );
+      }
+    } );
   } );
 };

--- a/classes/rest/class-rest-api.php
+++ b/classes/rest/class-rest-api.php
@@ -5,6 +5,7 @@
 
 namespace P4GBKS\Rest;
 
+use WP_REST_Request;
 use WP_REST_Server;
 
 /**
@@ -17,46 +18,100 @@ class Rest_Api {
 	 * Add custom endpoints.
 	 */
 	public static function add_endpoints(): void {
-		add_action(
-			'rest_api_init',
-			static function () {
-				/**
-				 * A lightweight endpoint to get all posts with only id and title.
-				 */
-				register_rest_route(
-					self::REST_NAMESPACE,
-					'/all-published-posts',
-					[
-						[
-							'methods'  => WP_REST_Server::READABLE,
-							'callback' => static function () {
-								global $wpdb;
+		add_action( 'rest_api_init', [ __CLASS__, 'endpoints' ] );
 
-								if ( is_plugin_active( 'sitepress-multilingual-cms/sitepress.php' ) ) {
-									// This is public data, no nonce needed.
-									// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-									if ( ! isset( $_GET['post_language'] ) ) {
-										return new \WP_REST_Response(
-											'WPML is active so you need to query posts with the `post_language` query parameter.',
-											400
-										);
-									}
-									// This is public data, no nonce needed.
-									// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-									$query = self::get_wpml_posts_query( $_GET['post_language'] );
-								} else {
-									$query = "SELECT id, post_title FROM wp_posts WHERE post_status = 'publish' AND post_type = 'post' ORDER BY post_date DESC";
-								}
-								// The query is prepared, just not in this line.
-								// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-								$result = $wpdb->get_results( $query );
+	}
 
-								return rest_ensure_response( $result );
-							},
-						],
-					]
-				);
-			}
+	/**
+	 * Register custom rest API endpoints.
+	 */
+	public static function endpoints(): void {
+		/**
+		 * A lightweight endpoint to get all posts with only id and title.
+		 */
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/all-published-posts',
+			[
+				[
+					'methods'  => WP_REST_Server::READABLE,
+					'callback' => static function () {
+						global $wpdb;
+
+						if ( is_plugin_active( 'sitepress-multilingual-cms/sitepress.php' ) ) {
+							// This is public data, no nonce needed.
+							// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+							if ( ! isset( $_GET['post_language'] ) ) {
+								return new \WP_REST_Response(
+									'WPML is active so you need to query posts with the `post_language` query parameter.',
+									400
+								);
+							}
+							// This is public data, no nonce needed.
+							// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+							$query = self::get_wpml_posts_query( $_GET['post_language'] );
+						} else {
+							$query = "SELECT id, post_title FROM wp_posts WHERE post_status = 'publish' AND post_type = 'post' ORDER BY post_date DESC";
+						}
+						// The query is prepared, just not in this line.
+						// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+						$result = $wpdb->get_results( $query );
+
+						return rest_ensure_response( $result );
+					},
+				],
+			]
+		);
+		/**
+		 * Save meta to the preview of the current user.
+		 */
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/save-preview-meta',
+			[
+				[
+					'methods'  => WP_REST_Server::CREATABLE,
+					'callback' => static function ( $request ) {
+						/**
+						 * @var WP_REST_Request $request
+						 */
+						$post_id = $request['post_id'];
+
+						$post = get_post( $post_id );
+
+						if ( ! $post ) {
+							return new \WP_REST_Response(
+								'No such post exists.',
+								400
+							);
+						}
+
+						if ( ! current_user_can( 'edit_post', $post_id ) ) {
+							return new \WP_REST_Response(
+								'You do not have permission to edit this post.',
+								403
+							);
+
+						}
+
+						$old_autosave = wp_get_post_autosave( $post_id, get_current_user_id() );
+
+						if ( ! $old_autosave ) {
+							// No existing autosave, so let's create one. Should only happen once for each user.
+							// @see \P4_Loader::do_not_delete_autosave The filter that ensures that.
+							$revision_id = _wp_put_post_revision( $post, true );
+						} else {
+							$revision_id = $old_autosave->ID;
+						}
+
+						foreach ( $request['meta'] as $key => $value ) {
+							update_metadata( 'post', $revision_id, $key, $value );
+						}
+
+						return rest_ensure_response( 'Saved all meta to the autosave revision.' );
+					},
+				],
+			]
 		);
 	}
 


### PR DESCRIPTION
* Add custom endpoint that saves meta for the autosave revision of the current
post and user.
* On change of a withPostMeta component send a request to that endpoint.