### PR TITLE
PLANET-5186: Switch script version to filectime

### DIFF
--- a/classes/blocks/class-articles.php
+++ b/classes/blocks/class-articles.php
@@ -191,7 +191,7 @@ class Articles extends Base_Block {
 
 		// Enqueue js for the frontend.
 		if ( ! $this->is_rest_request() ) {
-			wp_enqueue_script( 'load-more', P4GBKS_PLUGIN_URL . 'public/js/load_more.js', [ 'jquery' ], '0.3', true );
+			\P4GBKS\Loader::enqueue_local_script( 'load-more', 'public/js/load_more.js', [ 'jquery' ] );
 			wp_localize_script( 'load-more', 'more_url', [ admin_url( 'admin-ajax.php' ) ] );
 		}
 

--- a/classes/blocks/class-carouselheader.php
+++ b/classes/blocks/class-carouselheader.php
@@ -137,16 +137,14 @@ class CarouselHeader extends Base_Block {
 		if ( ! $this->is_rest_request() ) {
 			wp_enqueue_script( 'hammer', 'https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js', [], '2.0.8', true );
 			wp_register_script( 'lazyload', 'https://cdnjs.cloudflare.com/ajax/libs/vanilla-lazyload/12.3.0/lazyload.min.js', [], '12.3.0', true );
-			wp_enqueue_script(
+			\P4GBKS\Loader::enqueue_local_script(
 				'carousel-header',
-				P4GBKS_PLUGIN_URL . 'assets/build/carouselHeaderFrontIndex.js',
+				'assets/build/carouselHeaderFrontIndex.js',
 				[
 					'jquery',
 					'hammer',
 					'lazyload',
-				],
-				'0.3',
-				true
+				]
 			);
 		}
 

--- a/classes/blocks/class-columns.php
+++ b/classes/blocks/class-columns.php
@@ -177,7 +177,7 @@ class Columns extends Base_Block {
 
 		// enqueue script that equalizes the heights of the titles of the blocks.
 		if ( ! $this->is_rest_request() ) {
-			wp_enqueue_script( 'column-headers', P4GBKS_PLUGIN_URL . 'public/js/columns.js', [ 'jquery' ], '0.1', true );
+			\P4GBKS\Loader::enqueue_local_script( 'column-headers', 'public/js/columns.js', [ 'jquery' ] );
 		}
 
 		$block_data = [

--- a/classes/blocks/class-cookies.php
+++ b/classes/blocks/class-cookies.php
@@ -105,7 +105,7 @@ class Cookies extends Base_Block {
 
 		// Enqueue js for the frontend.
 		if ( ! $this->is_rest_request() ) {
-			wp_enqueue_script( 'cookies', P4GBKS_PLUGIN_URL . 'public/js/cookies.js', [ 'jquery' ], '0.1', true );
+			\P4GBKS\Loader::enqueue_local_script( 'cookies', 'public/js/cookies.js', [ 'jquery' ] );
 		}
 
 		$data = [

--- a/classes/blocks/class-counter.php
+++ b/classes/blocks/class-counter.php
@@ -124,7 +124,7 @@ class Counter extends Base_Block {
 
 		// Enqueue js for the frontend.
 		if ( ! $this->is_rest_request() ) {
-			wp_enqueue_script( 'counter', P4GBKS_PLUGIN_URL . 'public/js/counter.js', [ 'jquery' ], '0.1', true );
+			\P4GBKS\Loader::enqueue_local_script( 'counter', 'public/js/counter.js', [ 'jquery' ] );
 		}
 
 		return [

--- a/classes/blocks/class-covers.php
+++ b/classes/blocks/class-covers.php
@@ -122,8 +122,8 @@ class Covers extends Base_Block {
 
 		// Enqueue js for the frontend.
 		if ( ! $this->is_rest_request() ) {
-			wp_enqueue_script( 'covers', P4GBKS_PLUGIN_URL . 'public/js/load_more.js', [ 'jquery' ], '0.1', true );
-			wp_enqueue_script( 'pubslider', P4GBKS_PLUGIN_URL . 'public/js/pubslider.js', [ 'jquery' ], '0.1', true );
+			\P4GBKS\Loader::enqueue_local_script( 'covers', 'public/js/load_more.js', [ 'jquery' ] );
+			\P4GBKS\Loader::enqueue_local_script( 'pubslider', 'public/js/pubslider.js', [ 'jquery' ] );
 		}
 
 		$data = [

--- a/classes/blocks/class-happypoint.php
+++ b/classes/blocks/class-happypoint.php
@@ -134,7 +134,7 @@ class Happypoint extends Base_Block {
 
 		// Enqueue js for the frontend.
 		if ( ! $this->is_rest_request() ) {
-			wp_enqueue_script( 'happy-point', P4GBKS_PLUGIN_URL . 'public/js/happy_point.js', [ 'jquery' ], '0.2', true );
+			\P4GBKS\Loader::enqueue_local_script( 'happy-point', 'public/js/happy_point.js', [ 'jquery' ] );
 		}
 
 		return $data;

--- a/classes/blocks/class-media.php
+++ b/classes/blocks/class-media.php
@@ -120,7 +120,7 @@ class Media extends Base_Block {
 
 		// Enqueue js for the frontend.
 		if ( ! $this->is_rest_request() ) {
-			wp_enqueue_script( 'media', P4GBKS_PLUGIN_URL . 'public/js/media.js', [ 'jquery' ], '0.1', true );
+			\P4GBKS\Loader::enqueue_local_script( 'media', 'public/js/media.js', [ 'jquery' ] );
 		}
 
 		$data = [

--- a/classes/blocks/class-socialmediacards.php
+++ b/classes/blocks/class-socialmediacards.php
@@ -74,7 +74,7 @@ class SocialMediaCards extends Base_Block {
 	public function prepare_data( $fields ): array {
 		// Enqueue js for the frontend.
 		if ( ! $this->is_rest_request() ) {
-			wp_enqueue_script( 'social-media-cards', P4GBKS_PLUGIN_URL . 'public/js/social_media_cards.js', [], '0.1', true );
+			\P4GBKS\Loader::enqueue_local_script( 'social-media-cards', 'public/js/social_media_cards.js' );
 		}
 		$image_size = 'retina-large';
 

--- a/classes/blocks/class-submenu.php
+++ b/classes/blocks/class-submenu.php
@@ -148,7 +148,7 @@ class Submenu extends Base_Block {
 
 		// Enqueue js for the frontend.
 		if ( ! $this->is_rest_request() ) {
-			wp_enqueue_script( 'submenu', P4GBKS_PLUGIN_URL . 'public/js/submenu.js', [ 'jquery' ], '0.2', true );
+			\P4GBKS\Loader::enqueue_local_script( 'submenu', 'public/js/submenu.js', [ 'jquery' ] );
 			wp_localize_script( 'submenu', 'submenu', $menu );
 		}
 

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -314,21 +314,15 @@ final class Loader {
 			'p4gbks_admin_style',
 			P4GBKS_PLUGIN_URL . 'assets/build/editorStyle.min.css', // - Bundled CSS for the blocks
 			[],
-			'0.4'
+			self::file_ver( P4GBKS_PLUGIN_DIR . '/assets/build/editorStyle.min.css' )
 		);
 
-		wp_enqueue_script(
-			'p4gbks_admin_script',
-			P4GBKS_PLUGIN_URL . 'admin/js/editor.js',
-			[],
-			'0.2',
-			true
-		);
+		self::enqueue_local_script( 'p4gbks_admin_script', 'admin/js/editor.js' );
 
 		// Enqueue editor script for all Blocks in this Plugin.
-		wp_enqueue_script(
+		self::enqueue_local_script(
 			'planet4-blocks-script',
-			P4GBKS_PLUGIN_URL . 'assets/build/editorIndex.js',
+			'assets/build/editorIndex.js',
 			[
 				'wp-blocks',      // Helpers for registering blocks.
 				'wp-components',  // Wordpress components.
@@ -337,9 +331,7 @@ final class Loader {
 				'wp-i18n',        // Exports the __() function.
 				'wp-editor',
 				'wp-edit-post',
-			],
-			'0.1.15',
-			true
+			]
 		);
 
 		// Variables reflected from PHP to JS.
@@ -356,9 +348,6 @@ final class Loader {
 	 * Load assets for the frontend.
 	 */
 	public function enqueue_public_assets() {
-		// plugin-blocks assets.
-		$css_blocks_creation = filectime( P4GBKS_PLUGIN_DIR . '/assets/build/style.min.css' );
-
 		// Add master theme's main css as dependency for blocks css.
 		wp_enqueue_style(
 			'plugin-blocks',
@@ -368,13 +357,13 @@ final class Loader {
 				'slick',
 				'parent-style',
 			],
-			$css_blocks_creation
+			self::file_ver( P4GBKS_PLUGIN_DIR . '/assets/build/style.min.css' )
 		);
 
 		// Include React in the Frontend.
-		wp_enqueue_script(
+		self::enqueue_local_script(
 			'planet4-blocks-frontend',
-			P4GBKS_PLUGIN_URL . 'assets/build/frontendIndex.js',
+			'assets/build/frontendIndex.js',
 			[
 				// WP React wrapper.
 				'wp-element',
@@ -384,12 +373,10 @@ final class Loader {
 				'wp-api-fetch',
 				// URL helpers (as addQueryArgs).
 				'wp-url',
-			],
-			'0.1.7',
-			true
+			]
 		);
 
-		wp_enqueue_script( 'post_action', P4GBKS_PLUGIN_URL . 'public/js/post_action.js', [ 'jquery' ], '0.1', true );
+		self::enqueue_local_script( 'post_action', 'public/js/post_action.js', [ 'jquery' ] );
 	}
 
 	/**
@@ -407,15 +394,13 @@ final class Loader {
 
 			if ( is_string( $campaign_theme ) && ! empty( $campaign_theme ) ) {
 
-				$css_theme_creation = filectime( P4GBKS_PLUGIN_DIR . "/assets/build/theme_$campaign_theme.min.css" );
-
 				wp_enqueue_style(
 					'theme_antarctic',
 					P4GBKS_PLUGIN_URL . "/assets/build/theme_$campaign_theme.min.css",
 					[
 						'plugin-blocks',
 					],
-					$css_theme_creation
+					self::file_ver( P4GBKS_PLUGIN_DIR . "/assets/build/theme_$campaign_theme.min.css" )
 				);
 			}
 		}
@@ -592,6 +577,45 @@ final class Loader {
 		// Disable gradient presets & custom gradients.
 		add_theme_support( 'editor-gradient-presets', [] );
 		add_theme_support( 'disable-custom-gradients' );
+	}
+
+	/**
+	 * @param string $filepath Absolute path to the file.
+	 * @return int timestamp of file creation
+	 */
+	public static function file_ver( string $filepath ): int {
+		$ctime = filectime( $filepath );
+		if ( $ctime ) {
+			return $ctime;
+		}
+
+		return time();
+	}
+
+	/**
+	 * Enqueue a local, publicly accessible script.
+	 *
+	 * @see wp_enqueue_script()
+	 *
+	 * @param string   $handle    Name of the script. Should be unique.
+	 * @param string   $rel_path  Path to the script, relative to P4GBKS_PLUGIN_DIR.
+	 * @param string[] $deps      Optional. An array of registered script handles this script depends on. Default empty array.
+	 * @param bool     $in_footer Optional. Whether to enqueue the script before </body> instead of in the <head>.
+	 *                                Default 'false'.
+	 */
+	public static function enqueue_local_script(
+		string $handle,
+		string $rel_path,
+		array $deps = [],
+		bool $in_footer = true
+	): void {
+		wp_enqueue_script(
+			$handle,
+			trailingslashit( P4GBKS_PLUGIN_URL ) . $rel_path,
+			$deps,
+			self::file_ver( trailingslashit( P4GBKS_PLUGIN_DIR ) . $rel_path ),
+			$in_footer
+		);
 	}
 
 	/**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5186

Script version is not automatically updated when we make changes, which leads to cache problems if we forget it.

## Fix

Switch from hardcoded version to `filectime`.

Versions were found with regex `[0-9]{1,2}\.[0-9]{1,2}`, and by looking at `wp_enqueue_style` and `wp_enqueue_script` usage.

I took the liberty to regroup those calls in a static function, to limit the number of parameters used. If you feel like it's too big of a change and I went too far, I can roll this back :)

## Test

On the editor side while editing a page, in the network calls or in html source, we should see a call to `planet4-plugin-gutenberg-blocks/assets/build/editorIndex.js?ver=1591791157` with a timestamp as version number. You can filter by `ver=159` to see those calls.  
No network call related to this plugin should be a 404, on the public and the admin sides.

#### We need to talk...

... about `Using short ternaries is not allowed (WordPress.PHP.DisallowShortTernary.Found)`. It's making me sad, I feel like writing PHP4 😢 _Just read this https://make.wordpress.org/core/2019/07/12/php-coding-standards-changes/ , still not convinced.  
edit: this comment https://make.wordpress.org/core/2019/07/12/php-coding-standards-changes/#comment-37128 actually makes sense, but I don't feel it applies to us._