### PR TITLE
[No issue] Make the frontendRendered definition a bit more verbose.

### DIFF
--- a/assets/src/blocks/frontendRendered.js
+++ b/assets/src/blocks/frontendRendered.js
@@ -4,15 +4,21 @@ import { FrontendBlockNode } from '../components/FrontendBlockNode/FrontendBlock
  * This function is used in the `save()` method of `registerBlock` to
  * render React blocks in the frontend.
  *
+ * It returns a function with the same arguments as the `save()`
+ * method.
+ *
  * Be careful! Making changes in this function or in the `FrontendBlockNode`
  * component could potentially cause block validation errors in Gutenberg.
  *
  * @param {string} block
  */
-export const frontendRendered = ( block ) => ( attributes, className ) => {
-  return <FrontendBlockNode
-    attributes={ attributes }
-    className={ className }
-    blockName={ block }
-  />;
+export const frontendRendered = ( block ) => {
+  return ( attributes, className ) => {
+    return <FrontendBlockNode
+      attributes={ attributes }
+      className={ className }
+      blockName={ block }
+    />;
+  }
 }
+


### PR DESCRIPTION
After chatting with Dirk about the implementation of the frontend rendering, it seemed like a good idea to make this change. Some shortcuts in JS syntax can be confusing (in this case, chaining two arrow functions).

So maybe using a function block and return is clearer to a newcomer.