### PR TITLE
PLANET-4325: Apply P4 Standard vertical spacing to all native Gutenberg blocks across content types

### DIFF
--- a/assets/src/styles/blocks/core-overrides/BlockSpacing.scss
+++ b/assets/src/styles/blocks/core-overrides/BlockSpacing.scss
@@ -3,7 +3,6 @@
 .wp-block-file,
 .wp-block-table,
 .wp-block-button,
-.page-template > p,
 .page-template > h2,
 .page-template > ul {
   margin-top: $space-md;
@@ -13,4 +12,9 @@
     margin-top: $space-lg;
     margin-bottom: $space-xxl;
   }
+}
+
+.page-template > p {
+  margin-top: $space-md;
+  margin-bottom: $space-lg;
 }


### PR DESCRIPTION
Making a minor adjustment to `<p>` tags (Paragraph blocks) as discussed with Will. It's the same for all screen sizes.

Ref: https://jira.greenpeace.org/browse/PLANET-4325