### PR TITLE
Exclude current post id on frontend

### DIFF
--- a/assets/src/blocks/Articles/ArticlesFrontend.js
+++ b/assets/src/blocks/Articles/ArticlesFrontend.js
@@ -14,7 +14,11 @@ export const ArticlesFrontend = (props) => {
 
   const postType = document.body.getAttribute('data-post-type');
 
-  const { posts, loadNextPage, hasMorePages, loading } = useArticlesFetch(props, postType, null, document.body.dataset.nro);
+  const postIdClass = [...document.body.classList].find(className => /^postid-\d+$/.test(className));
+
+  const postId = !postIdClass ? null : postIdClass.split('-')[1];
+
+  const { posts, loadNextPage, hasMorePages, loading } = useArticlesFetch(props, postType, postId, document.body.dataset.nro);
 
   return (
     <section className="block articles-block">


### PR DESCRIPTION
* The block isn't available to be added in the post content, however it
is added automatically so we still need to exclude the current post id
if we're on a post.