### PR TITLE
PLANET-5018 Re-enable spreadsheet block on Campaigns

### DIFF
--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -134,9 +134,9 @@ const CAMPAIGN_BLOCK_TYPES = [
 	'planet4-blocks/happypoint',
 	'planet4-blocks/media',
 	'planet4-blocks/social-media',
-	'planet4-blocks/socialshare',
-	'planet4-blocks/split-two-columns',
-	'planet4-blocks/submenu',
+	'planet4-blocks/social-media-cards',
+	'planet4-blocks/spreadsheet',
+	'planet4-blocks/sub-pages',
 	'planet4-blocks/timeline',
 ];
 


### PR DESCRIPTION
Not sure how this got removed, but it should be whitelisted for all post types.

This also had some other wrong blocks whitelisted there (split-two-columns and submenu), one wrong name (socialshare instead of social-media-cards) and one missing sub-pages.

Not sure how this happened. It seems like something got wrong in a rebase.