### PR TITLE
PLANET-4946: Edit selection in Gallery Block

### DIFF
--- a/assets/src/blocks/Gallery/Gallery.js
+++ b/assets/src/blocks/Gallery/Gallery.js
@@ -80,7 +80,6 @@ export class Gallery extends Component {
               <MediaUploadCheck>
                 <MediaPlaceholder
                   addToGallery={ hasImages }
-                  disableMediaButtons={ hasImages  }
                   labels={ {
                     title: __( 'Select Gallery Images' ),
                     instructions: __('Upload an image or select from the media library.', 'p4ge'),


### PR DESCRIPTION
The deleted line was removing the "Select Gallery Images" placeholder from the Gallery after the user selected a few images.

Ref: https://jira.greenpeace.org/browse/PLANET-4946

<img width="876" alt="Captura de pantalla 2020-04-27 a la(s) 13 10 15" src="https://user-images.githubusercontent.com/340766/80394658-836b5280-8888-11ea-8aae-b4dbc63905c8.png">
