### PR TITLE
Planet 5037 add css variables attribute

### DIFF
--- a/assets/src/blocks/CssVariablesAttribute.js
+++ b/assets/src/blocks/CssVariablesAttribute.js
@@ -1,0 +1,4 @@
+export const CSS_VARIABLES_ATTRIBUTE = {
+  type: 'object',
+  default: {},
+}

--- a/assets/src/blocks/Spreadsheet/Spreadsheet.js
+++ b/assets/src/blocks/Spreadsheet/Spreadsheet.js
@@ -16,7 +16,11 @@ export class Spreadsheet extends Component {
   renderEdit() {
     const { __ } = wp.i18n;
 
-    const { color } = this.props;
+    const { attributes, setAttributes } = this.props;
+
+    const toAttribute = attributeName => value => {
+      setAttributes( { [ attributeName ]: value } );
+    };
 
     const colors = [
       { name: 'blue', color: '#C9E7FA' },
@@ -24,14 +28,23 @@ export class Spreadsheet extends Component {
       { name: 'grey', color: '#DCDCDC' },
     ];
 
+    const toCssVariable = ( variableName ) => ( value ) => {
+      setAttributes( {
+        css_variables: {
+          ...attributes.css_variables,
+          [variableName]: value,
+        }
+      } );
+    };
+
     return (
       <Fragment>
         <InspectorControls>
           <PanelBody title={__('Setting', 'p4ge')}>
             <ColorPaletteControl
               label={__('Table Color', 'p4ge')}
-              value={ color }
-              onChange={ this.props.onTableColorChange }
+              value={ attributes.css_variables['spreadsheet-row-background'] }
+              onChange={ toCssVariable('spreadsheet-row-background') }
               disableCustomColors
               clearable={ false }
               options= { colors }
@@ -49,8 +62,8 @@ export class Spreadsheet extends Component {
             even when "Automatically republish when changes are made" is checked. You can force an update by unpublishing
             and republishing the sheet. This will not change the sheet's public url.
             `, 'planet4-blocks-backend')}
-            value={this.props.url}
-            onChange={this.props.onUrlChange}
+            value={ attributes.url }
+            onChange={ toAttribute( 'url' ) }
           />
         </div>
       </Fragment>
@@ -68,9 +81,7 @@ export class Spreadsheet extends Component {
         <Preview showBar={this.props.isSelected}>
           <ServerSideRender
             block={ 'planet4-blocks/spreadsheet' }
-            attributes={{
-              url: this.props.url,
-            }}>
+            attributes={ this.props.attributes }>
           </ServerSideRender>
         </Preview>
       </div>

--- a/assets/src/blocks/Spreadsheet/SpreadsheetBlock.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetBlock.js
@@ -1,14 +1,10 @@
 import { Spreadsheet } from './Spreadsheet';
+import { CSS_VARIABLES_ATTRIBUTE } from '../CssVariablesAttribute';
 
 export class SpreadsheetBlock {
   constructor() {
     const { registerBlockType } = wp.blocks;
     const { __ } = wp.i18n;
-
-    const color_name_map =
-      { C9E7FA: 'blue',
-        D0FAC9: 'green',
-        DCDCDC: 'grey' };
 
     registerBlockType( 'planet4-blocks/spreadsheet', {
       title: __( 'Spreadsheet', 'planet4-blocks-backend' ),
@@ -19,29 +15,13 @@ export class SpreadsheetBlock {
           type: 'string',
           default: '',
         },
-        color: {
-          type: 'string',
-          default: '#DCDCDC'
-        },
-        color_name: {
-          type: 'string',
-          default: 'grey'
-        }
+        css_variables: CSS_VARIABLES_ATTRIBUTE,
       },
       edit: ( { isSelected, attributes, setAttributes } ) => {
-        function onUrlChange( value ) {
-          setAttributes( { url: value } );
-        }
-
-        function onTableColorChange( colors, value ) {
-          setAttributes( {color: value} );
-        }
-
         return <Spreadsheet
-          { ...attributes }
+          attributes={attributes}
+          setAttributes={setAttributes}
           isSelected={ isSelected }
-          onUrlChange={ onUrlChange }
-          onTableColorChange={ onTableColorChange }
         />
       },
       save() {

--- a/classes/blocks/class-base-block.php
+++ b/classes/blocks/class-base-block.php
@@ -14,6 +14,11 @@ namespace P4GBKS\Blocks;
  */
 abstract class Base_Block {
 
+	protected const CSS_VARIABLES_ATTRIBUTE = [
+		'type'    => 'object',
+		'default' => [],
+	];
+
 	/**
 	 * Get all the data that will be needed to render the block correctly.
 	 *

--- a/classes/blocks/class-spreadsheet.php
+++ b/classes/blocks/class-spreadsheet.php
@@ -31,18 +31,11 @@ class Spreadsheet extends Base_Block {
 				'editor_script'   => 'planet4-blocks',
 				'render_callback' => [ $this, 'render' ],
 				'attributes'      => [
-					'url' 		 => [
+					'url'           => [
 						'type'    => 'string',
 						'default' => '',
 					],
-					'color' 	 => [
-						'type'    => 'string',
-						'default' => '',
-					],
-					'color_name' => [
-						'type'    => 'string',
-						'default' => '',
-					],
+					'css_variables' => self::CSS_VARIABLES_ATTRIBUTE,
 				],
 			]
 		);
@@ -67,7 +60,10 @@ class Spreadsheet extends Base_Block {
 			$sheet = null;
 		}
 
-		return [ 'sheet' => $sheet ];
+		return [
+			'sheet'         => $sheet,
+			'css_variables' => $fields['css_variables'] ?? null,
+		];
 	}
 
 	/**

--- a/templates/blocks/css_variables.twig
+++ b/templates/blocks/css_variables.twig
@@ -1,0 +1,7 @@
+{% spaceless %}
+style="
+	{% for key,value in css_variables %}
+		--{{ key }}: {{ value }};
+	{% endfor %}
+	"
+{% endspaceless %}

--- a/templates/blocks/spreadsheet.twig
+++ b/templates/blocks/spreadsheet.twig
@@ -1,7 +1,7 @@
 {% block spreadsheet %}
 
 	{% if ( sheet ) %}
-		<div class="block-spreadsheet" {% include "css_variables.twig" %}>
+		<div class="block-spreadsheet" {% include "css_variables.twig" with css_variables %}>
 			<div class="form-inline">
 				<input class="spreadsheet-search form-control" type="text" placeholder="{{ __('Search data', 'planet4-blocks') }}"/>
 			</div>

--- a/templates/blocks/spreadsheet.twig
+++ b/templates/blocks/spreadsheet.twig
@@ -1,7 +1,7 @@
 {% block spreadsheet %}
 
 	{% if ( sheet ) %}
-		<div class="block-spreadsheet">
+		<div class="block-spreadsheet" {% include "css_variables.twig" %}>
 			<div class="form-inline">
 				<input class="spreadsheet-search form-control" type="text" placeholder="{{ __('Search data', 'planet4-blocks') }}"/>
 			</div>


### PR DESCRIPTION
Adds the backend support for using css variables inside blocks. Also setup the Spreadsheet block edit component to put the color into the attribute that is used to store the variables.