### PR TITLE
PLANET-4919: Ensure automatically selected options are correctly shown in the Preview when switching themes

### DIFF
--- a/assets/src/components/ColorPaletteControl/ColorPaletteControl.js
+++ b/assets/src/components/ColorPaletteControl/ColorPaletteControl.js
@@ -7,7 +7,7 @@ import { ColorPalette } from '@wordpress/components';
 function ColorPaletteControl( { label, className, value, help, instanceId, onChange, options = [], ...passThroughProps } ) {
   const id = `inspector-color-palette-control-${ instanceId }`;
 
-  const optionsAsColors = options.map( option => ( { color: option.value } ) );
+  const optionsAsColors = options.map( ( { value, ...props } ) => ( { color: value, ...props } ) );
 
   return !isEmpty( options ) && (
     <BaseControl label={ label } id={ id } help={ help }

--- a/assets/src/components/ColorPaletteControl/ColorPaletteControl.js
+++ b/assets/src/components/ColorPaletteControl/ColorPaletteControl.js
@@ -7,7 +7,7 @@ import { ColorPalette } from '@wordpress/components';
 function ColorPaletteControl( { label, className, value, help, instanceId, onChange, options = [], ...passThroughProps } ) {
   const id = `inspector-color-palette-control-${ instanceId }`;
 
-  const optionsAsColors = options.map( option => ( { color: option.value, name: option.label } ) );
+  const optionsAsColors = options.map( option => ( { color: option.value } ) );
 
   return !isEmpty( options ) && (
     <BaseControl label={ label } id={ id } help={ help }

--- a/assets/src/components/ColorPaletteControl/ColorPaletteControl.js
+++ b/assets/src/components/ColorPaletteControl/ColorPaletteControl.js
@@ -7,13 +7,15 @@ import { ColorPalette } from '@wordpress/components';
 function ColorPaletteControl( { label, className, value, help, instanceId, onChange, options = [], ...passThroughProps } ) {
   const id = `inspector-color-palette-control-${ instanceId }`;
 
+  const optionsAsColors = options.map( option => ( { color: option.value, name: option.label } ) );
+
   return !isEmpty( options ) && (
     <BaseControl label={ label } id={ id } help={ help }
                  className={ classnames( className, 'components-color-palette-control' ) }>
       <ColorPalette
         value={ value }
         onChange={ onChange }
-        colors={ options }
+        colors={ optionsAsColors }
         { ...passThroughProps }
       />
     </BaseControl>

--- a/assets/src/components/PostMeta/withPostMeta.js
+++ b/assets/src/components/PostMeta/withPostMeta.js
@@ -57,6 +57,7 @@ export function withPostMeta( WrappedComponent ) {
         )
       ) {
         value = this.props.defaultValue;
+        this.handleChange( metaKey, value );
       } else {
         value = metaValue;
       }

--- a/assets/src/components/PostMeta/withPostMeta.js
+++ b/assets/src/components/PostMeta/withPostMeta.js
@@ -33,9 +33,6 @@ export function withPostMeta( WrappedComponent ) {
       super( props );
       this.handleChange = this.handleChange.bind( this );
       this.valuePropName = getValuePropName( WrappedComponent );
-      this.state = {
-        value: null
-      };
     }
 
     async handleChange( metaKey, value ) {
@@ -46,19 +43,13 @@ export function withPostMeta( WrappedComponent ) {
       this.props.writeMeta( meta );
     }
 
-    static getDerivedStateFromProps(props, state) {
-      const value = getValueFromProps( props );
-      return {
-        value
-      }
-    }
-
     render() {
       const { metaKey, postMeta, writeMeta, getNewMeta, onChange, defaultValue, ...ownProps } = this.props;
+      const value = getValueFromProps( this.props );
 
       return <WrappedComponent
         { ...{
-          [ this.valuePropName ]: this.state.value,
+          [ this.valuePropName ]: value,
           onChange: ( value ) => {
             this.handleChange( metaKey, value || '' );
             // Fire any onchange event if passed by wrapped component.

--- a/assets/src/components/PostMeta/withPostMeta.js
+++ b/assets/src/components/PostMeta/withPostMeta.js
@@ -38,9 +38,11 @@ export function withPostMeta( WrappedComponent ) {
       };
     }
 
-    handleChange( metaKey, value ) {
-      const getNewMeta = this.props.getNewMeta || (( metaKey, value, meta ) => ({ [ metaKey ]: value }));
-      const meta = getNewMeta(metaKey, value, this.props.postMeta );
+    async handleChange( metaKey, value ) {
+      const getNewMeta = this.props.getNewMeta || (( metaKey, value, meta ) => {
+        return { [ metaKey ]: value };
+      });
+      const meta = await getNewMeta( metaKey, value, this.props.postMeta );
       this.props.writeMeta( meta );
     }
 
@@ -59,6 +61,7 @@ export function withPostMeta( WrappedComponent ) {
           [ this.valuePropName ]: this.state.value,
           onChange: ( value ) => {
             this.handleChange( metaKey, value || '' );
+            // Fire any onchange event if passed by wrapped component.
             if ( onChange ) {
               onChange( value );
             }

--- a/assets/src/components/Sidebar/CampaignSidebar.js
+++ b/assets/src/components/Sidebar/CampaignSidebar.js
@@ -8,6 +8,7 @@ import { withDefaultLabel } from '../withDefaultLabel/withDefaultLabel';
 import { __ } from '@wordpress/i18n';
 import { fromThemeOptions } from '../fromThemeOptions/fromThemeOptions';
 import isShallowEqual from '@wordpress/is-shallow-equal';
+import { savePreviewMeta } from '../../saveMetaToPreview';
 
 const themeOptions = [
   {
@@ -85,12 +86,12 @@ export class CampaignSidebar extends Component {
       meta: null,
       parent: null,
     };
-    this.handleThemeChange = this.handleThemeChange.bind( this );
   }
 
   componentDidMount() {
     wp.data.subscribe( () => {
       const meta = wp.data.select( 'core/editor' ).getEditedPostAttribute( 'meta' );
+
       if ( meta ) {
         let theme = meta[ 'theme' ];
         if ( theme === '' ) {
@@ -98,6 +99,7 @@ export class CampaignSidebar extends Component {
         }
         if ( !isShallowEqual( this.state.meta, meta ) ) {
           this.setState( { meta: meta } );
+          savePreviewMeta();
           if (
             this.state.theme === null || theme !== this.state.theme.id
           ) {
@@ -116,10 +118,6 @@ export class CampaignSidebar extends Component {
         this.setState( { parent: parentPage } );
       }
     } );
-  }
-
-  handleThemeChange( value ) {
-    this.loadTheme( value );
   }
 
   loadTheme( value ) {
@@ -164,7 +162,6 @@ export class CampaignSidebar extends Component {
                 <ThemeSelect
                   metaKey='theme'
                   label={ __( 'Theme', 'planet4-blocks-backend' ) }
-                  onChange={ this.handleThemeChange }
                   options={ themeOptions }
                 />
               </div>

--- a/assets/src/components/Sidebar/CampaignSidebar.js
+++ b/assets/src/components/Sidebar/CampaignSidebar.js
@@ -6,7 +6,7 @@ import ColorPaletteControl from '../ColorPaletteControl/ColorPaletteControl';
 import { withPostMeta } from '../PostMeta/withPostMeta';
 import { withDefaultLabel } from '../withDefaultLabel/withDefaultLabel';
 import { __ } from '@wordpress/i18n';
-import { fromThemeOptions } from '../fromThemeOptions/fromThemeOptions';
+import { fromThemeOptions, getFieldFromTheme } from '../fromThemeOptions/fromThemeOptions';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { savePreviewMeta } from '../../saveMetaToPreview';
 
@@ -86,6 +86,35 @@ export class CampaignSidebar extends Component {
       meta: null,
       parent: null,
     };
+    this.handleThemeSwitch = this.handleThemeSwitch.bind( this );
+    this.loadTheme = this.loadTheme.bind( this );
+  }
+
+  async handleThemeSwitch( metaKey, value, meta ) {
+    await this.loadTheme( value )
+
+    const invalidatedFields = this.state.theme.fields.filter( field => {
+
+      const resolvedField = getFieldFromTheme(this.state.theme, field.id, meta);
+
+      const currentValue = meta[ field.id ];
+
+      if ( !resolvedField || !resolvedField.options ) {
+        return !!currentValue;
+      }
+
+      return !(resolvedField.options.some( option => option.value === currentValue) );
+
+    } ).map( field => getFieldFromTheme( this.state.theme, field.id, meta ) )
+
+    return invalidatedFields.reduce( ( result, field ) => {
+      return {
+        ...result,
+        [ field.id ]: field.default || null,
+      };
+    }, {
+      [ metaKey ]: value,
+    } );
   }
 
   componentDidMount() {
@@ -101,7 +130,7 @@ export class CampaignSidebar extends Component {
           this.setState( { meta: meta } );
           savePreviewMeta();
           if (
-            this.state.theme === null || theme !== this.state.theme.id
+            this.state.theme === null
           ) {
             this.loadTheme( theme );
           }
@@ -127,7 +156,7 @@ export class CampaignSidebar extends Component {
     const baseUrl = window.location.href.split( '/wp-admin' )[ 0 ];
     const themeJsonUrl = `${ baseUrl }/wp-content/themes/planet4-master-theme/campaign_themes/${ value }.json`;
     console.log( `fetching theme ${ value }` );
-    fetch( themeJsonUrl )
+    return fetch( themeJsonUrl )
       .then( response => response.json() )
       .then( json => {
         this.setState( { theme: json } );
@@ -163,6 +192,7 @@ export class CampaignSidebar extends Component {
                   metaKey='theme'
                   label={ __( 'Theme', 'planet4-blocks-backend' ) }
                   options={ themeOptions }
+                  getNewMeta={ this.handleThemeSwitch }
                 />
               </div>
               <PanelBody

--- a/assets/src/components/fromThemeOptions/fromThemeOptions.js
+++ b/assets/src/components/fromThemeOptions/fromThemeOptions.js
@@ -64,37 +64,6 @@ export function fromThemeOptions( WrappedComponent ) {
       };
     }
 
-    componentDidMount() {
-      const field = getFieldFromTheme( this.props.theme, this.props.metaKey );
-      if ( !field ) {
-        return;
-      }
-      if ( field.dependsOn ) {
-        const dependencyField = theme.fields.find( field2 => field2.id === field.dependsOn );
-
-        if ( !dependencyField ) {
-          return;
-        }
-
-        wp.data.subscribe( () => {
-          const meta = wp.data.select( 'core/editor' ).getEditedPostAttribute( 'meta' );
-          if ( !meta ) {
-            return;
-          }
-          const dependencyValue = meta[ field.dependsOn ] || dependencyField.default;
-
-          if ( dependencyValue !== this.state.dependencyValue ) {
-            this.setState( prevState => {
-              return {
-                dependencyValue: dependencyValue,
-                ...prevState
-              };
-            } );
-          }
-        } );
-      }
-    }
-
     render() {
       const { theme, ...ownProps } = this.props;
 

--- a/assets/src/components/fromThemeOptions/fromThemeOptions.js
+++ b/assets/src/components/fromThemeOptions/fromThemeOptions.js
@@ -1,6 +1,6 @@
 import { Component } from '@wordpress/element';
 
-const getFieldFromTheme = ( theme, fieldName ) => {
+export const getFieldFromTheme = ( theme, fieldName, meta ) => {
   if ( !theme ) {
     return null;
   }
@@ -12,25 +12,24 @@ const getFieldFromTheme = ( theme, fieldName ) => {
   }
 
   if ( field.dependsOn ) {
-    return resolveDependency( theme, field );
+    return resolveDependency( theme, field, meta );
   }
 
   return field;
 };
 
-const resolveDependency = ( theme, field ) => {
+const resolveDependency = ( theme, field, meta ) => {
   const dependencyField = theme.fields.find( field2 => field2.id === field.dependsOn );
 
   if ( !dependencyField ) {
     return null;
   }
 
-  const meta = wp.data.select( 'core/editor' ).getEditedPostAttribute( 'meta' );
   if ( !meta ) {
     return null;
   }
 
-  const dependencyConfiguration = dependencyField.dependsOn ? resolveDependency( theme, dependencyField ) : dependencyField;
+  const dependencyConfiguration = dependencyField.dependsOn ? resolveDependency( theme, dependencyField, meta ) : dependencyField;
 
   if ( !dependencyConfiguration ) {
     return null;
@@ -51,7 +50,10 @@ const resolveDependency = ( theme, field ) => {
     return null;
   }
 
-  return field.configurations[ dependencyValue ];
+  return {
+    id: field.id,
+    ...field.configurations[ dependencyValue ],
+  };
 };
 
 const getDependencyUpdates = ( theme, fieldName, value, meta ) => {
@@ -64,7 +66,7 @@ const getDependencyUpdates = ( theme, fieldName, value, meta ) => {
         return typeof meta[ field.id  ] !== 'undefined'
       }
 
-      return !(configuration.options.includes( meta[ field.id ] ));
+      return !(configuration.options.some(option => option.value === meta[ field.id ] ));
     }
   );
 
@@ -73,23 +75,16 @@ const getDependencyUpdates = ( theme, fieldName, value, meta ) => {
   return needUpdate.reduce( ( updates, field ) => {
     const configuration = field.configurations[ value ];
 
-    return {
-      ...updates,
-      [ field.id ]: configuration && configuration.default ? configuration.default : null,
-    };
+    return Object.assign(
+      updates,
+      {[ field.id ]: configuration && configuration.default ? configuration.default : null}
+    );
   }, {} );
 };
 
 export function fromThemeOptions( WrappedComponent ) {
 
   return class extends Component {
-    constructor(props) {
-      super(props);
-      this.state = {
-        dependencyValue: null,
-      };
-    }
-
     render() {
       const { theme, ...ownProps } = this.props;
 
@@ -97,7 +92,9 @@ export function fromThemeOptions( WrappedComponent ) {
         return <WrappedComponent { ...ownProps }/>
       }
 
-      const field = getFieldFromTheme( theme, ownProps.metaKey );
+      const meta = wp.data.select( 'core/editor' ).getEditedPostAttribute( 'meta' );
+
+      const field = getFieldFromTheme( theme, ownProps.metaKey, meta );
 
       if ( !field || !field.options ) {
         return null;

--- a/assets/src/components/withDefaultLabel/withDefaultLabel.js
+++ b/assets/src/components/withDefaultLabel/withDefaultLabel.js
@@ -13,7 +13,7 @@ export function withDefaultLabel( WrappedComponent ) {
     render() {
       const { options, ...ownProps } = this.props;
 
-      const enhancedOptions = options.map( option => {
+      const enhancedOptions = !options ? [] : options.map( option => {
         const label = option.value === this.props.defaultValue ? option.label + ' ' + this.defaultLabel : option.label
         return {
             ...option,

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -22,7 +22,6 @@ import { addButtonLinkPasteWarning } from './addButtonLinkPasteWarning';
 import { setupCustomSidebar } from "./setupCustomSidebar";
 import { setUpCssVariables } from './connectCssVariables';
 import { SubPagesBlock } from './blocks/SubPages/SubPagesBlock';
-import { saveMetaToPreview } from './saveMetaToPreview';
 
 new ArticlesBlock();
 new CarouselHeaderBlock();
@@ -49,4 +48,3 @@ addButtonLinkPasteWarning();
 replaceTaxonomyTermSelectors();
 setupCustomSidebar();
 setUpCssVariables();
-saveMetaToPreview();

--- a/assets/src/saveMetaToPreview.js
+++ b/assets/src/saveMetaToPreview.js
@@ -1,19 +1,17 @@
-// Save the current state of the post meta fields to the user's preview, so that any old values are invalidated.
-export const saveMetaToPreview = () => {
-  document.addEventListener('DOMContentLoaded', (event) => {
-    const { apiFetch } = wp;
-    const { getEditedPostAttribute, getCurrentPostId } = wp.data.select( 'core/editor' );
+export const savePreviewMeta = () => {
+  const { apiFetch } = wp;
+  const { getEditedPostAttribute, getCurrentPostId } = wp.data.select( 'core/editor' );
 
-    if ( !['draft', 'auto-draft'].includes( getEditedPostAttribute( 'status' ) ) ) {
-      apiFetch( {
-        path: `/planet4/v1/save-preview-meta`,
-        method: 'POST',
-        data: {
-          post_id: getCurrentPostId(),
-          meta: getEditedPostAttribute('meta')
-        },
-      } );
-    }
+  console.info('Saving preview meta...');
 
-  })
-};
+  if ( !['draft', 'auto-draft'].includes( getEditedPostAttribute( 'status' ) ) ) {
+    apiFetch( {
+      path: `/planet4/v1/save-preview-meta`,
+      method: 'POST',
+      data: {
+        post_id: getCurrentPostId(),
+        meta: getEditedPostAttribute('meta')
+      },
+    } );
+  }
+}

--- a/assets/src/styles/blocks/Articles.scss
+++ b/assets/src/styles/blocks/Articles.scss
@@ -94,7 +94,7 @@
   font-size: 1.25rem;
   line-height: 1.3;
   font-weight: 500;
-  color: $black;
+  color: $dark-shade-black;
   margin: $space-xxs 0;
 
   @include large-and-up {

--- a/assets/src/styles/blocks/CarouselHeader.scss
+++ b/assets/src/styles/blocks/CarouselHeader.scss
@@ -194,7 +194,7 @@ $slide-transition-speed: 1s;
       width: 70%;
       line-height: 1.2;
       font-weight: bold;
-      color: $black;
+      color: $dark-shade-black;
       padding-left: 15px;
 
       html[dir="rtl"] & {
@@ -224,7 +224,7 @@ $slide-transition-speed: 1s;
       line-height: 1.3;
       font-weight: 400;
       width: 55%;
-      color: $black;
+      color: $dark-shade-black;
       margin-bottom: 0;
       padding-left: 15px;
 

--- a/assets/src/styles/blocks/CarouselHeader_full_width_classic.scss
+++ b/assets/src/styles/blocks/CarouselHeader_full_width_classic.scss
@@ -402,7 +402,7 @@ $medium-image-height: 600px;
         h1, h2, h3 {
           width: 100%;
           font-weight: bold;
-          color: $black;
+          color: $dark-shade-black;
           padding-left: 0;
           transition: unset;
           transform: translateX($text-slide-offset);
@@ -503,7 +503,7 @@ $medium-image-height: 600px;
 
         p {
           display: block;
-          color: $black;
+          color: $dark-shade-black;
           font-family: $roboto;
           font-size: .875rem;
           font-weight: 500;

--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -73,7 +73,7 @@
         font-weight: bold;
         line-height: 1.2;
         margin-bottom: $space-md;
-        color: $black;
+        color: $dark-shade-black;
 
         @include medium-and-up {
           font-size: 1.5rem;

--- a/assets/src/styles/blocks/Covers/ContentCovers.scss
+++ b/assets/src/styles/blocks/Covers/ContentCovers.scss
@@ -1,5 +1,5 @@
 .content-covers-block {
-  color: $black;
+  color: $dark-shade-black;
 
   .limit-visibility {
     margin-top: -$space-lg;

--- a/assets/src/styles/blocks/Gallery_carousel.scss
+++ b/assets/src/styles/blocks/Gallery_carousel.scss
@@ -3,7 +3,7 @@
 
   h1 {
     font-size: $font-size-lg;
-    color: $black;
+    color: $dark-shade-black;
     margin-bottom: 22px;
     margin-left: 0;
 

--- a/assets/src/styles/blocks/Happypoint.scss
+++ b/assets/src/styles/blocks/Happypoint.scss
@@ -81,7 +81,7 @@
       font-size: $font-size-xl;
       line-height: 34px;
       margin-bottom: 20px;
-      color: $black;
+      color: $dark-shade-black;
     }
 
     @include large-and-up {

--- a/assets/src/styles/blocks/SocialMediaCards.scss
+++ b/assets/src/styles/blocks/SocialMediaCards.scss
@@ -39,7 +39,7 @@
           height: 100%;
           width: 12%;
           margin: 0 11%;
-          color: $black;
+          color: $dark-shade-black;
 
           img {
             min-height: 22px;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4919

This check was not working for Palette options, because the value is stored as `color`, and not as `value` in the `options` array (check the comment a few lines above):
https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/develop/assets/src/components/PostMeta/withPostMeta.js#L56

Master theme PR: https://github.com/greenpeace/planet4-master-theme/pull/1053