### PR TITLE
[No issue]: Fix radio label alignment

### DIFF
--- a/assets/src/styles/editorOverrides.scss
+++ b/assets/src/styles/editorOverrides.scss
@@ -58,10 +58,18 @@
   }
 }
 
-
-
 .components-panel__body label {
   font-size: 13px;
+}
+
+.components-radio-control__option {
+  input.components-radio-control__input {
+    margin-right: 5px;
+  }
+
+  label {
+    margin-bottom: 0;
+  }
 }
 
 .wp-block-button .wp-block-button__link[role="textbox"] {


### PR DESCRIPTION
Our radio labels in the sidebar are being affected by some generic styles (e.g.: Bootstrap's reboot, and some styles from WP that look a bit unbalanced). So I added an override to fix their alignment.

Before:
<img width="300" alt="Captura de pantalla 2020-03-04 a la(s) 10 15 48" src="https://user-images.githubusercontent.com/340766/75883313-98d07d00-5e01-11ea-8a63-877b58313378.png">

After:
<img width="292" alt="Captura de pantalla 2020-03-04 a la(s) 10 36 12" src="https://user-images.githubusercontent.com/340766/75884649-fe256d80-5e03-11ea-918f-b59a5988db60.png">
