### PR TITLE
PLANET-5060 Make Take Action covers and boxouts links

### DIFF
--- a/assets/src/styles/blocks/Covers/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionCovers.scss
@@ -74,6 +74,11 @@
   background-size: cover;
   background-position: top;
   color: $grey-80;
+  display: block;
+
+  .external-icon {
+    display: none;
+  }
 
   @include medium-and-up {
     flex-basis: 48%;
@@ -120,6 +125,7 @@
   }
 
   &:hover {
+    text-decoration: none;
     @include background-before-opacity(linear-gradient(180deg, rgba(51, 51, 51, 0.6), rgba(250, 247, 236, 0.9), rgba(255, 255, 255, 0.8)), 1);
     box-shadow: 0 0 10px transparentize($black, .5);
 
@@ -130,7 +136,7 @@
       }
     }
 
-    .btn {
+    .cover-card-btn {
       display: block;
       background-color: $orange;
       border-color: $orange;
@@ -178,6 +184,7 @@
     transition: color 100ms linear;
     color: $white;
     text-shadow: 1px 1px 3px $black;
+    display: table;
 
     @include large-and-up {
       font-size: 1.5rem;
@@ -214,13 +221,12 @@
   color: $yellow;
   display: inline-block;
   margin-bottom: 8px;
-  text-decoration: none;
   text-shadow: 1.5px 1.5px 1.5px $black;
   font-weight: 800;
   font-family: $roboto;
 
   &:hover {
-    color: $yellow;
+    text-decoration: underline;
   }
 
   @include large-and-up {

--- a/templates/blocks/old_covers.twig
+++ b/templates/blocks/old_covers.twig
@@ -1,8 +1,9 @@
 {% block covers %}
 	<script>
-		const onCardClick = function(link) {
-			if (link) {
-				return window.open(link, '_self');
+		const onTagClick = function(event, href) {
+			event.preventDefault();
+			if (href) {
+				return window.open(href, '_self');
 			}
 		}
 	</script>
@@ -32,19 +33,18 @@
 				<div class="row limit-visibility">
 					{% for cover in covers %}
 						<div class="col-lg-4 col-md-6 cover-card-column">
-							<div onclick="onCardClick('{{ cover.button_link }}')" class="cover-card card-one" style="background-image: url({{ cover.image }});">
+							<a href="{{ cover.button_link|default('#') }}" class="cover-card card-one" style="background-image: url({{ cover.image }});">
 								<div class="cover-card-content">
 									{% if ( cover.tags ) %}
 										{% for tag in cover.tags %}
-											<a class="cover-card-tag"
-											   href="{{ tag.href|e('esc_url') }}">#{{ tag.name|e('wp_kses_post')|raw }}</a>
+											<div class="cover-card-tag" onclick="onTagClick(event, '{{ tag.href }}')">#{{ tag.name|e('wp_kses_post')|raw }}</div>
 										{% endfor %}
 									{% endif %}
 									<h2 class="cover-card-heading {{ cover.button_link ? 'clickable' : '' }}">{{ cover.title|e('wp_kses_post')|raw }}</h2>
 									<p>{{ cover.excerpt|truncate(20)|e('wp_kses_post')|raw }}</p>
 								</div>
-								<button class="btn btn-action btn-block cover-card-btn">{{ cover.button_text }}</button>
-							</div>
+								<div class="btn btn-action btn-block cover-card-btn">{{ cover.button_text }}</div>
+							</a>
 						</div>
 					{% endfor %}
 				</div>

--- a/templates/blocks/take_action_boxout.twig
+++ b/templates/blocks/take_action_boxout.twig
@@ -1,13 +1,10 @@
 {% block take_action_boxout %}
     <script>
-        const onBoxoutClick = function(link, new_tab) {
-            if (link) {
-                return window.open(link, new_tab ? '_blank' : '_self');
+        const onTagClick = function(event, href) {
+            event.preventDefault();
+            if (href) {
+                return window.open(href, '_self');
             }
-        }
-
-        const onTagClick = function(event) {
-            event.stopPropagation();
         }
     </script>
 
@@ -18,21 +15,23 @@
         {% else %}
             {% set bg_image = '' %}
         {% endif %}
-        <section onclick="onBoxoutClick('{{ boxout.link }}', '{{ boxout.new_tab }}')" id="action-card" class="cover-card single-cover dark-card-bg action-card" {{ bg_image|raw }}>
-            {% if ( boxout.campaigns ) %}
-                {% for campaign in boxout.campaigns %}
-                    <a href="{{ campaign.link|default('#') }}" onclick="onTagClick(event)" class="cover-card-tag">#{{ campaign.name|e('wp_kses_post')|raw }}</a>
-                {% endfor %}
-            {% endif %}
-            {% if ( boxout.title ) %}
-                <h2 class="cover-card-heading {{ boxout.link ? 'clickable' : '' }}">{{ boxout.title|e('wp_kses_post')|raw }}</h2>
-            {% endif %}
-            {% if ( boxout.excerpt ) %}
-                <p>{{ boxout.excerpt|e('wp_kses_post')|excerpt(25)|raw }}</p>
-            {% endif %}
-            {% if ( boxout.link ) %}
-                <button class="btn btn-action btn-block cover-card-btn">{{ boxout.link_text }}</button>
-            {% endif %}
+        <section id="action-card">
+            <a {{ boxout.new_tab and boxout.link ? 'target="_blank"' }} href="{{ boxout.link|default('#') }}" class="cover-card single-cover dark-card-bg action-card" {{ bg_image|raw }}>
+                {% if ( boxout.campaigns ) %}
+                    {% for campaign in boxout.campaigns %}
+                        <div onclick="onTagClick(event, '{{ campaign.link }}')" class="cover-card-tag">#{{ campaign.name|e('wp_kses_post')|raw }}</div>
+                    {% endfor %}
+                {% endif %}
+                {% if ( boxout.title ) %}
+                    <h2 class="cover-card-heading {{ boxout.link ? 'clickable' : '' }}">{{ boxout.title|e('wp_kses_post')|raw }}</h2>
+                {% endif %}
+                {% if ( boxout.excerpt ) %}
+                    <p>{{ boxout.excerpt|e('wp_kses_post')|excerpt(25)|raw }}</p>
+                {% endif %}
+                {% if ( boxout.link and boxout.link_text ) %}
+                    <div class="btn btn-action btn-block cover-card-btn">{{ boxout.link_text }}</div>
+                {% endif %}
+            </a>
         </section>
     {% endif %}
 


### PR DESCRIPTION
This PR is to explore the possibility of making the entire Take Action card a link (`<a>` tag) in order to achieve better accessibility. See [this PR](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/291) for more details (in particular the comment from @comzeradd)

The only issue is that `<a>` tags cannot have other `<a>` tags as children (https://www.w3.org/TR/html401/struct/links.html#h-12.2.2), so if we are going to choose this approach, the Take Action card's other links need to be replaced with other HTML tags. It's not a problem for the button as it anyway redirects to the same page as the rest of the card, but we have an issue for the tags (#oil for example) that link to other pages... I think that for these ones we don't have any other choice than using JavaScript.