### PR TITLE
Planet 5060 - Use overlay to make whole Take Action card clickable

### DIFF
--- a/assets/src/styles/blocks/Covers/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionCovers.scss
@@ -75,6 +75,20 @@
   background-position: top;
   color: $grey-80;
 
+  .cover-card-content {
+    position: relative;
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  .cover-card-overlay {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    right: 0;
+  }
+
   @include medium-and-up {
     flex-basis: 48%;
     min-height: 414px;
@@ -178,15 +192,15 @@
     transition: color 100ms linear;
     color: $white;
     text-shadow: 1px 1px 3px $black;
+    display: table;
+    z-index: 1;
+    pointer-events: all;
+    font-family: $roboto;
 
     @include large-and-up {
       font-size: 1.5rem;
       margin-top: 8px;
       max-width: 100%;
-    }
-
-    &.clickable:hover {
-      text-decoration: underline;
     }
   }
 
@@ -218,8 +232,11 @@
   text-shadow: 1.5px 1.5px 1.5px $black;
   font-weight: 800;
   font-family: $roboto;
+  pointer-events: all;
+  position: relative;
 
   &:hover {
+    text-decoration: underline;
     color: $yellow;
   }
 
@@ -238,6 +255,8 @@
   margin: $n15 auto;
   width: 92%;
   display: none;
+  z-index: 1;
+  pointer-events: all;
 }
 
 .load-more-covers-button-div {

--- a/templates/blocks/old_covers.twig
+++ b/templates/blocks/old_covers.twig
@@ -1,11 +1,4 @@
 {% block covers %}
-	<script>
-		const onCardClick = function(link) {
-			if (link) {
-				return window.open(link, '_self');
-			}
-		}
-	</script>
 
 	{% if ( covers ) %}
 
@@ -32,18 +25,20 @@
 				<div class="row limit-visibility">
 					{% for cover in covers %}
 						<div class="col-lg-4 col-md-6 cover-card-column">
-							<div onclick="onCardClick('{{ cover.button_link }}')" class="cover-card card-one" style="background-image: url({{ cover.image }});">
+							<div class="cover-card card-one" style="background-image: url({{ cover.image }});">
+								<a href="{{ cover.button_link|default('#') }}" class="cover-card-overlay" />
 								<div class="cover-card-content">
 									{% if ( cover.tags ) %}
 										{% for tag in cover.tags %}
-											<a class="cover-card-tag"
-											   href="{{ tag.href|e('esc_url') }}">#{{ tag.name|e('wp_kses_post')|raw }}</a>
+											<a class="cover-card-tag" href="{{ tag.href }}">#{{ tag.name|e('wp_kses_post')|raw }}</a>
 										{% endfor %}
 									{% endif %}
-									<h2 class="cover-card-heading {{ cover.button_link ? 'clickable' : '' }}">{{ cover.title|e('wp_kses_post')|raw }}</h2>
+									<a href="{{ cover.button_link|default('#') }}" class="cover-card-heading">{{ cover.title|e('wp_kses_post')|raw }}</a>
 									<p>{{ cover.excerpt|truncate(20)|e('wp_kses_post')|raw }}</p>
 								</div>
-								<button class="btn btn-action btn-block cover-card-btn">{{ cover.button_text }}</button>
+								<a href="{{ cover.button_link|default('#') }}" class="btn btn-action btn-block cover-card-btn">
+									{{ cover.button_text }}
+								</a>
 							</div>
 						</div>
 					{% endfor %}

--- a/templates/blocks/take_action_boxout.twig
+++ b/templates/blocks/take_action_boxout.twig
@@ -1,37 +1,32 @@
 {% block take_action_boxout %}
-    <script>
-        const onBoxoutClick = function(link, new_tab) {
-            if (link) {
-                return window.open(link, new_tab ? '_blank' : '_self');
-            }
-        }
-
-        const onTagClick = function(event) {
-            event.stopPropagation();
-        }
-    </script>
 
     {% if ( boxout ) %}
-
         {% if ( boxout.image ) %}
             {% set bg_image = 'style="background-image: linear-gradient(180deg, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0)), url(\''~boxout.image~'\');"' %}
         {% else %}
             {% set bg_image = '' %}
         {% endif %}
-        <section onclick="onBoxoutClick('{{ boxout.link }}', '{{ boxout.new_tab }}')" id="action-card" class="cover-card single-cover dark-card-bg action-card" {{ bg_image|raw }}>
-            {% if ( boxout.campaigns ) %}
-                {% for campaign in boxout.campaigns %}
-                    <a href="{{ campaign.link|default('#') }}" onclick="onTagClick(event)" class="cover-card-tag">#{{ campaign.name|e('wp_kses_post')|raw }}</a>
-                {% endfor %}
-            {% endif %}
-            {% if ( boxout.title ) %}
-                <h2 class="cover-card-heading {{ boxout.link ? 'clickable' : '' }}">{{ boxout.title|e('wp_kses_post')|raw }}</h2>
-            {% endif %}
+        <section id="action-card" class="cover-card single-cover dark-card-bg action-card" {{ bg_image|raw }}>
+            <a {{ boxout.new_tab and boxout.link ? 'target="_blank"' }} href="{{ boxout.link|default('#') }}" class="cover-card-overlay" />
+            <div class="cover-card-content">
+                {% if ( boxout.campaigns ) %}
+                    {% for campaign in boxout.campaigns %}
+                        <a href="{{ campaign.link }}" class="cover-card-tag">#{{ campaign.name|e('wp_kses_post')|raw }}</a>
+                    {% endfor %}
+                {% endif %}
+                {% if ( boxout.title ) %}
+                    <a class="cover-card-heading" {{ boxout.new_tab and boxout.link ? 'target="_blank"' }} href="{{ boxout.link|default('#') }}">
+                        {{ boxout.title|e('wp_kses_post')|raw }}
+                    </a>
+                {% endif %}
+            </div>
             {% if ( boxout.excerpt ) %}
                 <p>{{ boxout.excerpt|e('wp_kses_post')|excerpt(25)|raw }}</p>
             {% endif %}
-            {% if ( boxout.link ) %}
-                <button class="btn btn-action btn-block cover-card-btn">{{ boxout.link_text }}</button>
+            {% if ( boxout.link and boxout.link_text ) %}
+                <a {{ boxout.new_tab and boxout.link ? 'target="_blank"' }} href="{{ boxout.link|default('#') }}" class="btn btn-action btn-block cover-card-btn">
+                    {{ boxout.link_text }}
+                </a>
             {% endif %}
         </section>
     {% endif %}


### PR DESCRIPTION
This PR is to try to use a link overlay to make the whole Take Action card clickable using this trick: https://codepen.io/pwkip/pen/oGMZjb (see the last comment by @comzeradd on [this PR](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/293) for more details).

One side effect of this method is that clickable elements in the card that need UI effects (background change, underline, etc) need to be`<a>` tags, otherwise the interaction is gone. Those elements are the tags, the title and the CTA.