### PR TITLE
PLANET-4801 Use fetch with base url for wpml

### DIFF
--- a/assets/src/blocks/Articles/ArticlesFrontend.js
+++ b/assets/src/blocks/Articles/ArticlesFrontend.js
@@ -14,7 +14,7 @@ export const ArticlesFrontend = (props) => {
 
   const postType = document.body.getAttribute('data-post-type');
 
-  const { posts, loadNextPage, hasMorePages, loading } = useArticlesFetch(props, postType, null);
+  const { posts, loadNextPage, hasMorePages, loading } = useArticlesFetch(props, postType, null, document.body.dataset.nro);
 
   return (
     <section className="block articles-block">

--- a/assets/src/blocks/Articles/useArticlesFetch.js
+++ b/assets/src/blocks/Articles/useArticlesFetch.js
@@ -3,7 +3,12 @@ import { useState, useEffect } from '@wordpress/element';
 const { apiFetch } = wp;
 const { addQueryArgs } = wp.url;
 
-export const useArticlesFetch = (attributes, postType, postId) => {
+const fetchJson = async(url) => {
+  const response = await fetch(url);
+  return response.json();
+};
+
+export const useArticlesFetch = (attributes, postType, postId, baseUrl = null) => {
   const { article_count, post_types, posts, tags, ignore_categories } = attributes;
 
   const [totalPosts, setTotalPosts] = useState(null);
@@ -32,8 +37,11 @@ export const useArticlesFetch = (attributes, postType, postId) => {
       args.exclude_post_id = postId;
     }
 
+
     try {
-      const response = await apiFetch({ path: addQueryArgs('planet4/v1/get-posts', args) });
+      const response = baseUrl
+        ? await fetchJson(`${ baseUrl }/wp-json/${ addQueryArgs('planet4/v1/get-posts', args) }`)
+        : await apiFetch({ path: addQueryArgs('planet4/v1/get-posts', args) });
 
       const newPosts = [...prevPosts, ...response.recent_posts];
 

--- a/classes/blocks/class-articles.php
+++ b/classes/blocks/class-articles.php
@@ -121,8 +121,7 @@ class Articles extends Base_Block {
 		// b. inside post - Get results excluding specific post.
 		// 3) specific posts - Get posts by ids specified in backend - new behavior / manual override.
 		// 4) issue page - Get posts based on page's tags.
-		$fields_diff = count( array_diff( [ 'post_types', 'posts' ], array_keys( $fields ) ) );
-		if ( is_tag() && ! empty( $fields['tags'] ) && 2 === $fields_diff ) {
+		if ( empty( $fields['posts'] ) && empty( $fields['post_types'] ) && ! empty( $fields['tags'] ) && is_tag() ) {
 			$args = self::filter_posts_for_tag_page( $fields );
 		} elseif ( ! empty( $fields['post_types'] ) ||
 				! empty( $fields['tags'] ) ||


### PR DESCRIPTION
* Using ApiFetch doesn't pass any language parameter to the endpoint.
However if you prefix the wp-json API path with the language code it
does pick this up.
* Check if the attributes are not empty instead of extracting them as
array keys. That was not working anymore since it's now getting a
request object instead in $fields.