### PR TITLE
PLANET-4838 Hide confusing WPML global settings on post edit page.

### DIFF
--- a/assets/src/styles/editorOverrides.scss
+++ b/assets/src/styles/editorOverrides.scss
@@ -180,3 +180,7 @@
 .edit-post-sidebar-header > .components-icon-button.is-toggled {
   display: none !important;
 }
+
+#icl_div_config {
+  display: none !important;
+}


### PR DESCRIPTION
There is already a place for this config in the settings and there is
little value in having it at the bottom of each post edit page.
Furthermore these settings don't get saved by saving the post, instead
they have their own button which is small and not very noticeable in the
bottom right corner.