### PR TITLE
PLANET-4774 Add Duplicate postmeta report & WP CLI command to clean duplicate postmeta

### DIFF
--- a/classes/command/class-controller.php
+++ b/classes/command/class-controller.php
@@ -56,7 +56,36 @@ class Controller {
 		WP_CLI::log( 'Conversion duration: ' . round( $seconds_elapsed ) . ' seconds' );
 	}
 
-	// Add here new sub-commands e.g. wp p4-blocks new_sub_command.
+	/**
+	 * Sub command that removes duplicate postmeta records
+	 *
+	 * @throws WP_CLI\ExitException The thrown exception.
+	 */
+	public function remove_duplicate_postmeta() {
+
+		$start = microtime( true );
+
+		try {
+			WP_CLI::log( 'Removing duplicate postmeta records...' );
+
+			$deleted_rows = Duplicated_Postmeta::remove();
+
+			if ( $deleted_rows ) {
+				WP_CLI::success( "Removed $deleted_rows duplicate postmeta record/s" );
+			} else {
+				WP_CLI::log( 'No duplicate postmeta record found.' );
+			}
+		} catch ( \Error $e ) {
+			WP_CLI::error( $e->getMessage() );
+		} catch ( \Exception $e ) {
+			WP_CLI::log( 'Exception: ' . $e->getMessage() );
+		}
+
+		$seconds_elapsed = microtime( true ) - $start;
+		WP_CLI::log( 'Execution duration: ' . round( $seconds_elapsed ) . ' seconds' );
+	}
+
+	// Add here new sub-commands e.g. wp p4-gblocks new_sub_command.
 	// public function new_sub_command() {}.
 }
 

--- a/classes/command/class-duplicated-postmeta.php
+++ b/classes/command/class-duplicated-postmeta.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Detect and remove duplicate postmeta command
+ *
+ * @package P4GBKS
+ */
+
+namespace P4GBKS\Command;
+
+/**
+ * Class for detect and remove duplicate postmeta records.
+ */
+class Duplicated_Postmeta {
+
+	/**
+	 * List of meta_key check in duplicate list.
+	 *
+	 * @const array META_KEY_LIST.
+	 */
+	public const META_KEY_LIST = [
+		'sm_cloud',
+		'weight',
+		'_credit_text',
+		'_wp_attachment_image_alt',
+		'_searchwp_last_index',
+		'_media_restriction',
+	];
+
+	/**
+	 * Remove duplicate postmeta records
+	 *
+	 * @return int
+	 */
+	public static function remove() {
+
+		global $wpdb;
+
+		// phpcs:disable
+		$sql = "DELETE t1 FROM wp_postmeta t1 
+				INNER JOIN wp_postmeta t2  
+				WHERE  t1.meta_id < t2.meta_id 
+				AND  t1.meta_key = t2.meta_key 
+				AND t1.post_id = t2.post_id 
+				AND t1.meta_key IN (" . self::generate_placeholders( self::META_KEY_LIST, 1 ) . ")";
+
+		$prepared_sql = $wpdb->prepare( $sql, self::META_KEY_LIST );
+
+		return $wpdb->query( $prepared_sql );
+		// phpcs:enable
+	}
+
+	/**
+	 * Detect duplicate postmeta records
+	 *
+	 * @return object
+	 */
+	public static function detect() {
+
+		global $wpdb;
+
+		// phpcs:disable
+		$sql = "SELECT `post_id`, COUNT(meta_id) AS all_count , COUNT(DISTINCT meta_key) AS unique_count
+				FROM `wp_postmeta`
+				WHERE meta_key IN (" . self::generate_placeholders( self::META_KEY_LIST, 1 ) . ")
+				GROUP by `post_id`
+				HAVING all_count <> unique_count 
+				ORDER BY `all_count` DESC ";
+
+		$prepared_sql = $wpdb->prepare( $sql, self::META_KEY_LIST );
+
+		return $wpdb->get_results( $prepared_sql );
+		// phpcs:enable
+	}
+
+
+	/**
+	 * Generate a bunch of placeholders for use in an IN query.
+	 *
+	 * @param array $items The items to generate placeholders for.
+	 * @param int   $start_index The start index to use for creating the placeholders.
+	 * @return string The generated placeholders string.
+	 */
+	private static function generate_placeholders( array $items, int $start_index ): string {
+		$placeholders = [];
+		foreach ( range( $start_index, count( $items ) + $start_index - 1 ) as $i ) {
+			$placeholders[] = "'%$i\$s'";
+		}
+		return implode( ',', $placeholders );
+	}
+}

--- a/classes/controller/menu/class-postmeta-check-controller.php
+++ b/classes/controller/menu/class-postmeta-check-controller.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Post meta duplicate records check class
+ *
+ * @package P4BKS\Controllers\Menu
+ */
+
+namespace P4GBKS\Controllers\Menu;
+
+use P4GBKS\Command\Duplicated_Postmeta;
+
+/**
+ * Class Postmeta_Check_Controller
+ */
+class Postmeta_Check_Controller extends Controller {
+	/**
+	 * Create menu/submenu entry.
+	 */
+	public function create_admin_menu() {
+		$current_user = wp_get_current_user();
+		if ( in_array( 'administrator', $current_user->roles, true ) ) {
+			add_submenu_page(
+				P4GBKS_PLUGIN_SLUG_NAME,
+				__( 'Postmeta Check', 'planet4-blocks-backend' ),
+				__( 'Postmeta Check', 'planet4-blocks-backend' ),
+				'manage_options',
+				'postmeta_report',
+				[ $this, 'postmeta_check' ]
+			);
+		}
+	}
+
+	/**
+	 * Handle form submit.
+	 *
+	 * @param mixed[] $data The form data.
+	 */
+	public function handle_submit( &$data ) {
+		$remove_duplicate_postmeta = filter_input( INPUT_POST, 'delete_duplicate_postmeta', FILTER_SANITIZE_NUMBER_INT );
+		if ( 'POST' === $_SERVER['REQUEST_METHOD'] && $remove_duplicate_postmeta ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			try {
+				$deleted_rows = Duplicated_Postmeta::remove();
+			} catch ( \Error $e ) {
+				$data['message'] = $e->getMessage();
+			} catch ( \Exception $e ) {
+				$data['message'] = __( 'Exception: ', 'planet4-blocks-backend' ) . $e->getMessage();
+			}
+
+			if ( $deleted_rows ) {
+				// translators: %d = The duplicate postmeta count.
+				$data['message'] = sprintf( __( 'Remove %d duplicate postmeta records successfully.', 'planet4-blocks-backend' ), $deleted_rows );
+			} else {
+				$data['message'] = __( 'No duplicate postmeta record found.', 'planet4-blocks-backend' );
+			}
+		}
+	}
+
+	/**
+	 * Render the admin page with duplicate postmeta details.
+	 */
+	public function postmeta_check() {
+		$data = [];
+
+		$this->handle_submit( $data );
+		$data['duplicate_postmeta'] = Duplicated_Postmeta::detect();
+		$data['postmeta_keys']      = Duplicated_Postmeta::META_KEY_LIST;
+
+		$this->view->block( 'duplicate-postmeta-report', $data, 'twig', '' );
+	}
+}

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -278,6 +278,7 @@ P4GBKS\Loader::get_instance(
 		\P4GBKS\Controllers\Menu\Blocks_Usage_Controller::class,
 		\P4GBKS\Controllers\Menu\Reusable_Blocks_Controller::class,
 		\P4GBKS\Controllers\Menu\Archive_Import::class,
+		\P4GBKS\Controllers\Menu\Postmeta_Check_Controller::class,
 	],
 	\P4GBKS\Views\View::class
 );

--- a/templates/duplicate-postmeta-report.twig
+++ b/templates/duplicate-postmeta-report.twig
@@ -1,0 +1,54 @@
+{% block duplicate_postmeta_report %}
+
+	<div id="duplicate_postmeta_div" class="wrap">
+		<h2>{{ __( 'Duplicate Postmeta', 'planet4-blocks-backend' ) }}</h2>
+		</div>
+		<p>{{ __( 'Check duplicate postmeta records for below meta_key\'s', 'planet4-blocks-backend' ) }} - </p>
+		{% for postmeta_key in postmeta_keys %}
+			<p> - {{ postmeta_key }}</p>
+		{% endfor %}
+
+		<form id="p4bks_duplicate_postmeta_form" name="p4bks_duplicate_postmeta_form" method="post">
+		<p class="submit">
+			<input type="hidden" name="delete_duplicate_postmeta" value="1">
+			<input type="submit" name="remove_duplicate_postmenta" id="p4bks_remove_duplicate_button" class="button button-primary" value="{{ __( 'Remove Duplicate Postmeta', 'planet4-blocks-backend' ) }}">
+			<BR><BR>
+			<span class="convert-blocks-response cp-success">{{ message }}</span>
+			</p>
+		</form>
+		<div class="clear"></div>
+
+		<hr>
+		<h2>{{ __( 'Duplicate postmeta report', 'planet4-blocks-backend' ) }}</h2>
+		<table>
+		<tr>
+			<th style="padding: 0px 50px 0px 0px;">{{ __( 'Post ID', 'planet4-blocks-backend' ) }}</th>
+			<th>{{ __( 'Postmeta count', 'planet4-blocks-backend' ) }}</th>
+			<th>{{ __( 'Unique postmeta count', 'planet4-blocks-backend' ) }}</th>
+		</tr>
+		{% set all_count_total = 0 %}
+		{% set unique_count_total = 0 %}
+		{% for result in duplicate_postmeta %}
+			<tr>
+				<td>{{ result.post_id }}</td>
+				<td>{{ result.all_count }}</td>
+				<td>{{ result.unique_count }}</td>
+			</tr>
+			{% set all_count_total = all_count_total + result.all_count %}
+			{% set unique_count_total = unique_count_total + result.unique_count %}
+		{% endfor %}
+		{% if not duplicate_postmeta %}
+			<tr><td colspan="3"></td></tr>
+			<tr>
+				<td colspan="3">{{ __( 'No duplicate postmeta record/s found.', 'planet4-blocks-backend' ) }}</td>
+			</tr>
+		{% else %}
+			<tr>
+				<td><strong>{{ __( 'Total', 'planet4-blocks-backend' ) }}</strong></td>
+				<td><strong>{{ all_count_total }}</strong></td>
+				<td><strong>{{ unique_count_total }}</strong></td>
+			</tr>
+		{% endif %}
+		</table>
+
+{% endblock %}


### PR DESCRIPTION
[JIRA 4774](https://jira.greenpeace.org/browse/PLANET-4774)

- Add duplicate postmeta report in WP admin under "Blocks" menu
- The admin menu is visible only to 'administrator' user
- Add "Duplicate Postmeta" button on top of report to delete all duplicate postmeta records
- Add WP CLI command  to clean duplicate postmeta (`wp p4-gblocks remove_duplicate_postmeta`)

eg. https://k8s.p4.greenpeace.org/sagardev/wp-admin/admin.php?page=postmeta_report