### PR TITLE
PLANET-4750: Campaigns customiser - Adjust Header primary font options

### DIFF
--- a/assets/src/components/Sidebar/CampaignSidebar.js
+++ b/assets/src/components/Sidebar/CampaignSidebar.js
@@ -4,6 +4,7 @@ import { PanelBody, RadioControl, SelectControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import ColorPaletteControl from '../ColorPaletteControl/ColorPaletteControl';
 import { withPostMeta } from '../PostMeta/withPostMeta';
+import { withDefaultLabel } from '../withDefaultLabel/withDefaultLabel';
 import { __ } from '@wordpress/i18n';
 import { fromThemeOptions } from '../fromThemeOptions/fromThemeOptions';
 import isShallowEqual from '@wordpress/is-shallow-equal';
@@ -45,6 +46,12 @@ const themeOptions = [
 ];
 
 const ThemeSelect = withPostMeta( SelectControl );
+
+const SelectWithDefaultLabel = compose(
+  fromThemeOptions,
+  withPostMeta,
+  withDefaultLabel,
+)( SelectControl );
 
 const Select = compose(
   fromThemeOptions,
@@ -224,7 +231,7 @@ export class CampaignSidebar extends Component {
                 title={ __( "Fonts", 'planet4-blocks-backend' ) }
                 initialOpen={ true }
               >
-                <Select
+                <SelectWithDefaultLabel
                   metaKey='campaign_header_primary'
                   label={ __( 'Header Primary Font', 'planet4-blocks-backend' ) }
                   theme={ this.state.theme }

--- a/assets/src/components/withDefaultLabel/withDefaultLabel.js
+++ b/assets/src/components/withDefaultLabel/withDefaultLabel.js
@@ -1,0 +1,32 @@
+import { Component } from '@wordpress/element';
+
+export function withDefaultLabel( WrappedComponent ) {
+  const {__} = wp.i18n;
+
+  class LabeledComponent extends Component {
+    constructor( props ) {
+      super( props );
+
+      this.defaultLabel = __('(default)');
+    }
+
+    render() {
+      const { options, ...ownProps } = this.props;
+
+      const enhancedOptions = options.map( option => {
+        const label = option.value === this.props.defaultValue ? option.label + ' ' + this.defaultLabel : option.label
+        return {
+            ...option,
+           label: label,
+        }
+      });
+
+      return <WrappedComponent
+        options={ enhancedOptions }
+        { ...ownProps }
+      />;
+    }
+  }
+
+  return LabeledComponent;
+}


### PR DESCRIPTION
UAT Passed.

This adds another element to the `compose` chain for `Select`'s to add a "(default)" label to the default option.

Ref: https://jira.greenpeace.org/browse/PLANET-4750

Master Theme part: https://github.com/greenpeace/planet4-master-theme/pull/1030