### PR TITLE
PLANET-5014: Prevent the skip-links class from pushing page-content down

### DIFF
--- a/assets/src/styles/blocks/core-overrides/BlockSpacing.scss
+++ b/assets/src/styles/blocks/core-overrides/BlockSpacing.scss
@@ -25,13 +25,6 @@
 .post-details > h2,
 .post-details > ul {
   display: inline-block;
-  margin-top: $space-xs;
-  margin-bottom: $space-md;
-
-  @include large-and-up {
-    margin-top: $space-md;
-    margin-bottom: $space-lg;
-  }
 }
 
 .page-template > ul,

--- a/assets/src/styles/blocks/core-overrides/BlockSpacing.scss
+++ b/assets/src/styles/blocks/core-overrides/BlockSpacing.scss
@@ -21,9 +21,9 @@
 .wp-block-file,
 .wp-block-button,
 .page-template > h2,
-.page-template > ul,
+.page-template > ul:not(.skip-links),
 .post-details > h2,
-.post-details > ul {
+.post-details > ul:not(.skip-links) {
   display: inline-block;
 }
 


### PR DESCRIPTION
Because of typography changes using a too general css selector the skip-links class was pushing content down on some pages.
Excluding .skip-links now from displaying as inline-block and remove some duplicated rules