### PR TITLE
PLANET-4934: Trigger LazyLoad update on Article block

### DIFF
--- a/assets/src/blocks/Articles/Articles.js
+++ b/assets/src/blocks/Articles/Articles.js
@@ -11,12 +11,36 @@ import TagSelector from '../../components/TagSelector/TagSelector';
 import PostSelector from '../../components/PostSelector/PostSelector';
 import PostTypeSelector from '../../components/PostTypeSelector/PostTypeSelector';
 import {URLInput} from "../../components/URLInput/URLInput";
-
+import { v4 as uuidv4 } from 'uuid';
 
 const TextControl = withCharacterCounter( BaseTextControl );
 const TextareaControl = withCharacterCounter( BaseTextareaControl );
 
 export class Articles extends Component {
+  constructor(props) {
+    super(props);
+    this.instanceName = `planet4-blocks-articles-${ uuidv4() }`;
+  }
+
+  componentDidMount() {
+    this.lazyLoadInterval = setInterval(() => {
+      if (document.querySelector(`.${this.instanceName} section.articles-block`)) {
+        this.updateLazyLoad();
+        clearInterval(this.lazyLoadInterval);
+      }
+    }, 250);
+  }
+
+  componentDidUpdate() {
+    this.updateLazyLoad();
+  }
+
+  updateLazyLoad() {
+    if (window.lazyLoad) {
+      window.lazyLoad.update();
+    }
+  }
+
   renderEdit() {
     const {__} = wp.i18n;
 
@@ -147,6 +171,7 @@ export class Articles extends Component {
         }
         <Preview showBar={ this.props.isSelected }>
           <ServerSideRender
+            className={ this.instanceName }
             block={ 'planet4-blocks/articles' }
             attributes={ this.props.attributes }>
           </ServerSideRender>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4934

Trigger a `lazyLoad.update()` on Article block on the admin side, to display images in articles list.  

## Fix

There's no easy React-way to do this using vanilla-lazyload. When the block appears, its content is not yet present and is fetched by a `ServerSideRender` component, so we have to find a way to call lazyLoad only after the server-side rendered content appears, knowing that this does not trigger a `componentDidUpdate` in the parent component.

While I was toying with `setTimeout`, @pablocubico gave me a far better solution that checks the presence of a rendered div and clears itself when it's done.

We could think of different solutions like modifying the output or the server to not use lazyload on this case, but it would be more critical for the frontend, and the fact that we have planned to remove `ServerSideRender` usage at some point pushes us more to a js solution.

### Doc
Vanilla-lazyload : 
https://github.com/verlok/vanilla-lazyload/blob/754a55de96e6fa0dbc5a8262b0425932316c3abc/README.md#usage-with-react 

## Test

On the `/admin` side
- Add a new page with an `Articles` block
  This block should have some articles with images to display.
- Images should appear, in view mode and in edit mode