### PR TITLE
[No ticket]: Add descriptive names for the React Component debugger

### DIFF
--- a/assets/src/components/PostMeta/withPostMeta.js
+++ b/assets/src/components/PostMeta/withPostMeta.js
@@ -26,6 +26,10 @@ const getValueFromProps = ( props ) => {
 
 }
 
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+}
+
 export function withPostMeta( WrappedComponent ) {
 
   class WrappingComponent extends Component {
@@ -63,7 +67,7 @@ export function withPostMeta( WrappedComponent ) {
     }
   }
 
-  return compose(
+  const WithPostMetaHOC = compose(
     withSelect(
       ( select ) => {
         return {
@@ -81,4 +85,8 @@ export function withPostMeta( WrappedComponent ) {
       }
     )
   )( WrappingComponent );
+
+  WithPostMetaHOC.displayName = `WithPostMetaHOC(${getDisplayName(WrappedComponent)})`;
+
+  return WithPostMetaHOC;
 }

--- a/assets/src/components/fromThemeOptions/fromThemeOptions.js
+++ b/assets/src/components/fromThemeOptions/fromThemeOptions.js
@@ -1,5 +1,9 @@
 import { Component } from '@wordpress/element';
 
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+}
+
 export const getFieldFromTheme = ( theme, fieldName, meta ) => {
   if ( !theme ) {
     return null;
@@ -84,7 +88,7 @@ const getDependencyUpdates = ( theme, fieldName, value, meta ) => {
 
 export function fromThemeOptions( WrappedComponent ) {
 
-  return class extends Component {
+  class FromThemeOptionsHOC extends Component {
     render() {
       const { theme, ...ownProps } = this.props;
 
@@ -108,4 +112,8 @@ export function fromThemeOptions( WrappedComponent ) {
       return <WrappedComponent getNewMeta={ provideNewMeta } defaultValue={ field.default } options={ field.options } { ...ownProps } />;
     }
   };
+
+  FromThemeOptionsHOC.displayName = `FromThemeOptionsHOC(${getDisplayName(WrappedComponent)})`;
+
+  return FromThemeOptionsHOC;
 }

--- a/assets/src/components/withDefaultLabel/withDefaultLabel.js
+++ b/assets/src/components/withDefaultLabel/withDefaultLabel.js
@@ -1,9 +1,13 @@
 import { Component } from '@wordpress/element';
 
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+}
+
 export function withDefaultLabel( WrappedComponent ) {
   const {__} = wp.i18n;
 
-  class LabeledComponent extends Component {
+  class WithDefaultLabelHOC extends Component {
     constructor( props ) {
       super( props );
 
@@ -28,5 +32,7 @@ export function withDefaultLabel( WrappedComponent ) {
     }
   }
 
-  return LabeledComponent;
+  WithDefaultLabelHOC.displayName = `WithDefaultLabelHOC(${getDisplayName(WrappedComponent)})`;
+
+  return WithDefaultLabelHOC;
 }


### PR DESCRIPTION
This is just to reduce the number of anonymous classes in the React Devtools Component debugger.

It's following this recommendation from Facebook: 
https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging

It turns this:
<img width="947" alt="Captura de pantalla 2020-04-16 a la(s) 12 56 16" src="https://user-images.githubusercontent.com/340766/79479143-b557fb80-7fe2-11ea-842e-fe57256708a7.png">

Into this:
<img width="830" alt="Captura de pantalla 2020-04-16 a la(s) 12 59 50" src="https://user-images.githubusercontent.com/340766/79479181-c56fdb00-7fe2-11ea-959e-b4b3cdc36aa4.png">
