### PR TITLE
Planet 5058 - Table background colors

### DIFF
--- a/assets/src/BlockFilters.js
+++ b/assets/src/BlockFilters.js
@@ -1,10 +1,12 @@
 const { addFilter } = wp.hooks;
 
 import P4ButtonEdit from './components/p4_button/edit';
+import P4TableEdit from './components/p4_table/edit';
 
 export const addBlockFilters = () => {
   addFileBlockFilter();
   addButtonBlockFilter();
+  addTableBlockFilter();
 };
 
 const addFileBlockFilter = () => {
@@ -40,4 +42,24 @@ const addButtonBlockFilter = () => {
   };
 
   addFilter('blocks.registerBlockType', 'planet4-blocks/filters/button', updateButtonBlockEditMethod);
+};
+
+const addTableBlockFilter = () => {
+
+  const updateTableBlockEditMethod = (settings, name) => {
+
+    if ('core/table' !== name) {
+      return settings;
+    }
+
+    if ( settings.name === 'core/table' ) {
+      lodash.assign( settings, {
+        edit: P4TableEdit,
+      } );
+    }
+
+    return settings;
+  };
+
+  addFilter('blocks.registerBlockType', 'planet4-blocks/filters/table', updateTableBlockEditMethod);
 };

--- a/assets/src/components/p4_table/edit.js
+++ b/assets/src/components/p4_table/edit.js
@@ -1,0 +1,686 @@
+/**
+ * This file is copy of the table block edit.js (https://github.com/WordPress/gutenberg/blob/7dd6c58c3c6e17c85423fff7a666eab29d749689/packages/block-library/src/table/edit.js), with customize changes.
+ * Customize changes(PLANET-5058) :
+ *  - Added custom background colors for header, odd/even rows and footer.
+ */
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import {
+	InspectorControls,
+	BlockControls,
+	RichText,
+	PanelColorSettings,
+	createCustomColorsHOC,
+	BlockIcon,
+	AlignmentToolbar,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	DropdownMenu,
+	PanelBody,
+	Placeholder,
+	TextControl,
+	ToggleControl,
+	ToolbarGroup,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import {
+	createTable,
+	updateSelectedCell,
+	getCellAttribute,
+	insertRow,
+	deleteRow,
+	insertColumn,
+	deleteColumn,
+	toggleSection,
+	isEmptyTableSection,
+} from './state';
+
+const COLORS_VARIABLES_MAP = {
+  // Grey variables (default)
+  '#f5f7f8': {
+    'table-header-background': '#45494c',
+    'table-even-row-background': '#f5f7f8',
+    'table-odd-row-background': '#ececec',
+    'table-footer-background': '#e0e4e7'
+  },
+  // Green variables
+  '#eafee7': {
+    'table-header-background': '#073d14',
+    'table-even-row-background': '#eafee7',
+    'table-odd-row-background': '#d0fac9',
+    'table-footer-background': '#d1e8cd'
+  },
+  // Blue variables
+  '#e7f5fe': {
+    'table-header-background': '#074365',
+    'table-even-row-background': '#e7f5fe',
+    'table-odd-row-background': '#c9e7fa',
+    'table-footer-background': '#c3d7e2'
+  }
+}
+
+const BACKGROUND_COLORS = [
+	{
+		color: '#f5f7f8',
+    name: 'Grey',
+    slug: 'grey'
+	},
+	{
+		color: '#eafee7',
+    name: 'Green',
+    slug: 'green'
+	},
+	{
+		color: '#e7f5fe',
+    name: 'Blue',
+    slug: 'blue'
+	}
+];
+
+const ALIGNMENT_CONTROLS = [
+	{
+		icon: "editor-alignleft",
+		title: __( 'Align Column Left' ),
+		align: 'left',
+	},
+	{
+		icon: "editor-aligncenter",
+		title: __( 'Align Column Center' ),
+		align: 'center',
+	},
+	{
+		icon: "editor-alignright",
+		title: __( 'Align Column Right' ),
+		align: 'right',
+	},
+];
+
+const withCustomBackgroundColors = createCustomColorsHOC( BACKGROUND_COLORS );
+
+export class TableEdit extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.onCreateTable = this.onCreateTable.bind( this );
+		this.onChangeFixedLayout = this.onChangeFixedLayout.bind( this );
+		this.onChange = this.onChange.bind( this );
+		this.onChangeInitialColumnCount = this.onChangeInitialColumnCount.bind(
+			this
+		);
+		this.onChangeInitialRowCount = this.onChangeInitialRowCount.bind(
+			this
+		);
+		this.renderSection = this.renderSection.bind( this );
+		this.getTableControls = this.getTableControls.bind( this );
+		this.onInsertRow = this.onInsertRow.bind( this );
+		this.onInsertRowBefore = this.onInsertRowBefore.bind( this );
+		this.onInsertRowAfter = this.onInsertRowAfter.bind( this );
+		this.onDeleteRow = this.onDeleteRow.bind( this );
+		this.onInsertColumn = this.onInsertColumn.bind( this );
+		this.onInsertColumnBefore = this.onInsertColumnBefore.bind( this );
+		this.onInsertColumnAfter = this.onInsertColumnAfter.bind( this );
+		this.onDeleteColumn = this.onDeleteColumn.bind( this );
+		this.onToggleHeaderSection = this.onToggleHeaderSection.bind( this );
+		this.onToggleFooterSection = this.onToggleFooterSection.bind( this );
+		this.onChangeColumnAlignment = this.onChangeColumnAlignment.bind(
+			this
+		);
+		this.getCellAlignment = this.getCellAlignment.bind( this );
+
+		this.state = {
+			initialRowCount: 2,
+			initialColumnCount: 2,
+			selectedCell: null,
+		};
+	}
+
+	/**
+	 * Updates the initial column count used for table creation.
+	 *
+	 * @param {number} initialColumnCount New initial column count.
+	 */
+	onChangeInitialColumnCount( initialColumnCount ) {
+		this.setState( { initialColumnCount } );
+	}
+
+	/**
+	 * Updates the initial row count used for table creation.
+	 *
+	 * @param {number} initialRowCount New initial row count.
+	 */
+	onChangeInitialRowCount( initialRowCount ) {
+		this.setState( { initialRowCount } );
+	}
+
+	/**
+	 * Creates a table based on dimensions in local state.
+	 *
+	 * @param {Object} event Form submit event.
+	 */
+	onCreateTable( event ) {
+		event.preventDefault();
+
+		const { setAttributes } = this.props;
+		let { initialRowCount, initialColumnCount } = this.state;
+
+		initialRowCount = parseInt( initialRowCount, 10 ) || 2;
+		initialColumnCount = parseInt( initialColumnCount, 10 ) || 2;
+
+		setAttributes(
+			createTable( {
+				rowCount: initialRowCount,
+				columnCount: initialColumnCount,
+			} )
+		);
+	}
+
+	/**
+	 * Toggles whether the table has a fixed layout or not.
+	 */
+	onChangeFixedLayout() {
+		const { attributes, setAttributes } = this.props;
+		const { hasFixedLayout } = attributes;
+
+		setAttributes( { hasFixedLayout: ! hasFixedLayout } );
+	}
+
+	/**
+	 * Changes the content of the currently selected cell.
+	 *
+	 * @param {Array} content A RichText content value.
+	 */
+	onChange( content ) {
+		const { selectedCell } = this.state;
+
+		if ( ! selectedCell ) {
+			return;
+		}
+
+		const { attributes, setAttributes } = this.props;
+
+		setAttributes(
+			updateSelectedCell(
+				attributes,
+				selectedCell,
+				( cellAttributes ) => ( {
+					...cellAttributes,
+					content,
+				} )
+			)
+		);
+	}
+
+	/**
+	 * Align text within the a column.
+	 *
+	 * @param {string} align The new alignment to apply to the column.
+	 */
+	onChangeColumnAlignment( align ) {
+		const { selectedCell } = this.state;
+
+		if ( ! selectedCell ) {
+			return;
+		}
+
+		// Convert the cell selection to a column selection so that alignment
+		// is applied to the entire column.
+		const columnSelection = {
+			type: 'column',
+			columnIndex: selectedCell.columnIndex,
+		};
+
+		const { attributes, setAttributes } = this.props;
+		const newAttributes = updateSelectedCell(
+			attributes,
+			columnSelection,
+			( cellAttributes ) => ( {
+				...cellAttributes,
+				align,
+			} )
+		);
+		setAttributes( newAttributes );
+	}
+
+	/**
+	 * Get the alignment of the currently selected cell.
+	 *
+	 * @return {string} The new alignment to apply to the column.
+	 */
+	getCellAlignment() {
+		const { selectedCell } = this.state;
+
+		if ( ! selectedCell ) {
+			return;
+		}
+
+		const { attributes } = this.props;
+
+		return getCellAttribute( attributes, selectedCell, 'align' );
+	}
+
+	/**
+	 * Add or remove a `head` table section.
+	 */
+	onToggleHeaderSection() {
+		const { attributes, setAttributes } = this.props;
+		setAttributes( toggleSection( attributes, 'head' ) );
+	}
+
+	/**
+	 * Add or remove a `foot` table section.
+	 */
+	onToggleFooterSection() {
+		const { attributes, setAttributes } = this.props;
+		setAttributes( toggleSection( attributes, 'foot' ) );
+	}
+
+	/**
+	 * Inserts a row at the currently selected row index, plus `delta`.
+	 *
+	 * @param {number} delta Offset for selected row index at which to insert.
+	 */
+	onInsertRow( delta ) {
+		const { selectedCell } = this.state;
+
+		if ( ! selectedCell ) {
+			return;
+		}
+
+		const { attributes, setAttributes } = this.props;
+		const { sectionName, rowIndex } = selectedCell;
+
+		this.setState( { selectedCell: null } );
+		setAttributes(
+			insertRow( attributes, {
+				sectionName,
+				rowIndex: rowIndex + delta,
+			} )
+		);
+	}
+
+	/**
+	 * Inserts a row before the currently selected row.
+	 */
+	onInsertRowBefore() {
+		this.onInsertRow( 0 );
+	}
+
+	/**
+	 * Inserts a row after the currently selected row.
+	 */
+	onInsertRowAfter() {
+		this.onInsertRow( 1 );
+	}
+
+	/**
+	 * Deletes the currently selected row.
+	 */
+	onDeleteRow() {
+		const { selectedCell } = this.state;
+
+		if ( ! selectedCell ) {
+			return;
+		}
+
+		const { attributes, setAttributes } = this.props;
+		const { sectionName, rowIndex } = selectedCell;
+
+		this.setState( { selectedCell: null } );
+		setAttributes( deleteRow( attributes, { sectionName, rowIndex } ) );
+	}
+
+	/**
+	 * Inserts a column at the currently selected column index, plus `delta`.
+	 *
+	 * @param {number} delta Offset for selected column index at which to insert.
+	 */
+	onInsertColumn( delta = 0 ) {
+		const { selectedCell } = this.state;
+
+		if ( ! selectedCell ) {
+			return;
+		}
+
+		const { attributes, setAttributes } = this.props;
+		const { columnIndex } = selectedCell;
+
+		this.setState( { selectedCell: null } );
+		setAttributes(
+			insertColumn( attributes, {
+				columnIndex: columnIndex + delta,
+			} )
+		);
+	}
+
+	/**
+	 * Inserts a column before the currently selected column.
+	 */
+	onInsertColumnBefore() {
+		this.onInsertColumn( 0 );
+	}
+
+	/**
+	 * Inserts a column after the currently selected column.
+	 */
+	onInsertColumnAfter() {
+		this.onInsertColumn( 1 );
+	}
+
+	/**
+	 * Deletes the currently selected column.
+	 */
+	onDeleteColumn() {
+		const { selectedCell } = this.state;
+
+		if ( ! selectedCell ) {
+			return;
+		}
+
+		const { attributes, setAttributes } = this.props;
+		const { sectionName, columnIndex } = selectedCell;
+
+		this.setState( { selectedCell: null } );
+		setAttributes(
+			deleteColumn( attributes, { sectionName, columnIndex } )
+		);
+	}
+
+	/**
+	 * Creates an onFocus handler for a specified cell.
+	 *
+	 * @param {Object} cellLocation Object with `section`, `rowIndex`, and
+	 *                              `columnIndex` properties.
+	 *
+	 * @return {Function} Function to call on focus.
+	 */
+	createOnFocus( cellLocation ) {
+		return () => {
+			this.setState( {
+				selectedCell: {
+					...cellLocation,
+					type: 'cell',
+				},
+			} );
+		};
+	}
+
+	/**
+	 * Gets the table controls to display in the block toolbar.
+	 *
+	 * @return {Array} Table controls.
+	 */
+	getTableControls() {
+		const { selectedCell } = this.state;
+
+		return [
+			{
+				icon: "table-row-before",
+				title: __( 'Add Row Before' ),
+				isDisabled: ! selectedCell,
+				onClick: this.onInsertRowBefore,
+			},
+			{
+				icon: "table-row-after",
+				title: __( 'Add Row After' ),
+				isDisabled: ! selectedCell,
+				onClick: this.onInsertRowAfter,
+			},
+			{
+				icon: "table-row-delete",
+				title: __( 'Delete Row' ),
+				isDisabled: ! selectedCell,
+				onClick: this.onDeleteRow,
+			},
+			{
+				icon: "table-col-before",
+				title: __( 'Add Column Before' ),
+				isDisabled: ! selectedCell,
+				onClick: this.onInsertColumnBefore,
+			},
+			{
+				icon: "table-col-after",
+				title: __( 'Add Column After' ),
+				isDisabled: ! selectedCell,
+				onClick: this.onInsertColumnAfter,
+			},
+			{
+				icon: "table-col-delete",
+				title: __( 'Delete Column' ),
+				isDisabled: ! selectedCell,
+				onClick: this.onDeleteColumn,
+			},
+		];
+	}
+
+	/**
+	 * Renders a table section.
+	 *
+	 * @param {Object} options
+	 * @param {string} options.type Section type: head, body, or foot.
+	 * @param {Array}  options.rows The rows to render.
+	 *
+	 * @return {Object} React element for the section.
+	 */
+	renderSection( { name, rows } ) {
+		if ( isEmptyTableSection( rows ) ) {
+			return null;
+		}
+
+		const Tag = `t${ name }`;
+
+		return (
+			<Tag>
+				{ rows.map( ( { cells }, rowIndex ) => (
+					<tr key={ rowIndex }>
+						{ cells.map(
+							(
+								{ content, tag: CellTag, scope, align },
+								columnIndex
+							) => {
+								const cellLocation = {
+									sectionName: name,
+									rowIndex,
+									columnIndex,
+								};
+
+								const cellClasses = classnames(
+									{
+										[ `has-text-align-${ align }` ]: align,
+									},
+									'wp-block-table__cell-content'
+								);
+
+								let placeholder = '';
+								if ( name === 'head' ) {
+									placeholder = __( 'Header label' );
+								} else if ( name === 'foot' ) {
+									placeholder = __( 'Footer label' );
+								}
+
+								return (
+									<RichText
+										tagName={ CellTag }
+										key={ columnIndex }
+										className={ cellClasses }
+										scope={
+											CellTag === 'th' ? scope : undefined
+										}
+										value={ content }
+										onChange={ this.onChange }
+										unstableOnFocus={ this.createOnFocus(
+											cellLocation
+										) }
+										placeholder={ placeholder }
+									/>
+								);
+							}
+						) }
+					</tr>
+				) ) }
+			</Tag>
+		);
+	}
+
+	componentDidUpdate() {
+		const { isSelected } = this.props;
+		const { selectedCell } = this.state;
+
+		if ( ! isSelected && selectedCell ) {
+			this.setState( { selectedCell: null } );
+		}
+	}
+
+	render() {
+		const {
+			attributes,
+			className,
+			backgroundColor,
+			setBackgroundColor,
+			setAttributes,
+        } = this.props;
+        
+		const { initialRowCount, initialColumnCount } = this.state;
+		const { hasFixedLayout, caption, head, body, foot } = attributes;
+		const isEmpty =
+			isEmptyTableSection( head ) &&
+			isEmptyTableSection( body ) &&
+			isEmptyTableSection( foot );
+		const Section = this.renderSection;
+
+		if ( isEmpty ) {
+			return (
+				<Placeholder
+					label={ __( 'Table' ) }
+					icon={ <BlockIcon icon="block-table" showColors /> }
+					instructions={ __( 'Insert a table for sharing data.' ) }
+				>
+					<form
+						className="wp-block-table__placeholder-form"
+						onSubmit={ this.onCreateTable }
+					>
+						<TextControl
+							type="number"
+							label={ __( 'Column Count' ) }
+							value={ initialColumnCount }
+							onChange={ this.onChangeInitialColumnCount }
+							min="1"
+							className="wp-block-table__placeholder-input"
+						/>
+						<TextControl
+							type="number"
+							label={ __( 'Row Count' ) }
+							value={ initialRowCount }
+							onChange={ this.onChangeInitialRowCount }
+							min="1"
+							className="wp-block-table__placeholder-input"
+						/>
+						<Button
+							className="wp-block-table__placeholder-button"
+							isSecondary
+							type="submit"
+						>
+							{ __( 'Create Table' ) }
+						</Button>
+					</form>
+				</Placeholder>
+			);
+		}
+
+		const tableClasses = classnames( backgroundColor.class, {
+      'has-fixed-layout': hasFixedLayout
+    } );
+
+		return (
+			<>
+				<BlockControls>
+					<ToolbarGroup>
+						<DropdownMenu
+							hasArrowIndicator
+							icon="editor-table"
+							label={ __( 'Edit table' ) }
+							controls={ this.getTableControls() }
+						/>
+					</ToolbarGroup>
+					<AlignmentToolbar
+						label={ __( 'Change column alignment' ) }
+						alignmentControls={ ALIGNMENT_CONTROLS }
+						value={ this.getCellAlignment() }
+						onChange={ ( nextAlign ) =>
+							this.onChangeColumnAlignment( nextAlign )
+						}
+						onHover={ this.onHoverAlignment }
+					/>
+				</BlockControls>
+				<InspectorControls>
+					<PanelBody
+						title={ __( 'Table settings' ) }
+						className="blocks-table-settings"
+					>
+						<ToggleControl
+							label={ __( 'Fixed width table cells' ) }
+							checked={ !! hasFixedLayout }
+							onChange={ this.onChangeFixedLayout }
+						/>
+						<ToggleControl
+							label={ __( 'Header section' ) }
+							checked={ !! ( head && head.length ) }
+							onChange={ this.onToggleHeaderSection }
+						/>
+						<ToggleControl
+							label={ __( 'Footer section' ) }
+							checked={ !! ( foot && foot.length ) }
+							onChange={ this.onToggleFooterSection }
+						/>
+					</PanelBody>
+					<PanelColorSettings
+						title={ __( 'Color settings' ) }
+						initialOpen={ false }
+						colorSettings={ [
+							{
+								value: backgroundColor.color,
+								onChange: setBackgroundColor,
+								label: __( 'Background color' ),
+								disableCustomColors: true,
+								colors: BACKGROUND_COLORS,
+							},
+						] }
+					/>
+				</InspectorControls>
+				<figure className={ className }>
+					<table className={ tableClasses }>
+						<Section name="head" rows={ head } />
+						<Section name="body" rows={ body } />
+						<Section name="foot" rows={ foot } />
+					</table>
+					<RichText
+						tagName="figcaption"
+						placeholder={ __( 'Write caption…' ) }
+						value={ caption }
+						onChange={ ( value ) =>
+							setAttributes( { caption: value } )
+						}
+						// Deselect the selected table cell when the caption is focused.
+						unstableOnFocus={ () =>
+							this.setState( { selectedCell: null } )
+						}
+					/>
+				</figure>
+			</>
+		);
+	}
+}
+
+export default withCustomBackgroundColors( 'backgroundColor' )( TableEdit );

--- a/assets/src/components/p4_table/edit.js
+++ b/assets/src/components/p4_table/edit.js
@@ -599,7 +599,7 @@ export class TableEdit extends Component {
 			);
 		}
 
-		const tableClasses = classnames( backgroundColor.class, {
+		const tableClasses = classnames( backgroundColor.class, className, {
       'has-fixed-layout': hasFixedLayout
     } );
 
@@ -659,7 +659,7 @@ export class TableEdit extends Component {
 						] }
 					/>
 				</InspectorControls>
-				<figure className={ className }>
+				<figure>
 					<table className={ tableClasses }>
 						<Section name="head" rows={ head } />
 						<Section name="body" rows={ body } />

--- a/assets/src/components/p4_table/edit.js
+++ b/assets/src/components/p4_table/edit.js
@@ -599,7 +599,7 @@ export class TableEdit extends Component {
 			);
 		}
 
-		const tableClasses = classnames( backgroundColor.class, className, {
+		const tableClasses = classnames( backgroundColor.class, {
       'has-fixed-layout': hasFixedLayout
     } );
 
@@ -659,7 +659,7 @@ export class TableEdit extends Component {
 						] }
 					/>
 				</InspectorControls>
-				<figure>
+				<figure className={ className }>
 					<table className={ tableClasses }>
 						<Section name="head" rows={ head } />
 						<Section name="body" rows={ body } />

--- a/assets/src/components/p4_table/edit.js
+++ b/assets/src/components/p4_table/edit.js
@@ -48,30 +48,6 @@ import {
 	isEmptyTableSection,
 } from './state';
 
-const COLORS_VARIABLES_MAP = {
-  // Grey variables (default)
-  '#f5f7f8': {
-    'table-header-background': '#45494c',
-    'table-even-row-background': '#f5f7f8',
-    'table-odd-row-background': '#ececec',
-    'table-footer-background': '#e0e4e7'
-  },
-  // Green variables
-  '#eafee7': {
-    'table-header-background': '#073d14',
-    'table-even-row-background': '#eafee7',
-    'table-odd-row-background': '#d0fac9',
-    'table-footer-background': '#d1e8cd'
-  },
-  // Blue variables
-  '#e7f5fe': {
-    'table-header-background': '#074365',
-    'table-even-row-background': '#e7f5fe',
-    'table-odd-row-background': '#c9e7fa',
-    'table-footer-background': '#c3d7e2'
-  }
-}
-
 const BACKGROUND_COLORS = [
 	{
 		color: '#f5f7f8',

--- a/assets/src/components/p4_table/state.js
+++ b/assets/src/components/p4_table/state.js
@@ -1,0 +1,327 @@
+/**
+ * This file is copy of the table block state.js (https://github.com/WordPress/gutenberg/blob/7dd6c58c3c6e17c85423fff7a666eab29d749689/packages/block-library/src/table/state.js)
+ */
+
+/**
+ * External dependencies
+ */
+import { times, get, mapValues, every, pick } from 'lodash';
+
+const INHERITED_COLUMN_ATTRIBUTES = [ 'align' ];
+
+/**
+ * Creates a table state.
+ *
+ * @param {Object} options
+ * @param {number} options.rowCount    Row count for the table to create.
+ * @param {number} options.columnCount Column count for the table to create.
+ *
+ * @return {Object} New table state.
+ */
+export function createTable( { rowCount, columnCount } ) {
+	return {
+		body: times( rowCount, () => ( {
+			cells: times( columnCount, () => ( {
+				content: '',
+				tag: 'td',
+			} ) ),
+		} ) ),
+	};
+}
+
+/**
+ * Returns the first row in the table.
+ *
+ * @param {Object} state Current table state.
+ *
+ * @return {Object} The first table row.
+ */
+export function getFirstRow( state ) {
+	if ( ! isEmptyTableSection( state.head ) ) {
+		return state.head[ 0 ];
+	}
+	if ( ! isEmptyTableSection( state.body ) ) {
+		return state.body[ 0 ];
+	}
+	if ( ! isEmptyTableSection( state.foot ) ) {
+		return state.foot[ 0 ];
+	}
+}
+
+/**
+ * Gets an attribute for a cell.
+ *
+ * @param {Object} state 		 Current table state.
+ * @param {Object} cellLocation  The location of the cell
+ * @param {string} attributeName The name of the attribute to get the value of.
+ *
+ * @return {*} The attribute value.
+ */
+export function getCellAttribute( state, cellLocation, attributeName ) {
+	const { sectionName, rowIndex, columnIndex } = cellLocation;
+	return get( state, [
+		sectionName,
+		rowIndex,
+		'cells',
+		columnIndex,
+		attributeName,
+	] );
+}
+
+/**
+ * Returns updated cell attributes after applying the `updateCell` function to the selection.
+ *
+ * @param {Object}   state      The block attributes.
+ * @param {Object}   selection  The selection of cells to update.
+ * @param {Function} updateCell A function to update the selected cell attributes.
+ *
+ * @return {Object} New table state including the updated cells.
+ */
+export function updateSelectedCell( state, selection, updateCell ) {
+	if ( ! selection ) {
+		return state;
+	}
+
+	const tableSections = pick( state, [ 'head', 'body', 'foot' ] );
+	const {
+		sectionName: selectionSectionName,
+		rowIndex: selectionRowIndex,
+	} = selection;
+
+	return mapValues( tableSections, ( section, sectionName ) => {
+		if ( selectionSectionName && selectionSectionName !== sectionName ) {
+			return section;
+		}
+
+		return section.map( ( row, rowIndex ) => {
+			if ( selectionRowIndex && selectionRowIndex !== rowIndex ) {
+				return row;
+			}
+
+			return {
+				cells: row.cells.map( ( cellAttributes, columnIndex ) => {
+					const cellLocation = {
+						sectionName,
+						columnIndex,
+						rowIndex,
+					};
+
+					if ( ! isCellSelected( cellLocation, selection ) ) {
+						return cellAttributes;
+					}
+
+					return updateCell( cellAttributes );
+				} ),
+			};
+		} );
+	} );
+}
+
+/**
+ * Returns whether the cell at `cellLocation` is included in the selection `selection`.
+ *
+ * @param {Object} cellLocation An object containing cell location properties.
+ * @param {Object} selection    An object containing selection properties.
+ *
+ * @return {boolean} True if the cell is selected, false otherwise.
+ */
+export function isCellSelected( cellLocation, selection ) {
+	if ( ! cellLocation || ! selection ) {
+		return false;
+	}
+
+	switch ( selection.type ) {
+		case 'column':
+			return (
+				selection.type === 'column' &&
+				cellLocation.columnIndex === selection.columnIndex
+			);
+		case 'cell':
+			return (
+				selection.type === 'cell' &&
+				cellLocation.sectionName === selection.sectionName &&
+				cellLocation.columnIndex === selection.columnIndex &&
+				cellLocation.rowIndex === selection.rowIndex
+			);
+	}
+}
+
+/**
+ * Inserts a row in the table state.
+ *
+ * @param {Object} state               Current table state.
+ * @param {Object} options
+ * @param {string} options.sectionName Section in which to insert the row.
+ * @param {number} options.rowIndex    Row index at which to insert the row.
+ *
+ * @return {Object} New table state.
+ */
+export function insertRow( state, { sectionName, rowIndex, columnCount } ) {
+	const firstRow = getFirstRow( state );
+	const cellCount =
+		columnCount === undefined
+			? get( firstRow, [ 'cells', 'length' ] )
+			: columnCount;
+
+	// Bail early if the function cannot determine how many cells to add.
+	if ( ! cellCount ) {
+		return state;
+	}
+
+	return {
+		[ sectionName ]: [
+			...state[ sectionName ].slice( 0, rowIndex ),
+			{
+				cells: times( cellCount, ( index ) => {
+					const firstCellInColumn = get(
+						firstRow,
+						[ 'cells', index ],
+						{}
+					);
+					const inheritedAttributes = pick(
+						firstCellInColumn,
+						INHERITED_COLUMN_ATTRIBUTES
+					);
+
+					return {
+						...inheritedAttributes,
+						content: '',
+						tag: sectionName === 'head' ? 'th' : 'td',
+					};
+				} ),
+			},
+			...state[ sectionName ].slice( rowIndex ),
+		],
+	};
+}
+
+/**
+ * Deletes a row from the table state.
+ *
+ * @param {Object} state               Current table state.
+ * @param {Object} options
+ * @param {string} options.sectionName Section in which to delete the row.
+ * @param {number} options.rowIndex    Row index to delete.
+ *
+ * @return {Object} New table state.
+ */
+export function deleteRow( state, { sectionName, rowIndex } ) {
+	return {
+		[ sectionName ]: state[ sectionName ].filter(
+			( row, index ) => index !== rowIndex
+		),
+	};
+}
+
+/**
+ * Inserts a column in the table state.
+ *
+ * @param {Object} state               Current table state.
+ * @param {Object} options
+ * @param {number} options.columnIndex Column index at which to insert the column.
+ *
+ * @return {Object} New table state.
+ */
+export function insertColumn( state, { columnIndex } ) {
+	const tableSections = pick( state, [ 'head', 'body', 'foot' ] );
+
+	return mapValues( tableSections, ( section, sectionName ) => {
+		// Bail early if the table section is empty.
+		if ( isEmptyTableSection( section ) ) {
+			return section;
+		}
+
+		return section.map( ( row ) => {
+			// Bail early if the row is empty or it's an attempt to insert past
+			// the last possible index of the array.
+			if ( isEmptyRow( row ) || row.cells.length < columnIndex ) {
+				return row;
+			}
+
+			return {
+				cells: [
+					...row.cells.slice( 0, columnIndex ),
+					{
+						content: '',
+						tag: sectionName === 'head' ? 'th' : 'td',
+					},
+					...row.cells.slice( columnIndex ),
+				],
+			};
+		} );
+	} );
+}
+
+/**
+ * Deletes a column from the table state.
+ *
+ * @param {Object} state               Current table state.
+ * @param {Object} options
+ * @param {number} options.columnIndex Column index to delete.
+ *
+ * @return {Object} New table state.
+ */
+export function deleteColumn( state, { columnIndex } ) {
+	const tableSections = pick( state, [ 'head', 'body', 'foot' ] );
+
+	return mapValues( tableSections, ( section ) => {
+		// Bail early if the table section is empty.
+		if ( isEmptyTableSection( section ) ) {
+			return section;
+		}
+
+		return section
+			.map( ( row ) => ( {
+				cells:
+					row.cells.length >= columnIndex
+						? row.cells.filter(
+								( cell, index ) => index !== columnIndex
+						  )
+						: row.cells,
+			} ) )
+			.filter( ( row ) => row.cells.length );
+	} );
+}
+
+/**
+ * Toggles the existance of a section.
+ *
+ * @param {Object} state       Current table state.
+ * @param {string} sectionName Name of the section to toggle.
+ *
+ * @return {Object} New table state.
+ */
+export function toggleSection( state, sectionName ) {
+	// Section exists, replace it with an empty row to remove it.
+	if ( ! isEmptyTableSection( state[ sectionName ] ) ) {
+		return { [ sectionName ]: [] };
+	}
+
+	// Get the length of the first row of the body to use when creating the header.
+	const columnCount = get( state, [ 'body', 0, 'cells', 'length' ], 1 );
+
+	// Section doesn't exist, insert an empty row to create the section.
+	return insertRow( state, { sectionName, rowIndex: 0, columnCount } );
+}
+
+/**
+ * Determines whether a table section is empty.
+ *
+ * @param {Object} section Table section state.
+ *
+ * @return {boolean} True if the table section is empty, false otherwise.
+ */
+export function isEmptyTableSection( section ) {
+	return ! section || ! section.length || every( section, isEmptyRow );
+}
+
+/**
+ * Determines whether a table row is empty.
+ *
+ * @param {Object} row Table row state.
+ *
+ * @return {boolean} True if the table section is empty, false otherwise.
+ */
+export function isEmptyRow( row ) {
+	return ! ( row.cells && row.cells.length );
+}

--- a/assets/src/styles/blocks.scss
+++ b/assets/src/styles/blocks.scss
@@ -24,6 +24,7 @@
 @import "blocks/core-overrides/Image";
 @import "blocks/core-overrides/BlockSpacing";
 @import "blocks/core-overrides/Separator";
+@import "blocks/core-overrides/Table";
 
 // Other
 @import "blocks/WideBlocks";

--- a/assets/src/styles/blocks/Spreadsheet.scss
+++ b/assets/src/styles/blocks/Spreadsheet.scss
@@ -24,9 +24,9 @@ table.spreadsheet-table {
   }
 
   th {
-    background: var(--spreadsheet-header-background, #45494c);
-    color: #ffffff;
-    border-bottom: 1px solid var(--spreadsheet-header-background, #45494c);
+    background: var(--spreadsheet-header-background, $table-header-grey);
+    color: $white;
+    border-bottom: 1px solid var(--spreadsheet-header-background, $table-header-grey);
     cursor: pointer;
     font-size: $font-size-sm;
     position: sticky;
@@ -34,11 +34,11 @@ table.spreadsheet-table {
   }
 
   tr {
+    color: $table-font-color;
+
     td {
       padding: 5px 20px;
-
-      background: var(--spreadsheet-even-row-background, #f5f7f8);
-      color: #020202;
+      background: var(--spreadsheet-even-row-background, $table-even-row-grey);
       font-size: $font-size-xs;
 
       @include x-large-and-up {
@@ -48,8 +48,7 @@ table.spreadsheet-table {
 
     &:nth-child(odd) {
       td {
-        background: var(--spreadsheet-odd-row-background, #ececec);
-        color: #020202;
+        background: var(--spreadsheet-odd-row-background, $table-odd-row-grey);
       }
     }
   }
@@ -61,7 +60,7 @@ table.spreadsheet-table {
   height: 2rem;
   margin: 10px 0;
   padding: 0 8px;
-  border-color: var(--spreadsheet-header-background, #45494c);
+  border-color: var(--spreadsheet-header-background, $table-header-grey);
   border: 1px solid;
 }
 

--- a/assets/src/styles/blocks/core-overrides/Table.scss
+++ b/assets/src/styles/blocks/core-overrides/Table.scss
@@ -62,4 +62,8 @@
       background-color: $table-odd-row-blue;
     }
   }
+
+  &:not(.is-style-stripes) table tbody tr:not(:last-child) {
+    border-bottom: 1px solid $white;
+  }
 }

--- a/assets/src/styles/blocks/core-overrides/Table.scss
+++ b/assets/src/styles/blocks/core-overrides/Table.scss
@@ -1,0 +1,65 @@
+
+// Table background colors (header, footer, odd/even rows)
+.wp-block-table {
+  table {
+    // Grey background (defaut)
+    th {
+      background-color: $table-header-grey;
+    }
+
+    tr {
+      background-color: $table-even-row-grey;
+    }
+
+    tfoot td {
+      background-color: $table-footer-grey;
+    }
+
+    // Green background
+    &.has-green-background-color {
+      th {
+        background-color: $table-header-green;
+      }
+
+      tr {
+        background-color: $table-even-row-green;
+      }
+
+      tfoot td {
+        background-color: $table-footer-green;
+      }
+    }
+
+    // Blue background
+    &.has-blue-background-color {
+      th {
+        background-color: $table-header-blue;
+      }
+
+      tr {
+        background-color: $table-even-row-blue;
+      }
+
+      tfoot td {
+        background-color: $table-footer-blue;
+      }
+    }
+  }
+
+  &.is-style-stripes table {
+    // Grey background (defaut)
+    tr:nth-child(odd) {
+      background-color: $table-odd-row-grey;
+    }
+
+    // Green background
+    &.has-green-background-color tr:nth-child(odd) {
+      background-color: $table-odd-row-green;
+    }
+
+    // Blue background
+    &.has-blue-background-color tr:nth-child(odd) {
+      background-color: $table-odd-row-blue;
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,25 +13,208 @@
       }
     },
     "@babel/core": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz",
-      "integrity": "sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.6.tgz",
+      "integrity": "sha512-nD3deLvbsApbHAHttzIssYqgb883yU/d9roe4RZymBCDaZryMJDbptVpEpeQuRh4BJ+SYI8le9YGxKvFEvl1Wg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.4",
-        "@babel/helpers": "^7.4.4",
-        "@babel/parser": "^7.4.5",
-        "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.5",
-        "@babel/types": "^7.4.4",
-        "convert-source-map": "^1.1.0",
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.9.6",
+        "@babel/helper-module-transforms": "^7.9.0",
+        "@babel/helpers": "^7.9.6",
+        "@babel/parser": "^7.9.6",
+        "@babel/template": "^7.8.6",
+        "@babel/traverse": "^7.9.6",
+        "@babel/types": "^7.9.6",
+        "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "json5": "^2.1.0",
-        "lodash": "^4.17.11",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.13",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
+          "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.9.6",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+          "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.9.5"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+          "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+          "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+          "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.8.3",
+            "@babel/helper-replace-supers": "^7.8.6",
+            "@babel/helper-simple-access": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/template": "^7.8.6",
+            "@babel/types": "^7.9.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+          "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.9.6.tgz",
+          "integrity": "sha512-qX+chbxkbArLyCImk3bWV+jB5gTNU/rsze+JlcF6Nf8tVTigPJSI1o1oBow/9Resa1yehUO9lIipsmu9oG4RzA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.8.3",
+            "@babel/helper-optimise-call-expression": "^7.8.3",
+            "@babel/traverse": "^7.9.6",
+            "@babel/types": "^7.9.6"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+          "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+          "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.0",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+          "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.8.6",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+          "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.6",
+            "@babel/types": "^7.8.6"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
+          "integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.6",
+            "@babel/helper-function-name": "^7.9.5",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.9.6",
+            "@babel/types": "^7.9.6",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+          "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "convert-source-map": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+          "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        }
       }
     },
     "@babel/generator": {
@@ -237,6 +420,12 @@
         "@babel/types": "^7.4.4"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+      "dev": true
+    },
     "@babel/helper-wrap-function": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
@@ -250,14 +439,122 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
-      "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.6.tgz",
+      "integrity": "sha512-tI4bUbldloLcHWoRUMAj4g1bF313M/o6fBKhIsb3QnGVPwRm9JsNf/gqMkQ7zjqReABiffPV6RWj7hEglID5Iw==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.9.6",
+        "@babel/types": "^7.9.6"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
+          "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.9.6",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+          "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.9.5"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+          "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.0",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+          "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.8.6",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+          "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.6",
+            "@babel/types": "^7.8.6"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
+          "integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.6",
+            "@babel/helper-function-name": "^7.9.5",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.9.6",
+            "@babel/types": "^7.9.6",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+          "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/highlight": {
@@ -7411,6 +7708,12 @@
         "globule": "^1.0.0"
       }
     },
+    "gensync": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -7643,6 +7946,27 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
+      }
+    },
+    "handlebars": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
@@ -8743,8 +9067,12 @@
     },
     "istanbul-reports": {
       "version": "2.2.6",
-      "resolved": "",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.1.2"
+      }
     },
     "jest": {
       "version": "24.9.0",
@@ -10166,20 +10494,12 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-      "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
+        "minimist": "^1.2.5"
       }
     },
     "jsprim": {
@@ -10764,6 +11084,12 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -15837,6 +16163,25 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
+        }
+      }
+    },
+    "uglify-js": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.3.tgz",
+      "integrity": "sha512-r5ImcL6QyzQGVimQoov3aL2ZScywrOgBXGndbWrdehKoSvGe/RmiE5Jpw/v+GvxODt6l2tpBXwA7n+qZVlHBMA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "commander": "~2.20.3"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
See https://jira.greenpeace.org/browse/PLANET-5058

We want to offer the same color options for the Table block as we do for the Spreadsheet block. The only difference is that tables also have a footer, which requires an additional color. This PR takes care of several things:
- Move table background colors to an override file, also add white border to table rows when no stripes ("regular" style)
- Create a custom `edit.js` file for the table block, based on a copy of [the original](https://github.com/WordPress/gutenberg/blob/7dd6c58c3c6e17c85423fff7a666eab29d749689/packages/block-library/src/table/edit.js)
- Add a copy of [the original](https://github.com/WordPress/gutenberg/blob/7dd6c58c3c6e17c85423fff7a666eab29d749689/packages/block-library/src/table/state.js) `state.js` file for table block, needed for import
- Add filter to use our custom table block instead of the core one
- Update Spreadsheet block to use newly created color variables

See corresponding styleguide PR [here](https://github.com/greenpeace/planet4-styleguide/pull/56) and master-theme [here](https://github.com/greenpeace/planet4-master-theme/pull/1093)