### PR TITLE
PLANET-5263: Follow header typography rules for campaigns

### DIFF
--- a/assets/src/styles/campaigns/themes/_theme_antarctic.scss
+++ b/assets/src/styles/campaigns/themes/_theme_antarctic.scss
@@ -62,14 +62,10 @@ body.theme-antarctic {
     @include page-header-block($sanctuary);
 
     .page-header-title {
-      font-size: 3.125rem;
-      line-height: 4.375rem;
       color: $antarctic-blue;
     }
 
     .page-header-subtitle {
-      font-size: $font-size-xl;
-      line-height: 2.5rem;
       color: $antarctic-dark-blue;
     }
 

--- a/assets/src/styles/campaigns/themes/_theme_arctic.scss
+++ b/assets/src/styles/campaigns/themes/_theme_arctic.scss
@@ -74,15 +74,23 @@ body.theme-arctic {
     @include page-header-block($save-the-arctic);
 
     .page-header-title {
-      font-size: 3.125rem;
-      line-height: 3.75rem;
       color: $arctic-blue;
+
+      @include mobile-only {
+        line-height: 1.38;
+        margin-bottom: 5px;
+        font-size: $font-size-xl;
+      }
     }
 
     .page-header-subtitle {
-      font-size: $font-size-xl;
-      line-height: 2.125rem;
       color: $arctic-blue;
+
+      @include mobile-only {
+        line-height: 1.38;
+        margin-bottom: 5px;
+        font-size: $font-size-lg;
+      }
     }
 
     .page-header-background:after {

--- a/assets/src/styles/campaigns/themes/_theme_climate.scss
+++ b/assets/src/styles/campaigns/themes/_theme_climate.scss
@@ -106,16 +106,6 @@ body.theme-climate {
       font-weight: $bold;
     }
 
-    .page-header-title {
-      font-size: 3.125rem;
-      line-height: 4.375rem;
-    }
-
-    .page-header-subtitle {
-      font-size: $font-size-xl;
-      line-height: 2.5rem;
-    }
-
     .page-header-content {
       font-family: $roboto;
       font-size: 1.125rem;
@@ -130,11 +120,6 @@ body.theme-climate {
 
     @include small-and-up {
       background-image: linear-gradient(116deg, $bg-gradient-start, $bg-gradient-end);
-
-      .page-header-title {
-        font-size: 5.625rem;
-        line-height: 1;
-      }
     }
 
     @include large-and-up {

--- a/assets/src/styles/campaigns/themes/_theme_forest.scss
+++ b/assets/src/styles/campaigns/themes/_theme_forest.scss
@@ -65,15 +65,11 @@ body.theme-forest {
     @include page-header-block($kanit);
 
     .page-header-title {
-      font-size: 3.125rem;
-      line-height: 3.75rem;
       color: $forest-black;
       font-weight: $extra-bold;
     }
 
     .page-header-subtitle {
-      font-size: 1.875rem;
-      line-height: 2.25rem;
       color: $forest-black;
       font-weight: $semi-bold;
     }

--- a/assets/src/styles/campaigns/themes/_theme_oceans.scss
+++ b/assets/src/styles/campaigns/themes/_theme_oceans.scss
@@ -68,14 +68,10 @@ body.theme-oceans {
     overflow: hidden;
 
     .page-header-title {
-      font-size: 3.125rem;
-      line-height: 3.75rem;
       color: white;
     }
 
     .page-header-subtitle {
-      font-size: 1.875rem;
-      line-height: 2.25rem;
       color: white;
     }
 

--- a/assets/src/styles/campaigns/themes/_theme_oil.scss
+++ b/assets/src/styles/campaigns/themes/_theme_oil.scss
@@ -88,16 +88,6 @@ body.theme-oil {
       font-weight: $bold;
     }
 
-    .page-header-title {
-      font-size: 3.125rem;
-      line-height: 4.375rem;
-    }
-
-    .page-header-subtitle {
-      font-size: $font-size-xl;
-      line-height: 2.5rem;
-    }
-
     .page-header-content {
       font-family: $roboto;
       font-size: 1.125rem;

--- a/assets/src/styles/campaigns/themes/_theme_plastic.scss
+++ b/assets/src/styles/campaigns/themes/_theme_plastic.scss
@@ -62,21 +62,6 @@ body.theme-plastic {
       font-family: $montserrat;
       text-transform: uppercase;
     }
-
-    .page-header-title {
-      font-size: 2.5rem;
-      line-height: 3rem;
-
-      @include medium-and-up {
-        font-size: 3.125rem;
-        line-height: 4.375rem;
-      }
-    }
-
-    .page-header-subtitle {
-      font-size: $font-size-xl;
-      line-height: 2.5rem;
-    }
   }
 
   .covers-block {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5263

> This screen shot looks like H1 is not resizing for Mobile. This is the non campaign rules (...) So either apply H1 or H2 rules to it. H1 looks the closest.
 
Removing `page-header-(title|subtitle)` typography declarations to follow our styleguide rules.  `.page-header-title` is always associated with `h1`, `.page-header-subtitle` with `h2`, so no additional rule is needed.  
An exception was made for theme Arctic, as the font is really big and would break layout if treated as `h1/h2`. It takes `h2/h3` rules.   
Title can take a larger space on large screens, so it doesn't look like a column with large font-size.

![mob-comp](https://user-images.githubusercontent.com/617346/88902901-15ea0c00-d253-11ea-98b6-2b7e26fa8a92.png)


