### PR TITLE
PLANET-4680 Apply Image block typographic rules to all caption styles

### DIFF
--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -1,28 +1,7 @@
-.wp-block-image.caption-style-blue-overlay {
+.wp-block-image {
   position: relative;
-
-  figure {
-    position: relative;
-  }
-
   width: auto;
   max-width: 100%;
-
-  .alignnone {
-    margin-bottom: $space-xl;
-    margin-top: $space-md;
-
-    @include large-and-up {
-      margin-bottom: $space-xxl;
-      margin-top: $space-lg;
-    }
-  }
-
-  img {
-    width: 100%;
-    max-width: 100%;
-    height: auto;
-  }
 
   @include medium-and-up {
     .image-credit {
@@ -35,34 +14,65 @@
     }
   }
 
-  .image-desc {
-    display: block;
+  figure {
+    position: relative;
+  }
+
+  img {
+    width: 100%;
+    max-width: 100%;
+    height: auto;
   }
 
   figcaption {
-    display: block;
-    caption-side: bottom;
-    font-size: 0.8125rem;
-    margin: 0;
-    line-height: 1.4;
-    color: $white;
+    font-size: $font-size-xxs;
     font-family: $roboto;
-    width: 100%;
-    max-width: 100%;
-    background: linear-gradient(210deg, transparentize($med-blue, .8) 0%, $med-blue 100%);
-    padding: $n10 $n20;
+    line-height: 1.4;
+  }
 
-    @include medium-and-up {
-      display: table-caption;
-      position: absolute;
-      left: 0;
-      bottom: 0;
-      padding: $n20 $n30;
-      height: auto;
+  &.caption-style-blue-overlay {
+    .alignnone {
+      margin-bottom: $space-xl;
+      margin-top: $space-md;
+
+      @include large-and-up {
+        margin-bottom: $space-xxl;
+        margin-top: $space-lg;
+      }
     }
 
-    @include large-and-up {
-      padding: $n20 $n30;
+    .image-desc {
+      display: block;
+    }
+
+    figcaption {
+      display: block;
+      caption-side: bottom;
+      color: $white;
+      width: 100%;
+      margin: 0;
+      max-width: 100%;
+      background: linear-gradient(210deg, transparentize($med-blue, .8) 0%, $med-blue 100%);
+      padding: $n10 $n20;
+
+      @include medium-and-up {
+        display: table-caption;
+        position: absolute;
+        left: 0;
+        bottom: 0;
+        padding: $n20 $n30;
+        height: auto;
+      }
+
+      @include large-and-up {
+        padding: $n20 $n30;
+      }
+    }
+  }
+
+  &.caption-style-medium {
+    figcaption {
+      color: $grey-60;
     }
   }
 }


### PR DESCRIPTION
We already have some typographic rules in place for the blue overlay caption style. This fix the same rules to the medium styles that comes with WP.

Ref: https://jira.greenpeace.org/browse/PLANET-4680