### PR TITLE
PLANET-5062 Fix TAB 'take_action_page' datatype

### DIFF
--- a/assets/src/blocks/Takeactionboxout/TakeactionboxoutBlock.js
+++ b/assets/src/blocks/Takeactionboxout/TakeactionboxoutBlock.js
@@ -166,7 +166,7 @@ export class TakeactionboxoutBlock {
 				// These methods are passed down to the
 				// Articles component, they update the corresponding attribute.
 				function onSelectTakeActoinPage( value ) {
-					setAttributes({ take_action_page: value });
+					setAttributes({ take_action_page: parseInt(value) });
 				}
 
 				function onCustomTitleChange(value) {


### PR DESCRIPTION
[JIRA 5062](https://jira.greenpeace.org/browse/PLANET-5062)

- The issue was the `take_action_page` passed as string ({"take_action_page":"23439"} ) where as the field is defined as integer in backend and Gutenberg.