### PR TITLE
PLANET-5371 Translate defaults on the backend

### DIFF
--- a/assets/src/blocks/Articles/ArticlesBlock.js
+++ b/assets/src/blocks/Articles/ArticlesBlock.js
@@ -15,7 +15,7 @@ export class ArticlesBlock {
       attributes: {
         article_heading: {
           type: 'string',
-          default: __('Latest Articles', 'planet4-blocks')
+          default: __('Related Articles', 'planet4-blocks')
         },
         articles_description: {
           type: 'string',
@@ -60,7 +60,6 @@ export class ArticlesBlock {
           attributes: {
             article_heading: {
               type: 'string',
-              default: __('Latest Articles', 'planet4-blocks')
             },
             articles_description: {
               type: 'string',
@@ -83,7 +82,6 @@ export class ArticlesBlock {
             },
             read_more_text: {
               type: 'string',
-              default: __('Load More', 'planet4-blocks')
             },
             read_more_link: {
               type: 'string',

--- a/assets/src/blocks/Articles/ArticlesFrontend.js
+++ b/assets/src/blocks/Articles/ArticlesFrontend.js
@@ -20,7 +20,7 @@ export const ArticlesFrontend = (props) => {
     <section className="block articles-block">
       <div className="container">
         <header>
-          <h2 className="page-section-header">{ article_heading || __('Latest Articles', 'planet4-blocks') }</h2>
+          <h2 className="page-section-header">{ article_heading }</h2>
         </header>
         { articles_description &&
           <div className="page-section-description" dangerouslySetInnerHTML={{ __html: articles_description }} />
@@ -35,7 +35,7 @@ export const ArticlesFrontend = (props) => {
                 href={ read_more_link }
                 target={ button_link_new_tab ? '_blank' : '' }
               >
-                { read_more_text || __('Load More', 'planet4-blocks') }
+                { read_more_text }
               </a>
             </div> :
             <div className="col-md-12 col-lg-5 col-xl-5">
@@ -44,7 +44,7 @@ export const ArticlesFrontend = (props) => {
                 onClick={ loadNextPage }
                 disabled={ loading }
               >
-                { read_more_text || __('Load More', 'planet4-blocks') }
+                { read_more_text }
               </button>
             </div>
           }

--- a/classes/blocks/class-articles.php
+++ b/classes/blocks/class-articles.php
@@ -43,7 +43,7 @@ class Articles extends Base_Block {
 				// todo: Remove when all content is migrated.
 				'render_callback' => static function ( $attributes ) {
 					if ( empty( $attributes['read_more_text'] ) ) {
-						$attributes['read_more_text'] = __('Load More', 'planet4-blocks');
+						$attributes['read_more_text'] = __( 'Load More', 'planet4-blocks' );
 					}
 
 					if ( empty( $attributes['article_heading'] ) ) {

--- a/classes/blocks/class-articles.php
+++ b/classes/blocks/class-articles.php
@@ -42,6 +42,14 @@ class Articles extends Base_Block {
 				'editor_script'   => 'planet4-blocks',
 				// todo: Remove when all content is migrated.
 				'render_callback' => static function ( $attributes ) {
+					if ( empty( $attributes['read_more_text'] ) ) {
+						$attributes['read_more_text'] = __('Load More', 'planet4-blocks');
+					}
+
+					if ( empty( $attributes['article_heading'] ) ) {
+						$attributes['article_heading'] = __( 'Related Articles', 'planet4-blocks' );
+					}
+
 					$json = wp_json_encode( [ 'attributes' => $attributes ] );
 
 					return '<div data-render="planet4-blocks/articles" data-attributes="' . htmlspecialchars( $json ) . '"></div>';


### PR DESCRIPTION
* For translations to work on the frontend we need to setup some things
first, so this workaround restores what was previously translated on the
backend until we have set up the frontend translations.

Ref: https://jira.greenpeace.org/browse/PLANET-5371
Deployed on https://k8s.p4.greenpeace.org/test-pandora/wp-admin/