### PR TITLE
Planet 5060 - Simplify passive state of Take Action cards

### DIFF
--- a/assets/src/styles/blocks/Covers/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionCovers.scss
@@ -180,7 +180,7 @@
       max-width: 100%;
     }
 
-    &:hover {
+    &.clickable:hover {
       text-decoration: underline;
     }
   }

--- a/assets/src/styles/blocks/Covers/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionCovers.scss
@@ -75,6 +75,20 @@
   background-position: top;
   color: $grey-80;
 
+  .cover-card-content {
+    position: relative;
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  .cover-card-overlay {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    right: 0;
+  }
+
   @include medium-and-up {
     flex-basis: 48%;
     min-height: 414px;
@@ -178,15 +192,15 @@
     transition: color 100ms linear;
     color: $white;
     text-shadow: 1px 1px 3px $black;
+    display: table;
+    z-index: 1;
+    pointer-events: all;
+    font-family: $roboto;
 
     @include large-and-up {
       font-size: 1.5rem;
       margin-top: 8px;
       max-width: 100%;
-    }
-
-    &.clickable:hover {
-      text-decoration: underline;
     }
   }
 
@@ -218,8 +232,11 @@
   text-shadow: 1.5px 1.5px 1.5px $black;
   font-weight: 800;
   font-family: $roboto;
+  pointer-events: all;
+  position: relative;
 
   &:hover {
+    text-decoration: underline;
     color: $yellow;
   }
 
@@ -238,6 +255,8 @@
   margin: $n15 auto;
   width: 92%;
   display: none;
+  z-index: 1;
+  pointer-events: all;
 }
 
 .load-more-covers-button-div {

--- a/assets/src/styles/blocks/Covers/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionCovers.scss
@@ -65,6 +65,7 @@
 }
 
 .cover-card {
+  cursor: pointer;
   flex-basis: 100%;
   padding: 32px $n15 $n60;
   margin-top: $space-md;
@@ -130,6 +131,7 @@
     }
 
     .btn {
+      display: block;
       background-color: $orange-hover;
       border-color: $orange-hover;
     }
@@ -176,6 +178,10 @@
       font-size: 1.5rem;
       margin-top: 8px;
       max-width: 100%;
+    }
+
+    &:hover {
+      text-decoration: underline;
     }
   }
 
@@ -226,7 +232,7 @@
   right: 0;
   margin: $n15 auto;
   width: 92%;
-  cursor: pointer;
+  display: none;
 }
 
 .load-more-covers-button-div {

--- a/assets/src/styles/blocks/Covers/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionCovers.scss
@@ -132,8 +132,13 @@
 
     .btn {
       display: block;
-      background-color: $orange-hover;
-      border-color: $orange-hover;
+      background-color: $orange;
+      border-color: $orange;
+
+      &:hover {
+        background-color: $orange-hover;
+        border-color: $orange-hover;
+      }
     }
   }
 

--- a/templates/blocks/old_covers.twig
+++ b/templates/blocks/old_covers.twig
@@ -25,42 +25,48 @@
 				<div class="row limit-visibility">
 					{% for cover in covers %}
 						<div class="col-lg-4 col-md-6 cover-card-column">
-							<div
-								class="cover-card card-one"
-								style="background-image: url({{ cover.image }});"
-								data-ga-category="Take Action Covers"
-								data-ga-action="Image"
-								data-ga-label="n/a">
-									<div class="cover-card-content">
-										{% if ( cover.tags ) %}
-											{% for tag in cover.tags %}
-												<a
-													class="cover-card-tag"
-													href="{{ tag.href|e('esc_url') }}"
-													data-ga-category="Take Action Covers"
-													data-ga-action="Navigation Tag"
-													data-ga-label="n/a">
-														#{{ tag.name|e('wp_kses_post')|raw }}
-												</a>
-											{% endfor %}
-										{% endif %}
-										<h2
-											class="cover-card-heading"
-											data-ga-category="Take Action Covers"
-											data-ga-action="Title"
-											data-ga-label="n/a">
-												{{ cover.title|e('wp_kses_post')|raw }}
-										</h2>
-										<p>{{ cover.excerpt|truncate(20)|e('wp_kses_post')|raw }}</p>
-									</div>
+							<div class="cover-card card-one" style="background-image: url({{ cover.image }});">
+								<a
+									class="cover-card-overlay"
+									data-ga-category="Take Action Covers"
+									data-ga-action="Image"
+									data-ga-label="n/a"
+									href="{{ cover.button_link|default('#') }}"
+								/>
+								<div class="cover-card-content">
+									{% if ( cover.tags ) %}
+										{% for tag in cover.tags %}
+											<a
+												class="cover-card-tag"
+												data-ga-category="Take Action Covers"
+												data-ga-action="Navigation Tag"
+												data-ga-label="n/a"
+												href="{{ tag.href|e('esc_url') }}"
+											>
+												#{{ tag.name|e('wp_kses_post')|raw }}
+											</a>
+										{% endfor %}
+									{% endif %}
 									<a
-										class="btn btn-action btn-block cover-card-btn"
-										href="{{ cover.button_link|e('esc_url') }}"
+										class="cover-card-heading"
 										data-ga-category="Take Action Covers"
-										data-ga-action="Call to Action"
-										data-ga-label="n/a">
-											{{ cover.button_text }}
+										data-ga-action="Title"
+										data-ga-label="n/a"
+										href="{{ cover.button_link|default('#') }}"
+									>
+										{{ cover.title|e('wp_kses_post')|raw }}
 									</a>
+									<p>{{ cover.excerpt|truncate(20)|e('wp_kses_post')|raw }}</p>
+								</div>
+								<a
+									class="btn btn-action btn-block cover-card-btn"
+									data-ga-category="Take Action Covers"
+									data-ga-action="Call to Action"
+									data-ga-label="n/a"
+									href="{{ cover.button_link|default('#') }}"
+								>
+									{{ cover.button_text }}
+								</a>
 							</div>
 						</div>
 					{% endfor %}

--- a/templates/blocks/take_action_boxout.twig
+++ b/templates/blocks/take_action_boxout.twig
@@ -6,45 +6,55 @@
 		{% else %}
 			{% set bg_image = '' %}
 		{% endif %}
-		<section
-			id="action-card"
-			class="cover-card single-cover dark-card-bg action-card"
-			data-ga-category="Take Action Boxout"
-			data-ga-action="Image"
-			data-ga-label="n/a"
-			{{ bg_image|raw }}>
-			{% if ( boxout.campaigns ) %}
-				{% for campaign in boxout.campaigns %}
-					<a
-						href="{{ campaign.link|default('#') }}"
-						class="cover-card-tag"
-						data-ga-category="Take Action Boxout"
-						data-ga-action="Navigation Tag"
-						data-ga-label="n/a">
-							#{{ campaign.name|e('wp_kses_post')|raw }}
-					</a>
-				{% endfor %}
-			{% endif %}
-			{% if ( boxout.title ) %}
-				<h2
-					class="cover-card-heading"
-					data-ga-category="Take Action Boxout"
-					data-ga-action="Title"
-					data-ga-label="n/a">
-						{{ boxout.title|e('wp_kses_post')|raw }}
-				</h2>
-			{% endif %}
+		<section id="action-card" class="cover-card single-cover dark-card-bg action-card" {{ bg_image|raw }}>
+            <a
+                data-ga-category="Take Action Boxout"
+                data-ga-action="Image"
+                data-ga-label="n/a"
+                class="cover-card-overlay"
+                href="{{ boxout.link|default('#') }}"
+                {{ boxout.new_tab and boxout.link ? 'target="_blank"' }}
+            />
+            <div class="cover-card-content">
+                {% if ( boxout.campaigns ) %}
+                    {% for campaign in boxout.campaigns %}
+                        <a
+                            class="cover-card-tag"
+                            data-ga-category="Take Action Boxout"
+                            data-ga-action="Navigation Tag"
+                            data-ga-label="n/a"
+                            href="{{ campaign.link|e('esc_url') }}"
+                        >
+                            #{{ campaign.name|e('wp_kses_post')|raw }}
+                        </a>
+                    {% endfor %}
+                {% endif %}
+                {% if ( boxout.title ) %}
+                    <a
+                        class="cover-card-heading"
+                        data-ga-category="Take Action Boxout"
+                        data-ga-action="Title"
+                        data-ga-label="n/a"
+                        href="{{ boxout.link|default('#') }}"
+                        {{ boxout.new_tab and boxout.link ? 'target="_blank"' }}
+                    >
+                        {{ boxout.title|e('wp_kses_post')|raw }}
+                    </a>
+                {% endif %}
+            </div>
 			{% if ( boxout.excerpt ) %}
 				<p>{{ boxout.excerpt|e('wp_kses_post')|excerpt(25)|raw }}</p>
 			{% endif %}
-			{% if ( boxout.link ) %}
-				<a
-					class="btn btn-action btn-block cover-card-btn" {{  'true' == boxout.new_tab ? 'target="_blank"' }}
-					href="{{ boxout.link }}"
+			{% if ( boxout.link and boxout.link_text ) %}
+                <a
+					class="btn btn-action btn-block cover-card-btn"
 					data-ga-category="Take Action Boxout"
 					data-ga-action="Call to Action"
-					data-ga-label="n/a">
-						{{ boxout.link_text }}
+                    data-ga-label="n/a"
+                    href="{{ boxout.link|default('#') }}"
+                    {{ boxout.new_tab and boxout.link ? 'target="_blank"' }}
+                >
+					{{ boxout.link_text }}
 				</a>
 			{% endif %}
 		</section>


### PR DESCRIPTION
This PR takes care of the changes for both the Take Action card (https://jira.greenpeace.org/browse/PLANET-5060) and the Take Action boxout (https://jira.greenpeace.org/browse/PLANET-5126):
- Hide CTA in passive state, show it only on rollover
- Make whole card clickable (instead of just the CTA), adjust cursor to pointer
- Underline heading on rollover