### PR TITLE
PLANET-5017 Fix: Restore trim() on HighlightMatches and remove it from setState

### DIFF
--- a/assets/src/blocks/HighlightMatches.js
+++ b/assets/src/blocks/HighlightMatches.js
@@ -1,7 +1,7 @@
 import { Fragment } from '@wordpress/element';
 
 export const HighlightMatches = ( cellValue, searchText, className = 'highlighted-text' ) => {
-	let reg = new RegExp('(' + searchText + ')', 'gi')
+	let reg = new RegExp('(' + searchText.trim() + ')', 'gi')
 	let parts = cellValue.split(reg)
 
 	// Skips the first empty value and the intermediate parts

--- a/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
@@ -171,7 +171,7 @@ export class SpreadsheetFrontend extends Component {
             <input className="spreadsheet-search form-control"
               type="text"
               value={ this.state.searchText }
-              onChange={ event => this.setState({ searchText: event.target.value.trim() }) }
+              onChange={ event => this.setState({ searchText: event.target.value }) }
               placeholder={ __('Search data', 'planet4-blocks') } />
           </div>
           <div className="table-wrapper">


### PR DESCRIPTION
I inadvertently committed these lines while rebasing the branch, I was testing a suggestion from the PR review, but using `trim()` in the `setState()` call actually prevents you from typing any spaces in the controlled search input, so this is to restore the lines to the way they originally were.

Please merge asap!