### PR TITLE
PLANET-5305: Column block: non-linked Header styles broken

### DIFF
--- a/templates/blocks/columns.twig
+++ b/templates/blocks/columns.twig
@@ -48,6 +48,8 @@
 											data-ga-category="Columns Block"
 											data-ga-action="Title"
 											data-ga-label="{{ col.cta_link|e('esc_url') }}">
+								{% else %}
+									<h3>
 								{% endif %}
 											{{ col.title|e('wp_kses_post')|raw }}
 								{% if col.cta_link and not is_campaign %}</a>{% endif %}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5305

Following https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/313 , a missing opening tag `h3` causes Column titles without links to display as regular text.  
The fix adds an opening tag in the default case (no link, no campaign)

## Tests

Add a column block to a page, one of the column title has to be without link (field `Button/CtA Link` empty).

Before fix:
<img width="742" alt="Screenshot 2020-07-10 at 17 14 24" src="https://user-images.githubusercontent.com/617346/87170124-37e61380-c2d1-11ea-943c-536dd5f40fe4.png">

After fix:
<img width="750" alt="Screenshot 2020-07-10 at 17 14 39" src="https://user-images.githubusercontent.com/617346/87170133-3b799a80-c2d1-11ea-86e4-9950ce30ab32.png">

