### PR TITLE
PLANET-4325: Apply P4 Standard vertical spacing to all native Gutenberg blocks across content types

### DIFF
--- a/assets/src/styles/blocks/core-overrides/BlockSpacing.scss
+++ b/assets/src/styles/blocks/core-overrides/BlockSpacing.scss
@@ -1,0 +1,16 @@
+.wp-block-image,
+.wp-block-quote,
+.wp-block-file,
+.wp-block-table,
+.wp-block-button,
+.page-template > p,
+.page-template > h2,
+.page-template > ul {
+  margin-top: $space-md;
+  margin-bottom: $space-xl;
+
+  @include large-and-up {
+    margin-top: $space-lg;
+    margin-bottom: $space-xxl;
+  }
+}

--- a/assets/src/styles/editorStyle.scss
+++ b/assets/src/styles/editorStyle.scss
@@ -37,6 +37,7 @@
 @import "blocks/Timeline";
 
 @import "blocks/core-overrides/Image";
+@import "blocks/core-overrides/BlockSpacing";
 
 @import "blocks/ArticlesEditor";
 @import "blocks/CarouselHeaderEditor";

--- a/assets/src/styles/style.scss
+++ b/assets/src/styles/style.scss
@@ -30,6 +30,7 @@
 // Native Blocks
 @import "blocks/core-overrides/Image";
 @import "blocks/core-overrides/Spacer";
+@import "blocks/core-overrides/BlockSpacing";
 
 // Other
 @import "blocks/WideBlocks";


### PR DESCRIPTION
UAT Passed.

Ref: https://jira.greenpeace.org/browse/PLANET-4325