### PR TITLE
PLANET-5078 Print duplicate metakey counts in CLI cmd before deleting

### DIFF
--- a/classes/command/class-duplicated-postmeta.php
+++ b/classes/command/class-duplicated-postmeta.php
@@ -59,19 +59,15 @@ class Duplicated_Postmeta {
 		global $wpdb;
 
 		// phpcs:disable
-		$sql = "SELECT `post_id`, COUNT(meta_id) AS all_count , COUNT(DISTINCT meta_key) AS unique_count
+		$sql = "SELECT `meta_key`, COUNT(post_id) AS all_count , COUNT(DISTINCT post_id) AS unique_count
 				FROM `wp_postmeta`
-				WHERE meta_key IN (" . self::generate_placeholders( self::META_KEY_LIST, 1 ) . ")
-				GROUP by `post_id`
-				HAVING all_count <> unique_count 
-				ORDER BY `all_count` DESC ";
+				GROUP by `meta_key`
+				HAVING all_count <> unique_count
+				ORDER BY `all_count` DESC";
 
-		$prepared_sql = $wpdb->prepare( $sql, self::META_KEY_LIST );
-
-		return $wpdb->get_results( $prepared_sql );
+		return $wpdb->get_results( $sql );
 		// phpcs:enable
 	}
-
 
 	/**
 	 * Generate a bunch of placeholders for use in an IN query.

--- a/classes/controller/menu/class-postmeta-check-controller.php
+++ b/classes/controller/menu/class-postmeta-check-controller.php
@@ -50,7 +50,7 @@ class Postmeta_Check_Controller extends Controller {
 				// translators: %d = The duplicate postmeta count.
 				$data['message'] = sprintf( __( 'Remove %d duplicate postmeta records successfully.', 'planet4-blocks-backend' ), $deleted_rows );
 			} else {
-				$data['message'] = __( 'No duplicate postmeta record found.', 'planet4-blocks-backend' );
+				$data['message'] = __( 'No whitelisted duplicate postmeta records found.', 'planet4-blocks-backend' );
 			}
 		}
 	}

--- a/templates/duplicate-postmeta-report.twig
+++ b/templates/duplicate-postmeta-report.twig
@@ -3,7 +3,7 @@
 	<div id="duplicate_postmeta_div" class="wrap">
 		<h2>{{ __( 'Duplicate Postmeta', 'planet4-blocks-backend' ) }}</h2>
 		</div>
-		<p>{{ __( 'Check duplicate postmeta records for below meta_key\'s', 'planet4-blocks-backend' ) }} - </p>
+		<p>{{ __( 'Whitelisted meta_key\'s for delete operation', 'planet4-blocks-backend' ) }} - </p>
 		{% for postmeta_key in postmeta_keys %}
 			<p> - {{ postmeta_key }}</p>
 		{% endfor %}
@@ -22,31 +22,33 @@
 		<h2>{{ __( 'Duplicate postmeta report', 'planet4-blocks-backend' ) }}</h2>
 		<table>
 		<tr>
-			<th style="padding: 0px 50px 0px 0px;">{{ __( 'Post ID', 'planet4-blocks-backend' ) }}</th>
-			<th>{{ __( 'Postmeta count', 'planet4-blocks-backend' ) }}</th>
-			<th>{{ __( 'Unique postmeta count', 'planet4-blocks-backend' ) }}</th>
+			<th style="padding: 0px 50px 0px 0px;">{{ __( 'No.', 'planet4-blocks-backend' ) }}</th>
+			<th>{{ __( 'meta_key', 'planet4-blocks-backend' ) }}</th>
+			<th>{{ __( 'Duplicate count', 'planet4-blocks-backend' ) }}</th>
 		</tr>
-		{% set all_count_total = 0 %}
-		{% set unique_count_total = 0 %}
+		{% set total_count = 0 %}
 		{% for result in duplicate_postmeta %}
+			{% set duplicate_count = result.all_count - result.unique_count %}
+			{% set total_count = total_count + duplicate_count %}
 			<tr>
-				<td>{{ result.post_id }}</td>
-				<td>{{ result.all_count }}</td>
-				<td>{{ result.unique_count }}</td>
+				<td>{{ loop.index }}</td>
+				<td>{{ result.meta_key }} {% if result.meta_key in postmeta_keys %} * {% endif %} </td>
+				<td>{{ duplicate_count }}</td>
 			</tr>
-			{% set all_count_total = all_count_total + result.all_count %}
-			{% set unique_count_total = unique_count_total + result.unique_count %}
 		{% endfor %}
 		{% if not duplicate_postmeta %}
 			<tr><td colspan="3"></td></tr>
 			<tr>
-				<td colspan="3">{{ __( 'No duplicate postmeta record/s found.', 'planet4-blocks-backend' ) }}</td>
+				<td colspan="3">{{ __( 'No duplicate postmeta records found.', 'planet4-blocks-backend' ) }}</td>
 			</tr>
 		{% else %}
 			<tr>
+				<td></td>
 				<td><strong>{{ __( 'Total', 'planet4-blocks-backend' ) }}</strong></td>
-				<td><strong>{{ all_count_total }}</strong></td>
-				<td><strong>{{ unique_count_total }}</strong></td>
+				<td><strong>{{ total_count }}</strong></td>
+			</tr>
+			<tr>
+				<td colspan="3">{{ __( 'The * indicates whitelisted metakey\'s for delete operation.', 'planet4-blocks-backend' ) }}</td>
 			</tr>
 		{% endif %}
 		</table>


### PR DESCRIPTION
- Add new CLI cmd to print duplicate postmeta key counts (`wp p4-gblocks print_duplicate_postmeta`)
- On execution of `wp p4-gblocks remove_duplicate_postmeta` cmd print duplicate postmeta keys before delete. 
- Update Admin duplicate postmeta report with `meta_key` and counts