### PR TITLE
PLANET-5296 Fix empty TA Card on Posts

### DIFF
--- a/classes/blocks/class-takeactionboxout.php
+++ b/classes/blocks/class-takeactionboxout.php
@@ -144,8 +144,9 @@ class TakeActionBoxout extends Base_Block {
 		}
 
 		$args = [
-			'p'         => intval( $page_id ), // ID of a page, post.
-			'post_type' => 'any',
+			'p'           => (int) $page_id, // ID of a page, post.
+			'post_type'   => 'any',
+			'post_status' => 'publish',
 		];
 
 		// Try to find the page that the user selected.
@@ -153,20 +154,22 @@ class TakeActionBoxout extends Base_Block {
 		$page  = null;
 		$tag   = null;
 
-		// If page is found populate the necessary fields for the block.
-		if ( $query->have_posts() ) {
-			$posts   = $query->get_posts();
-			$page    = $posts[0];
-			$wp_tags = wp_get_post_tags( $page->ID );
-			$tags    = [];
+		if ( ! $query->have_posts() ) {
+			return [];
+		}
 
-			if ( is_array( $wp_tags ) && $wp_tags ) {
-				foreach ( $wp_tags as $wp_tag ) {
-					$tags[] = [
-						'name' => $wp_tag->name,
-						'link' => get_tag_link( $wp_tag ),
-					];
-				}
+		// Populate the necessary fields for the block.
+		$posts   = $query->get_posts();
+		$page    = $posts[0];
+		$wp_tags = wp_get_post_tags( $page->ID );
+		$tags    = [];
+
+		if ( is_array( $wp_tags ) && $wp_tags ) {
+			foreach ( $wp_tags as $wp_tag ) {
+				$tags[] = [
+					'name' => $wp_tag->name,
+					'link' => get_tag_link( $wp_tag ),
+				];
 			}
 		}
 
@@ -174,7 +177,7 @@ class TakeActionBoxout extends Base_Block {
 
 		// Populate variables.
 		$block = [
-			'campaigns' => $tags,
+			'campaigns' => $tags ?? [],
 			'title'     => null === $page ? '' : $page->post_title,
 			'excerpt'   => null === $page ? '' : $page->post_excerpt,
 			'link'      => null === $page ? '' : get_permalink( $page ),
@@ -186,6 +189,7 @@ class TakeActionBoxout extends Base_Block {
 		$data = [
 			'boxout' => $block,
 		];
+
 		return $data;
 	}
 


### PR DESCRIPTION
Related to [JIRA #5296](https://jira.greenpeace.org/browse/PLANET-5296) 

Fix -
- Add  'post_status' = 'publish' condition on selected TAB page
- Return empty array if no TAB page is active
- Fix `PHP Notice:  Undefined variable: tags`

Test -
- Add a new TA page
- add/edit post and select newly added TA page from "Take Action Page Selector" dropdown at bottom of post or add a "Take Action Boxout" block from P4 blocks with new TA page
- Check the new post on frontend, the TAB is visible as intended
- Now change the status of TA page to draft
- The TAB should no longer visible on post page

e.g. https://k8s.p4.greenpeace.org/test-venus/story/28509/fukushima-and-the-2020-olympics/