### PR TITLE
PLANET-5161 Make columns headers bold in platics

### DIFF
--- a/assets/src/styles/campaigns/themes/_theme_plastic.scss
+++ b/assets/src/styles/campaigns/themes/_theme_plastic.scss
@@ -411,7 +411,7 @@ body.theme-plastic {
   }
 
   .columns-block.block-style-no_image {
-    @include campaign_columns_style_no_image($montserrat, $plastics-blue, 400, none);
+    @include campaign_columns_style_no_image($montserrat, $plastics-blue, $extra-bold, none);
 
     font-size: 1.875rem;
     line-height: 2.25rem;
@@ -438,7 +438,7 @@ body.theme-plastic {
   }
 
   .columns-block.block-style-image {
-    @include campaign_columns_style_no_image($montserrat, $plastics-blue, 400, none);
+    @include campaign_columns_style_no_image($montserrat, $plastics-blue, $extra-bold, none);
 
     h2 {
       text-transform: none;


### PR DESCRIPTION
The ticket requested these to be bold, although the previous style was font-weight 900 (extra bold). That extra bold came from the campaign sidebar settings, but somehow this rule got removed. I didn't add it back because it affects all headers.