### PR TITLE
PLANET-5187: Fix button link color in plastic theme

### DIFF
--- a/assets/src/styles/campaigns/themes/_theme_plastic.scss
+++ b/assets/src/styles/campaigns/themes/_theme_plastic.scss
@@ -391,6 +391,10 @@ body.theme-plastic {
         }
       }
     }
+
+    .btn-primary {
+      @extend .btn-primary;
+    }
   } // end take action task block
 
   .split-three-column {
@@ -426,6 +430,10 @@ body.theme-plastic {
       @include large-and-up {
         padding-bottom: 0;
       }
+    }
+
+    .btn-primary {
+      @extend .btn-primary;
     }
   }
 
@@ -464,10 +472,10 @@ body.theme-plastic {
         line-height: 2.1rem;
         font-size: 1.5rem;
       }
+    }
 
-      .btn-primary {
-        @extend .btn-primary;
-      }
+    .btn-primary {
+      @extend .btn-primary;
     }
   }
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5187

> The rounded buttons in the column blocks need white text not blue in the icon columns block in the https://www.greenpeace.org/international/campaign/single-use-ban-in-your-community/

<img width="647" alt="Screenshot 2020-07-22 at 17 35 52" src="https://user-images.githubusercontent.com/617346/88196736-d3687400-cc41-11ea-9f2e-7d563c55f525.png">


## Fix 

Links in primary buttons have a rule for white color text (`plastics-button($background: $plastics-peach-darker, $foreground: white)` I guess ?), but a more precise one `.page-template a` (coming from https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/265) overrides it.  
The fix adds a new rule for `a.btn-primary` specifically. 

I feel like I should parameterize text color to use the same variable for text and link, but not sure if this is possible in a simple way <sub>my god when did frontend become so convoluted let me out 🔨 </sub>

## Tests

- Export campaigns from the [staging site](https://release.k8s.p4.greenpeace.org/international/) (Tools > Export)
- Import the file locally (Tools > Import)
- Display the campaign _Lobby for Single-Use Ban in Your Community_
- Buttons should have a white text

<img width="639" alt="Screenshot 2020-07-22 at 17 38 10" src="https://user-images.githubusercontent.com/617346/88196997-280bef00-cc42-11ea-8a85-f8091c63498a.png">

