### PR TITLE
PLANET-4913 Fix spreadsheet block size and scrolling

### DIFF
--- a/assets/src/styles/blocks.scss
+++ b/assets/src/styles/blocks.scss
@@ -1,0 +1,29 @@
+// P4 Blocks
+@import "blocks/Articles";
+@import "blocks/Columns";
+@import "blocks/CarouselHeader";
+@import "blocks/CarouselHeader_full_width_classic";
+@import "blocks/Covers/TakeActionCovers";
+@import "blocks/Covers/CampaignCovers";
+@import "blocks/Covers/ContentCovers";
+@import "blocks/Counter";
+@import "blocks/Gallery_carousel";
+@import "blocks/Gallery_content_three_column";
+@import "blocks/Gallery_grid";
+@import "blocks/File";
+@import "blocks/Happypoint";
+@import "blocks/Media";
+@import "blocks/Socialmedia";
+@import "blocks/SocialMediaCards";
+@import "blocks/SplitTwoColumns";
+@import "blocks/Spreadsheet";
+@import "blocks/Submenu";
+@import "blocks/Timeline";
+
+// Native Blocks
+@import "blocks/core-overrides/Image";
+@import "blocks/core-overrides/Spacer";
+@import "blocks/core-overrides/BlockSpacing";
+
+// Other
+@import "blocks/WideBlocks";

--- a/assets/src/styles/blocks/Spreadsheet.scss
+++ b/assets/src/styles/blocks/Spreadsheet.scss
@@ -1,8 +1,36 @@
-table.spreadsheet-table {
-  margin: 16px 0;
+.table-wrapper {
+  overflow: auto;
+
+  max-height: 320px;
+  margin: 1.5rem 0;
 
   @include medium-and-up {
-    margin: 24px 0;
+    max-height: 520px;
+    margin: 2rem 0;
+  }
+
+  @include large-and-up {
+    max-height: 575px;
+  }
+}
+
+table.spreadsheet-table {
+  min-width: 100%;
+
+  margin-bottom: 0;
+
+  @include mobile-only {
+    overflow: visible;
+  }
+
+  th {
+    background: var(--spreadsheet-first-row-background, #06293a);
+    color: var(--spreadsheet-first-row-color, #ffffff);
+    border-bottom: 1px solid var(--spreadsheet-first-row-border-color, #ffffff);
+    cursor: pointer;
+    font-size: $font-size-sm;
+    position: sticky;
+    top: 0;
   }
 
   tr {
@@ -12,6 +40,7 @@ table.spreadsheet-table {
       background: var(--spreadsheet-row-background, #0a4461);
       color: var(--spreadsheet-row-color, #ffffff);
       font-size: $font-size-xs;
+
       @include x-large-and-up {
         font-size: $font-size-xs;
       }
@@ -23,54 +52,17 @@ table.spreadsheet-table {
         color: var(--spreadsheet-odd-rows-color, #0a4461);
       }
     }
-
-    &:hover {
-      td {
-        color: var(--spreadsheet-rows-hover-color, #ffffff);
-        background-color: var(--spreadsheet-rows-hover-background, #074365);
-      }
-    }
-
-    &:first-child {
-      td {
-        background: var(--spreadsheet-first-row-background, #06293a);
-        color: var(--spreadsheet-first-row-color, #ffffff);
-      }
-    }
-
-    th {
-      padding: 10px 20px;
-      border-bottom: 1px solid var(--spreadsheet-header-border-color, #ffffff);
-      cursor: pointer;
-      font-size: $font-size-sm;
-    }
-  }
-
-  @include mobile-only {
-    margin-left: -15px;
-    margin-right: -15px;
   }
 }
 
 .spreadsheet-search {
   width: 350px;
   max-width: 100%;
-  margin: 10px 10px 10px 0;
+  height: 2rem;
+  margin: 10px 0;
   padding: 0 8px;
-  height: 40px;
-  border: 1px solid;
-}
-
-.spreadsheet-table-search {
   border-color: var(--spreadsheet-search-border-color, #407ea2);
-}
-
-.spreadsheet-default-sort {
-  height: 40px !important;
-  box-sizing: border-box;
-  line-height: 1rem !important;
-  width: auto;
-  margin-bottom: 0;
+  border: 1px solid;
 }
 
 .spreadsheet-sorted-by {

--- a/assets/src/styles/editorStyle.scss
+++ b/assets/src/styles/editorStyle.scss
@@ -16,32 +16,12 @@
 @import "styleguide/src/layout/navbar";
 @import "styleguide/src/layout/page-header";
 
-@import "blocks/Articles";
-@import "blocks/CarouselHeader";
-@import "blocks/CarouselHeader_full_width_classic";
-@import "blocks/Columns";
-@import "blocks/ColumnsEditor";
-@import "blocks/Counter";
-@import "blocks/Covers/TakeActionCovers";
-@import "blocks/Covers/CampaignCovers";
-@import "blocks/Covers/ContentCovers";
-@import "blocks/File";
-@import "blocks/Gallery_carousel";
-@import "blocks/Gallery_content_three_column";
-@import "blocks/Gallery_grid";
-@import "blocks/Happypoint";
-@import "blocks/Socialmedia";
-@import "blocks/SocialMediaCards";
-@import "blocks/SplitTwoColumns";
-@import "blocks/Submenu";
-@import "blocks/Timeline";
-
-@import "blocks/core-overrides/Image";
-@import "blocks/core-overrides/BlockSpacing";
+@import "blocks";
 
 @import "blocks/ArticlesEditor";
 @import "blocks/CarouselHeaderEditor";
 @import "blocks/CarouselHeaderEditorOverrides";
+@import "blocks/ColumnsEditor";
 @import "blocks/GalleryEditor";
 @import "blocks/SplitTwoColumnsEditor";
 @import "blocks/SubmenuEditor";

--- a/assets/src/styles/style.scss
+++ b/assets/src/styles/style.scss
@@ -5,32 +5,4 @@
 @import "styleguide/src/base/mixins";
 @import "styleguide/src/base/fonts";
 
-// P4 Blocks
-@import "blocks/Articles";
-@import "blocks/Columns";
-@import "blocks/CarouselHeader";
-@import "blocks/CarouselHeader_full_width_classic";
-@import "blocks/Covers/TakeActionCovers";
-@import "blocks/Covers/CampaignCovers";
-@import "blocks/Covers/ContentCovers";
-@import "blocks/Counter";
-@import "blocks/Gallery_carousel";
-@import "blocks/Gallery_content_three_column";
-@import "blocks/Gallery_grid";
-@import "blocks/File";
-@import "blocks/Happypoint";
-@import "blocks/Media";
-@import "blocks/Socialmedia";
-@import "blocks/SocialMediaCards";
-@import "blocks/SplitTwoColumns";
-@import "blocks/Spreadsheet";
-@import "blocks/Submenu";
-@import "blocks/Timeline";
-
-// Native Blocks
-@import "blocks/core-overrides/Image";
-@import "blocks/core-overrides/Spacer";
-@import "blocks/core-overrides/BlockSpacing";
-
-// Other
-@import "blocks/WideBlocks";
+@import "blocks";

--- a/templates/blocks/spreadsheet.twig
+++ b/templates/blocks/spreadsheet.twig
@@ -1,24 +1,30 @@
 {% block spreadsheet %}
 
-	{% if ( fields.rows ) %}
+	{% if ( sheet ) %}
 		<div class="block-spreadsheet">
 			<div class="form-inline">
 				<input class="spreadsheet-search form-control" type="text" placeholder="{{ __('Search data', 'planet4-blocks') }}"/>
-				<button class="spreadsheet-default-sort btn btn-small btn-secondary">{{ __('Default sorting', 'planet4-blocks') }}</button>
 			</div>
-			<table class="spreadsheet-table">
-				{% for rowNumber, row in fields.rows %}
-					<tr data-order="{{ rowNumber }}">
-						{% for cell in row %}
-							{% if rowNumber == 0 %}
+			<div class="table-wrapper">
+				<table class="spreadsheet-table">
+					<thead>
+						<tr>
+							{% for cell in sheet.header %}
 								<th title="{{ __('Sort by', 'planet4-blocks') }}">{{ cell|escape }}</th>
-							{% else %}
+							{% endfor %}
+						</tr>
+					</thead>
+					<tbody>
+					{% for rowNumber, row in sheet.rows %}
+						<tr data-order="{{ rowNumber }}">
+							{% for cell in row %}
 								<td>{{ cell|escape }}</td>
-							{% endif %}
-						{% endfor %}
-					</tr>
-				{% endfor %}
-			</table>
+							{% endfor %}
+						</tr>
+					{% endfor %}
+					</tbody>
+				</table>
+			</div>
 			<div class="spreadsheet-empty-message">{{ __('No data matching your search.', 'planet4-blocks') }}</div>
 		</div>
 	{% endif %}


### PR DESCRIPTION
* Apply sticky positioning to the header.
* Apply a max height for different screen sizes.
* Cache the sheet response for 5 minutes.
* Use `<thead>` and `<tbody>`. For now this assumes the first row is
always a header, we might want to make that configurable.
* Remove the default sort button.
* Fix alternating colors when the rows are filtered by using a different
technique. Instead of hiding the elements, remove them and add them back
when needed.
* Fix sorting not applied after filtering.