### PR TITLE
PLANET-4705: Header Carousel: icon to delete image is not shown

### DIFF
--- a/assets/src/blocks/Carouselheader/CarouselHeader.js
+++ b/assets/src/blocks/Carouselheader/CarouselHeader.js
@@ -12,7 +12,7 @@ import {initializeCarouselHeader} from "./CarouselHeaderFront";
 export class CarouselHeader extends Component {
   constructor(props) {
     super(props);
-    this.refs = [];
+    this.references = [];
     this.firstRender = true;
   }
 
@@ -43,14 +43,16 @@ export class CarouselHeader extends Component {
 
   getSnapshotBeforeUpdate(prevProps, prevState) {
     this.setDOMListener();
+
+    return null;
   }
 
   /**
    * Collapse all active slides.
    */
   collapseSlides() {
-    let refs = this.refs;
-    Object.keys(this.refs).forEach(function (index) {
+    let refs = this.references;
+    Object.keys(this.references).forEach(function (index) {
       if (null !== refs[index]) {
         refs[index].collapseSlide();
       }
@@ -112,7 +114,7 @@ export class CarouselHeader extends Component {
 
         {this.props.slides.map((slide, i) => {
           return (
-            <Fragment>
+            <Fragment key={i}>
               <CarouselHeaderSlide
                 {...slide}
                 onImageChange={this.props.onImageChange}
@@ -129,7 +131,7 @@ export class CarouselHeader extends Component {
                 index={i}
                 key={i}
                 ref={(instance) => {
-                  this.refs[i] = instance
+                  this.references[i] = instance
                 }}
               />
             </Fragment>

--- a/assets/src/blocks/Carouselheader/CarouselHeaderImage.js
+++ b/assets/src/blocks/Carouselheader/CarouselHeaderImage.js
@@ -1,6 +1,7 @@
 import {Component, Fragment} from '@wordpress/element';
 import {
   Dashicon,
+  Button,
   FocalPointPicker
 } from '@wordpress/components';
 import {MediaUpload} from "@wordpress/editor";
@@ -13,7 +14,6 @@ export class CarouselHeaderImage extends Component {
 
   render() {
     const {onChange, onRemove, image_id, image_url, onFocalPointsChange, focal_points} = this.props;
-    let   hasRemove = true;
 
     let imageClass = [];
     if (!image_url) {
@@ -38,11 +38,14 @@ export class CarouselHeaderImage extends Component {
                   className={imageClass}
                   tabIndex={0}
                 >
-                  {image_url && onRemove && hasRemove && (
-                    <button className="ch-image-upload-remove" onClick={ev => {
+                  {image_url && onRemove && (
+                    <Button className="ch-image-upload-remove" onClick={ev => {
                       onRemove();
                       ev.stopPropagation()
-                    }}><Dashicon icon="no"/></button>
+                    }}>
+                      <Dashicon icon="no"/>
+                      Remove this image
+                    </Button>
                   )}
                   <FocalPointPicker
                     url={image_url}
@@ -65,7 +68,7 @@ export class CarouselHeaderImage extends Component {
                 role="button"
                 tabIndex={0}
                 >
-                {image_url && onRemove && hasRemove && (
+                {image_url && onRemove && (
                   <button className="ch-image-upload-remove" onClick={ev => {
                     onRemove();
                     ev.stopPropagation()

--- a/assets/src/blocks/Carouselheader/CarouselHeaderSlide.js
+++ b/assets/src/blocks/Carouselheader/CarouselHeaderSlide.js
@@ -103,26 +103,29 @@ export class CarouselHeaderSlide extends Component {
                 onChange={(image) => this.onImageChange(image)}
                 onFocalPointsChange={(f) => this.onFocalPointsChange(f)}
               />
-              <div className="ch-url-input-control__wrapper">
-
-                <TextControl
-                  className="carouselh-header-input"
-                  label={__('Header', 'p4ge')}
-                  placeholder={__('Enter header', 'p4ge')}
-                  value={this.props.header}
-                  onChange={(e) => this.props.onHeaderChange(this.props.index, e)}
-                  characterLimit={40}
-                />
-                <SelectControl
-                  label={__('Header text size', 'p4ge')}
-                  value={this.props.header_size}
-                  options={[
-                    {label: 'h1', value: 'h1'},
-                    {label: 'h2', value: 'h2'},
-                    {label: 'h3', value: 'h3'},
-                  ]}
-                  onChange={(e) => this.props.onHeaderSizeChange(this.props.index, e)}
-                />
+              <div className="row">
+                <div className="col">
+                  <TextControl
+                    className="carouselh-header-input"
+                    label={__('Header', 'p4ge')}
+                    placeholder={__('Enter header', 'p4ge')}
+                    value={this.props.header}
+                    onChange={(e) => this.props.onHeaderChange(this.props.index, e)}
+                    characterLimit={40}
+                  />
+                </div>
+                <div className="col">
+                  <SelectControl
+                    label={__('Header text size', 'p4ge')}
+                    value={this.props.header_size}
+                    options={[
+                      {label: 'h1', value: 'h1'},
+                      {label: 'h2', value: 'h2'},
+                      {label: 'h3', value: 'h3'},
+                    ]}
+                    onChange={(e) => this.props.onHeaderSizeChange(this.props.index, e)}
+                  />
+                </div>
               </div>
               {this.props.hasSubheader &&
               <TextControl
@@ -140,35 +143,35 @@ export class CarouselHeaderSlide extends Component {
                 onChange={(e) => this.props.onDescriptionChange(this.props.index, e)}
                 characterLimit={200}
               />
-              <div className="ch-url-input-control__wrapper">
-
-                <TextControl
-                  label={__('Link text and url', 'p4ge')}
-                  placeholder={__('Enter link text for image', 'p4ge')}
-                  value={this.props.link_text}
-                  onChange={(e) => this.props.onLinkTextChange(this.props.index, e)}
-                  className='carousel-header-link-text-input'
-                />
-                <form
-                  className="ch-url-input-control"
-                  onSubmit={event => event.preventDefault()}>
-                  <div className="ch-url-input-control__wrapper">
-                    <URLInput
-                      label={__('Url for link', 'p4ge')}
-                      className="ch-url-input-control__input"
-                      value={this.props.link_url}
-                      onChange={(e) => this.props.onLinkUrlChange(this.props.index, e)}
-                      autoFocus={false}
+              <div className="row">
+                <div className="col">
+                  <TextControl
+                    label={__('Link text and url', 'p4ge')}
+                    placeholder={__('Enter link text for image', 'p4ge')}
+                    value={this.props.link_text}
+                    onChange={(e) => this.props.onLinkTextChange(this.props.index, e)}
+                  />
+                </div>
+                <div className="col">
+                  <URLInput
+                    label={__('Url for link', 'p4ge')}
+                    className="ch-url-input-control__input"
+                    value={this.props.link_url}
+                    onChange={(e) => this.props.onLinkUrlChange(this.props.index, e)}
+                    autoFocus={false}
+                  />
+                </div>
+              </div>
+              <div className="row">
+                <div className="col">
+                  <div className="InlineToggleControl">
+                    <ToggleControl
+                      help={__('Open link in a new tab', 'p4ge')}
+                      checked={this.props.link_url_new_tab}
+                      onChange={(e) => this.props.onLinkNewTabChange(this.props.index, e)}
                     />
-                    <div className="ch-url-input-control__new-tab">
-                      <ToggleControl
-                        help={__('New Tab', 'p4ge')}
-                        checked={this.props.link_url_new_tab}
-                        onChange={(e) => this.props.onLinkNewTabChange(this.props.index, e)}
-                      />
-                    </div>
                   </div>
-                </form>
+                </div>
               </div>
             </div>
           </Fragment>

--- a/assets/src/styles/blocks/CarouselHeaderEditor.scss
+++ b/assets/src/styles/blocks/CarouselHeaderEditor.scss
@@ -52,21 +52,11 @@
 }
 
 .ch-image-upload-remove {
-  background: none !important;
-  color: #ddd;
-  border: none;
-  position: absolute;
-  top: 10px;
-  right: 4px;
-  cursor: pointer;
-  display: none;
-  z-index: 9 !important;
+  display: block;
+  margin: auto;
 
   svg {
-    stroke: rgba(0, 0, 0, 0.3);
-    stroke-width: 1px;
-    fill: #ccc;
-    max-width: none;
+    margin-top: -4px;
   }
 }
 
@@ -117,8 +107,6 @@
 }
 
 .ch-url-input-control__input {
-  width: 80%;
-
   input {
     padding: 6px 8px !important;
     box-shadow: 0 0 0 transparent;
@@ -158,22 +146,18 @@
   }
 }
 
-.carouselh-header-input {
-  width: 75%;
-  margin-right: 15px;
-}
-
-.carousel-header-link-text-input {
-  margin-right: 10px;
-  width: 30%;
-}
-
 .slide-hr {
   margin: 0;
 }
 
 .carousel-header-image-container {
   position: relative;
+
+  .components-focal-point-picker_position-display-container {
+    .components-base-control__field {
+      min-width: 200px;
+    }
+  }
 }
 
 .carousel-header-slide-options-wrapper {

--- a/assets/src/styles/components/CharacterCounter.scss
+++ b/assets/src/styles/components/CharacterCounter.scss
@@ -1,5 +1,6 @@
 .counted-field-wrapper {
   position: relative;
+  margin-bottom: 16px;
 
   textarea {
     // Needed to ensure same spacing as input[type=text].

--- a/assets/src/styles/editorOverrides.scss
+++ b/assets/src/styles/editorOverrides.scss
@@ -188,3 +188,17 @@
 input.describe[type=text][data-setting=caption] {
   pointer-events: none;
 }
+
+.InlineToggleControl {
+  .components-toggle-control {
+    display: flex;
+
+    .components-base-control__field {
+      margin: 0;
+    }
+
+    p {
+      margin: 0;
+    }
+  }
+}


### PR DESCRIPTION
After tinkering a bit with the block, I realized this editing experience is totally different from the Gallery block. I restored the Delete Image button, made it more prominent in the UI and did a few CSS changes to make the editing experience look more polished. 

There were also some React warnings to control (details in the commit), and even an error preventing to create a new CarouselHeader (attempting to mutate `this.refs` directly). This could probably use a few refactors, but I guess that should be part of the WYSIWYG epic. 

As for this ticket, the issue is addressed and the editing experience looks much better now. 

Ref: https://jira.greenpeace.org/browse/PLANET-4705