### PR TITLE
PLANET-5114 Add css variables for easier child-theme customisation

### DIFF
--- a/assets/src/styles/blocks/Articles.scss
+++ b/assets/src/styles/blocks/Articles.scss
@@ -94,9 +94,8 @@
   font-size: 1.25rem;
   line-height: 1.3;
   font-weight: 500;
-  color: var(--article-list-item-headline_color, $dark-shade-black);
+  color: var(--article-list-item-headline-color, $dark-shade-black);
   margin: $space-xxs 0;
-  display: table;
 
   @include large-and-up {
     font-size: 1.375rem;
@@ -105,14 +104,10 @@
   @include x-large-and-up {
     font-size: 1.5rem;
   }
-
-  &:hover {
-    color: var(--article-list-item-headline_hover_color, $dark-shade-black);
-  }
 }
 
 .article-list-item-meta {
-  color: var(--article-list-item-meta_color, $grey-60);
+  color: var(--article-list-item-meta-color, $grey-60);
   font-family: $roboto;
   font-style: italic;
   font-size: 0.875rem;

--- a/assets/src/styles/blocks/Articles.scss
+++ b/assets/src/styles/blocks/Articles.scss
@@ -94,8 +94,9 @@
   font-size: 1.25rem;
   line-height: 1.3;
   font-weight: 500;
-  color: $dark-shade-black;
+  color: var(--article-list-item-headline_color, $dark-shade-black);
   margin: $space-xxs 0;
+  display: table;
 
   @include large-and-up {
     font-size: 1.375rem;
@@ -104,10 +105,14 @@
   @include x-large-and-up {
     font-size: 1.5rem;
   }
+
+  &:hover {
+    color: var(--article-list-item-headline_hover_color, $dark-shade-black);
+  }
 }
 
 .article-list-item-meta {
-  color: $grey-60;
+  color: var(--article-list-item-meta_color, $grey-60);
   font-family: $roboto;
   font-style: italic;
   font-size: 0.875rem;

--- a/assets/src/styles/blocks/Covers/CampaignCovers.scss
+++ b/assets/src/styles/blocks/Covers/CampaignCovers.scss
@@ -105,7 +105,6 @@
         text-align: center;
         font-size: $font-size-md;
         font-family: $roboto;
-        background-color: transparent;
         color: $yellow;
         font-weight: 500;
         position: absolute;
@@ -128,8 +127,6 @@
 
         &:hover {
           text-decoration: none;
-          background-color: transparent;
-          color: $yellow;
         }
       }
     }

--- a/assets/src/styles/blocks/Covers/CampaignCovers.scss
+++ b/assets/src/styles/blocks/Covers/CampaignCovers.scss
@@ -105,6 +105,7 @@
         text-align: center;
         font-size: $font-size-md;
         font-family: $roboto;
+        background-color: transparent;
         color: $yellow;
         font-weight: 500;
         position: absolute;
@@ -127,6 +128,8 @@
 
         &:hover {
           text-decoration: none;
+          background-color: transparent;
+          color: $yellow;
         }
       }
     }

--- a/assets/src/styles/blocks/Covers/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionCovers.scss
@@ -144,14 +144,14 @@
       }
     }
 
-    .cover-card-btn {
+    .btn {
       display: block;
-      background-color: var(--cover-card-btn_background_color, $orange);
-      border-color: var(--cover-card-btn_border_color, $orange);
+      background-color: var(--cover-card-btn-background-color, $orange);
+      border-color: var(--cover-card-btn-border-color, $orange);
 
       &:hover {
-        background-color: var(--cover-card-btn_hover_background_color, $orange-hover);
-        border-color: var(--cover-card-btn_hover_border_color, $orange-hover);
+        background-color: var(--cover-card-btn-hover-background-color, $orange-hover);
+        border-color: var(--cover-card-btn-hover-border-color, $orange-hover);
       }
     }
   }
@@ -190,7 +190,7 @@
     padding-top: 0;
     max-width: 80%;
     transition: color 100ms linear;
-    color: var(--cover-card-heading_color, $white);
+    color: var(--cover-card-heading-color, $white);
     text-shadow: 1px 1px 3px $black;
     display: table;
     z-index: 1;
@@ -201,10 +201,6 @@
       font-size: 1.5rem;
       margin-top: 8px;
       max-width: 100%;
-    }
-
-    &:hover {
-      color: var(--cover-card-heading_hover_color, $white);
     }
   }
 
@@ -229,8 +225,7 @@
 }
 
 .cover-card-tag {
-  color: var(--cover-card-tag_color, $yellow);
-  background-color: var(--cover-card-tag_background_color, transparent);
+  color: var(--cover-card-tag-color, $yellow);
   display: inline-block;
   margin-bottom: 8px;
   text-decoration: none;
@@ -242,7 +237,7 @@
 
   &:hover {
     text-decoration: underline;
-    color: var(--cover-card-tag_hover_color, $yellow);
+    color: var(--cover-card-tag-hover-color, $yellow);
   }
 
   @include large-and-up {

--- a/assets/src/styles/blocks/Covers/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionCovers.scss
@@ -144,14 +144,14 @@
       }
     }
 
-    .btn {
+    .cover-card-btn {
       display: block;
-      background-color: $orange;
-      border-color: $orange;
+      background-color: var(--cover-card-btn_background_color, $orange);
+      border-color: var(--cover-card-btn_border_color, $orange);
 
       &:hover {
-        background-color: $orange-hover;
-        border-color: $orange-hover;
+        background-color: var(--cover-card-btn_hover_background_color, $orange-hover);
+        border-color: var(--cover-card-btn_hover_border_color, $orange-hover);
       }
     }
   }
@@ -190,7 +190,7 @@
     padding-top: 0;
     max-width: 80%;
     transition: color 100ms linear;
-    color: $white;
+    color: var(--cover-card-heading_color, $white);
     text-shadow: 1px 1px 3px $black;
     display: table;
     z-index: 1;
@@ -201,6 +201,10 @@
       font-size: 1.5rem;
       margin-top: 8px;
       max-width: 100%;
+    }
+
+    &:hover {
+      color: var(--cover-card-heading_hover_color, $white);
     }
   }
 
@@ -225,7 +229,8 @@
 }
 
 .cover-card-tag {
-  color: $yellow;
+  color: var(--cover-card-tag_color, $yellow);
+  background-color: var(--cover-card-tag_background_color, transparent);
   display: inline-block;
   margin-bottom: 8px;
   text-decoration: none;
@@ -237,7 +242,7 @@
 
   &:hover {
     text-decoration: underline;
-    color: $yellow;
+    color: var(--cover-card-tag_hover_color, $yellow);
   }
 
   @include large-and-up {

--- a/assets/src/styles/campaigns/components/_campaign_covers.scss
+++ b/assets/src/styles/campaigns/components/_campaign_covers.scss
@@ -105,7 +105,6 @@
         text-align: center;
         font-size: $font-size-md;
         font-family: $roboto;
-        background-color: transparent;
         color: $yellow;
         font-weight: 500;
         position: absolute;
@@ -128,8 +127,6 @@
 
         &:hover {
           text-decoration: none;
-          background-color: transparent;
-          color: $yellow;
         }
       }
     }

--- a/assets/src/styles/campaigns/components/_campaign_covers.scss
+++ b/assets/src/styles/campaigns/components/_campaign_covers.scss
@@ -105,6 +105,7 @@
         text-align: center;
         font-size: $font-size-md;
         font-family: $roboto;
+        background-color: transparent;
         color: $yellow;
         font-weight: 500;
         position: absolute;
@@ -127,6 +128,8 @@
 
         &:hover {
           text-decoration: none;
+          background-color: transparent;
+          color: $yellow;
         }
       }
     }

--- a/assets/src/styles/editorOverrides.scss
+++ b/assets/src/styles/editorOverrides.scss
@@ -74,7 +74,7 @@
   text-align: center;
   text-decoration: none;
   text-transform: uppercase;
-  color: $white;
+  color: var(--btn_color, $white);
   font-weight: 500;
   border-radius: 0;
   border: 1px solid transparent;
@@ -89,9 +89,9 @@
 
 .wp-block-button.is-style-secondary .wp-block-button__link[role="textbox"],
 [class="wp-block-button"] .wp-block-button__link[role="textbox"] {
-  background-color: transparentize($white, .7);
-  border-color: $dark-blue;
-  color: $dark-blue;
+  background-color: var(--btn-secondary_background_color, transparentize($white, .7));
+  border-color: var(--btn-secondary_border_color, $dark-blue);
+  color: var(--btn-secondary_color, $dark-blue);
   box-shadow: none;
   font-size: $font-size-xxs;
   white-space: nowrap;
@@ -107,13 +107,13 @@
 }
 
 .wp-block-button.is-style-cta .wp-block-button__link[role="textbox"] {
-  background-color: $orange;
+  background-color: var(--btn-primary_background_color, $orange);
   box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
 }
 
 .wp-block-button.is-style-donate .wp-block-button__link[role="textbox"] {
-  background-color: $aquamarine;
-  color: $grey;
+  background-color: var(--btn-donate_background_color, $aquamarine);
+  color: var(--btn-donate_color, $grey);
   font-size: $font-size-sm;
   line-height: 1.65;
   min-width: 180px;

--- a/assets/src/styles/editorOverrides.scss
+++ b/assets/src/styles/editorOverrides.scss
@@ -74,7 +74,7 @@
   text-align: center;
   text-decoration: none;
   text-transform: uppercase;
-  color: var(--btn_color, $white);
+  color: $white;
   font-weight: 500;
   border-radius: 0;
   border: 1px solid transparent;
@@ -89,9 +89,9 @@
 
 .wp-block-button.is-style-secondary .wp-block-button__link[role="textbox"],
 [class="wp-block-button"] .wp-block-button__link[role="textbox"] {
-  background-color: var(--btn-secondary_background_color, transparentize($white, .7));
-  border-color: var(--btn-secondary_border_color, $dark-blue);
-  color: var(--btn-secondary_color, $dark-blue);
+  background-color: var(--btn-secondary-background-color, transparentize($white, .7));
+  border-color: var(--btn-secondary-border-color, $dark-blue);
+  color: var(--btn-secondary-color, $dark-blue);
   box-shadow: none;
   font-size: $font-size-xxs;
   white-space: nowrap;
@@ -107,13 +107,14 @@
 }
 
 .wp-block-button.is-style-cta .wp-block-button__link[role="textbox"] {
-  background-color: var(--btn-primary_background_color, $orange);
+  background-color: var(--btn-primary-background-color, $orange);
+  color: var(--btn-primary-color, $white);
   box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
 }
 
 .wp-block-button.is-style-donate .wp-block-button__link[role="textbox"] {
-  background-color: var(--btn-donate_background_color, $aquamarine);
-  color: var(--btn-donate_color, $grey);
+  background-color: var(--btn-donate-background-color, $aquamarine);
+  color: var(--btn-donate-color, $grey);
   font-size: $font-size-sm;
   line-height: 1.65;
   min-width: 180px;


### PR DESCRIPTION
This is a non-exhaustive list of added variables that child-themes could use for easier customisation of Planet4 (see [PLANET-5114](https://jira.greenpeace.org/browse/PLANET-5114) for more details). The ones listed below are already in the code and could be used right away, but maybe they need to be renamed?

#### Campaign colors
- Navigation bar background color: [--campaign_nav_color](https://github.com/greenpeace/planet4-styleguide/blob/master/src/layout/_navbar.scss#L83)
- Footer background color: [--footer_color](https://github.com/greenpeace/planet4-styleguide/blob/master/src/layout/_footer.scss#L47)
- Footer links color: [--footer_links_color](https://github.com/greenpeace/planet4-styleguide/blob/master/src/layout/_footer.scss#L68)

#### Spreadsheet colors
- Spreadsheet header background color: [--spreadsheet-header-background](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/assets/src/styles/blocks/Spreadsheet.scss#L27)
- Spreadsheet even rows background color: [--spreadsheet-even-row-background](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/assets/src/styles/blocks/Spreadsheet.scss#L41)
- Spreadsheet odd rows background color: [--spreadsheet-odd-row-background](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/assets/src/styles/blocks/Spreadsheet.scss#L51)

Corresponding styleguide PR: https://github.com/greenpeace/planet4-styleguide/pull/59
Corresponding master-theme PR: https://github.com/greenpeace/planet4-master-theme/pull/1117
Related ticket: https://jira.greenpeace.org/browse/PLANET-5104