### PR TITLE
PLANET-5199 Add data attributes on Columns Block

### DIFF
--- a/templates/blocks/columns.twig
+++ b/templates/blocks/columns.twig
@@ -25,7 +25,9 @@
 											<a
 												href="{{ col.cta_link|e('esc_url') }}"
 												{{  col.link_new_tab and col.link_new_tab != "false" ? 'target="_blank"' }}
-											>
+												data-ga-category="Columns Block"
+												data-ga-action="{{ fields.columns_block_style == 'icons' ? 'Icon' : 'Image' }}"
+												data-ga-label="{{ col.cta_link|e('esc_url') }}">
 										{% endif %}
 											<img src="{{ col.attachment }}" alt="{{ col.title }}">
 										{% if col.cta_link %}
@@ -34,11 +36,22 @@
 									</div>
 								{% endif %}
 
-								<h3>
-									{% if col.cta_link and not is_campaign %}<a href="{{ col.cta_link|e('esc_url') }}">{% endif %}
-										{{ col.title|e('wp_kses_post')|raw }}
-										{% if col.cta_link and not is_campaign %}</a>{% endif %}
-								</h3>
+								{% if col.cta_link and is_campaign %}
+									<h3
+										data-ga-category="Columns Block"
+										data-ga-action="Title"
+										data-ga-label="n/a">
+								{% elseif col.cta_link %}
+									<h3>
+										<a
+											href="{{ col.cta_link|e('esc_url') }}"
+											data-ga-category="Columns Block"
+											data-ga-action="Title"
+											data-ga-label="{{ col.cta_link|e('esc_url') }}">
+								{% endif %}
+											{{ col.title|e('wp_kses_post')|raw }}
+								{% if col.cta_link and not is_campaign %}</a>{% endif %}
+									</h3>
 								{% if col.description %}
 									<p>{{ col.description|e('wp_kses_post')|raw|nl2br }}</p>
 								{% endif %}
@@ -49,7 +62,10 @@
 											class="btn {{ is_campaign ? 'btn-primary' : 'btn-secondary' }}"
 										{% else %}
 											class="call-to-action-link"
-										{% endif %}>
+										{% endif %}
+											data-ga-category="Columns Block"
+											data-ga-action="Call to Action"
+											data-ga-label="{{ col.cta_link|e('esc_url') }}">
 										{{ col.cta_text|e('wp_kses_post')|raw }}
 									</a>
 								{% endif %}

--- a/templates/blocks/columns_tasks.twig
+++ b/templates/blocks/columns_tasks.twig
@@ -20,7 +20,13 @@
 						{% for col in fields.columns %}
 							<div class="col" data-id="{{ loop.index }}">
 								<span class="step-number">
-									<span class="step-number-inner">{{ loop.index }}</span>
+									<span
+										class="step-number-inner"
+										data-ga-category="Columns Block"
+										data-ga-action="Task Number"
+										data-ga-label="n/a">
+											{{ loop.index }}
+									</span>
 								</span>
 							</div>
 						{% endfor %}
@@ -29,7 +35,12 @@
 						<div class="row">
 							{% for col in fields.columns %}
 								<div class="col" data-id="{{ loop.index }}">
-									<h5>{{ col.title }}</h5>
+									<h5
+										data-ga-category="Columns Block"
+										data-ga-action="Title"
+										data-ga-label="n/a">
+											{{ col.title }}
+									</h5>
 								</div>
 							{% endfor %}
 						</div>
@@ -50,7 +61,11 @@
 									<div class="col" data-id="{{ loop.index }}">
 										{% if ( col.attachment ) %}
 												{% if ( col.cta_link ) %}
-													<a href="{{ col.cta_link }}">
+													<a
+														href="{{ col.cta_link|e('esc_url') }}"
+														data-ga-category="Columns Block"
+														data-ga-action="Image"
+														data-ga-label="{{ col.cta_link|e('esc_url') }}">
 												{% endif %}
 														<img src="{{ col.attachment }}" alt=""/>
 												{% if ( col.cta_link ) %}
@@ -64,10 +79,14 @@
 								{% for col in fields.columns %}
 									<div class="col" data-id="{{ loop.index }}">
 										{% if ( col.cta_text and col.cta_link ) %}
-											<a class="btn btn-small btn-medium {{ is_campaign ? 'btn-primary' : 'btn-secondary' }}"
-												href="{{ col.cta_link }}"
-												{{  col.link_new_tab  ? 'target="_blank"' }}>
-												{{ col.cta_text }}
+											<a
+												class="btn btn-small btn-medium {{ is_campaign ? 'btn-primary' : 'btn-secondary' }}"
+												href="{{ col.cta_link|e('esc_url') }}"
+												{{  col.link_new_tab  ? 'target="_blank"' }}
+												data-ga-category="Columns Block"
+												data-ga-action="Call to Action"
+												data-ga-label="{{ col.cta_link|e('esc_url') }}">
+													{{ col.cta_text }}
 											</a>
 										{% endif %}
 									</div>
@@ -95,8 +114,17 @@
 									   data-toggle="collapse" data-target=".card-header:hover + #collapse-{{ number_to_word }}"
 									   href="#collapse-{{ number_to_word }}"
 									   aria-expanded="true"
-									   aria-controls="collapse-{{ number_to_word }}">
-										<span class="step-number">{{ loop.index }}</span>
+									   aria-controls="collapse-{{ number_to_word }}"
+									   data-ga-category="Columns Block"
+									   data-ga-action="Title"
+									   data-ga-label="n/a">
+										<span
+											class="step-number"
+											data-ga-category="Columns Block"
+											data-ga-action="Task Number"
+											data-ga-label="n/a">
+												{{ loop.index }}
+										</span>
 										{% if ( col.title ) %}
 											{{ col.title }}
 										{% endif %}
@@ -131,8 +159,13 @@
 											{% endif %}
 
 											{% if ( col.cta_text and col.cta_link ) %}
-												<a class="btn btn-small {{ is_campaign ? 'btn-primary' : 'btn-secondary' }}"
-												   href="{{ col.cta_link }}">{{ col.cta_text }}
+												<a
+													class="btn btn-small {{ is_campaign ? 'btn-primary' : 'btn-secondary' }}"
+													href="{{ col.cta_link|e('esc_url') }}"
+													data-ga-category="Columns Block"
+													data-ga-action="Call to Action"
+													data-ga-label="{{ col.cta_link|e('esc_url') }}">
+														{{ col.cta_text }}
 												</a>
 											{% endif %}
 


### PR DESCRIPTION
Related to [JIRA 5199](https://jira.greenpeace.org/browse/PLANET-5199)

Task -
- Add data attributes on columns block title, image and CTA link/buttons as per the JIRA ticket.

Testing -
- Create a [new page](https://k8s.p4.greenpeace.org/test-pluto/wp-admin/post-new.php?post_type=page) with all columns styles and check the data attributes by inspecting the column title, image and CTA html tags.
- The attributes and their values should be as per JIRA ticket details
Note: On Task column block please  check for mobile screen view. also test column block on campaign page, the column title has no anchor tag on campaign page.