### PR TITLE
PLANET-5142 Add twig filter(cf_img_url) on carousal header image urls

### DIFF
--- a/templates/blocks/carousel_header_full-width-classic.twig
+++ b/templates/blocks/carousel_header_full-width-classic.twig
@@ -27,12 +27,12 @@
 								{% if slide.image %}
 									<img
 										{% if ( loop.first ) %}
-										src="{{ slide.image }}"
-										srcset="{{ slide.image_srcset }}"
+										src="{{ slide.image|cf_img_url(slide.image_srcset) }}"
+										srcset="{{ slide.image_srcset|cf_img_url }}"
 										sizes="{{ slide.image_sizes }}"
 										{% else %}
-										data-src="{{ slide.image }}"
-										data-srcset="{{ slide.image_srcset }}"
+										data-src="{{ slide.image|cf_img_url(slide.image_srcset) }}"
+										data-srcset="{{ slide.image_srcset|cf_img_url }}"
 										data-sizes="{{ slide.image_sizes }}"
 										class="preload"
 										{% endif %}


### PR DESCRIPTION
Ref. 
[JIRA 5142](https://jira.greenpeace.org/browse/PLANET-5142)
https://developers.cloudflare.com/images/responsive

~- Add a twig filter which returns cloudflare ready(cloudflare optimized) image url~
Note: The twig filter code moved to [master theme](https://github.com/greenpeace/planet4-master-theme/pull/1139).