### PR TITLE
PLANET-5343: Plastics theme: items should be center aligned

### DIFF
--- a/assets/src/styles/campaigns/themes/_theme_plastic.scss
+++ b/assets/src/styles/campaigns/themes/_theme_plastic.scss
@@ -343,7 +343,7 @@ body.theme-plastic {
         height: 154px;
         width: 154px;
         line-height: 154px;
-        margin-bottom: 20px;
+        margin: 0 auto 20px auto;
 
         .step-number-inner {
           background-image: url("../../public/images/plastic/take-action.png");
@@ -359,6 +359,12 @@ body.theme-plastic {
           font-family: $montserrat;
           font-weight: $semi-bold;
           text-transform: none;
+        }
+      }
+
+      .steps-action {
+        .row > .col {
+          text-align: center;
         }
       }
     }
@@ -394,6 +400,14 @@ body.theme-plastic {
 
     .btn-primary {
       @extend .btn-primary;
+
+      @include large-and-up {
+        padding: 0 20px;
+      }
+
+      @include x-large-and-up {
+        padding: 0 40px;
+      }
     }
   } // end take action task block
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5343

> Task column block copy, icon and button copy should be centre aligned and not left aligned

This PR aligns icon and button of plastic campaign columns to the center.

<img width="915" alt="Screenshot 2020-07-27 at 17 22 20" src="https://user-images.githubusercontent.com/617346/88559977-d1315b80-d02d-11ea-8d33-b7fd48d4d6d1.png">
