### PR TITLE
PLANET-4801 Render block node in backend

### DIFF
--- a/classes/blocks/class-articles.php
+++ b/classes/blocks/class-articles.php
@@ -39,8 +39,14 @@ class Articles extends Base_Block {
 		register_block_type(
 			'planet4-blocks/articles',
 			[
-				'editor_script' => 'planet4-blocks',
-				'attributes'    => [
+				'editor_script'   => 'planet4-blocks',
+				// todo: Remove when all content is migrated.
+				'render_callback' => static function ( $attributes ) {
+					$json = wp_json_encode( [ 'attributes' => $attributes ] );
+
+					return '<div data-render="planet4-blocks/articles" data-attributes="' . htmlspecialchars( $json ) . '"></div>';
+				},
+				'attributes'      => [
 					'article_heading'      => [
 						'type' => 'string',
 					],


### PR DESCRIPTION
* Otherwise older blocks that weren't saved with the block node in the
block content would not display until they are saved in the wywiwyg
version.