### PR TITLE
PLANET-5301 Added JS acceptance tests for Articles block

### DIFF
--- a/tests/js/__snapshots__/articles.editor.spec.js.snap
+++ b/tests/js/__snapshots__/articles.editor.spec.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Articles block is inserted into the Editor 1`] = `
+"<!-- wp:planet4-blocks/articles -->
+<div class=\\"wp-block-planet4-blocks-articles\\" data-render=\\"planet4-blocks/articles\\" data-attributes=\\"{&quot;attributes&quot;:{&quot;article_heading&quot;:&quot;Related Articles&quot;,&quot;article_count&quot;:3,&quot;tags&quot;:[],&quot;posts&quot;:[],&quot;post_types&quot;:[],&quot;read_more_text&quot;:&quot;Load More&quot;,&quot;read_more_link&quot;:&quot;&quot;,&quot;button_link_new_tab&quot;:false,&quot;ignore_categories&quot;:false},&quot;innerBlocks&quot;:[]}\\"></div>
+<!-- /wp:planet4-blocks/articles -->"
+`;
+
+exports[`Articles block should use only the manually chosen posts if any are entered 1`] = `
+"<!-- wp:planet4-blocks/articles {\\"posts\\":[\\"263\\",\\"260\\",\\"256\\"]} -->
+<div class=\\"wp-block-planet4-blocks-articles\\" data-render=\\"planet4-blocks/articles\\" data-attributes=\\"{&quot;attributes&quot;:{&quot;article_heading&quot;:&quot;Related Articles&quot;,&quot;article_count&quot;:3,&quot;tags&quot;:[],&quot;posts&quot;:[&quot;263&quot;,&quot;260&quot;,&quot;256&quot;],&quot;post_types&quot;:[],&quot;read_more_text&quot;:&quot;Load More&quot;,&quot;read_more_link&quot;:&quot;&quot;,&quot;button_link_new_tab&quot;:false,&quot;ignore_categories&quot;:false},&quot;innerBlocks&quot;:[]}\\"></div>
+<!-- /wp:planet4-blocks/articles -->"
+`;
+
+exports[`Articles block should work with all editor inputs 1`] = `
+"<!-- wp:planet4-blocks/articles {\\"article_heading\\":\\"News\\",\\"articles_description\\":\\"Latest news details\\",\\"article_count\\":4,\\"tags\\":[6],\\"post_types\\":[16],\\"read_more_text\\":\\"Read more\\",\\"read_more_link\\":\\"https://www.greenpeace.org\\",\\"button_link_new_tab\\":true,\\"ignore_categories\\":true} -->
+<div class=\\"wp-block-planet4-blocks-articles\\" data-render=\\"planet4-blocks/articles\\" data-attributes=\\"{&quot;attributes&quot;:{&quot;article_heading&quot;:&quot;News&quot;,&quot;article_count&quot;:4,&quot;tags&quot;:[6],&quot;posts&quot;:[],&quot;post_types&quot;:[16],&quot;read_more_text&quot;:&quot;Read more&quot;,&quot;read_more_link&quot;:&quot;https://www.greenpeace.org&quot;,&quot;button_link_new_tab&quot;:true,&quot;ignore_categories&quot;:true,&quot;articles_description&quot;:&quot;Latest news details&quot;},&quot;innerBlocks&quot;:[]}\\"></div>
+<!-- /wp:planet4-blocks/articles -->"
+`;

--- a/tests/js/articles.editor.spec.js
+++ b/tests/js/articles.editor.spec.js
@@ -1,0 +1,103 @@
+import {
+  createNewPost,
+  enablePageDialogAccept,
+  getEditedPostContent,
+  insertBlock,
+} from '@wordpress/e2e-test-utils';
+
+import {
+  selectBlockByName,
+  openSidebarPanelWithTitle,
+  typeInInputWithLabel,
+  typeInInputWithPlaceholderLabel,
+  clickElementByText,
+  typeInDropdownWithLabel,
+  clearPreviousTextWithLabel,
+  clearPreviousTextWithPlaceholder,
+} from './e2e-tests-helpers';
+
+import 'expect-puppeteer';
+
+const ARTICLES_INVALID_URL_WARNING = 'The URL must start with "https://"';
+
+describe( 'Articles block', () => {
+  beforeAll( async () => {
+    // This helps in overriding Wordpress dialogs preventing actions.
+    await enablePageDialogAccept();
+  } );
+  beforeEach( async () => {
+    // Before running each test, go to the create post page.
+    await createNewPost({
+      postType: 'page',
+      title: 'Test Articles block',
+    } );
+
+    // Insert block by title.
+    await insertBlock( 'Articles' );
+    await page.waitForSelector( '.articles-title-container' );
+  } , 40000);
+
+  // This is the first test, tests starts with it().
+  it ( 'is inserted into the Editor', async () => {
+    // Check if block was inserted
+    expect( await page.$( '[data-type="planet4-blocks/articles"]' ) ).not.toBeNull();
+
+    expect( await getEditedPostContent() ).toMatchSnapshot();
+  } );
+
+  it ( 'should work with all editor inputs', async () => {
+    await selectBlockByName( 'planet4-blocks/articles' );
+
+    // Add richtext inputs.
+    await clearPreviousTextWithPlaceholder( 'Enter title' );
+    await typeInInputWithPlaceholderLabel( 'Enter title', 'News' );
+    await typeInInputWithPlaceholderLabel( 'Enter description', 'Latest news details' );
+
+    // Add loadmore button text in wysiwyg editor.
+    await clearPreviousTextWithLabel( 'Button Text' );
+    await typeInInputWithPlaceholderLabel( 'Enter text', 'More News' );
+
+    // Add Setting inputs
+    await openSidebarPanelWithTitle( 'Setting' );
+    await clearPreviousTextWithLabel( 'Button Text' );
+    await typeInInputWithLabel( 'Button Text', 'Read more' );
+    await typeInInputWithLabel( 'Button Link', 'https://www.greenpeace.org' );
+    await clickElementByText( 'label', 'Open in a new Tab' );
+    await clearPreviousTextWithLabel( 'Articles count' );
+    await typeInInputWithLabel( 'Articles count', '4' );
+    await typeInDropdownWithLabel( 'Select Tags', 'Climate' );
+    await typeInDropdownWithLabel( 'Post Types', 'Story' );
+    await clickElementByText( 'label', 'Ignore categories' );
+
+    expect( await getEditedPostContent() ).toMatchSnapshot();
+  }, 50000 );
+
+  it ( 'should show a warning if the URL is wrong', async () => {
+    await typeInInputWithLabel( 'Button Link', 'this is not a URL' );
+
+    // The warning component should appear.
+    await expect( page ).toMatchElement( '.edit-post-sidebar .input_error' );
+
+    // The warning text should appear.
+    await expect( page ).toMatch( ARTICLES_INVALID_URL_WARNING );
+  } );
+
+  it.skip ( 'should use only the manually chosen posts if any are entered', async () => {
+    await openSidebarPanelWithTitle( 'Setting' );
+
+    await typeInDropdownWithLabel( 'Manual override', 'Duis posuere' );
+    await typeInDropdownWithLabel( 'Manual override', 'Mauris quis dictum magna' );
+    await typeInDropdownWithLabel( 'Manual override', 'Lorem ipsum dolor sit amet' );
+
+    // The only 3 manually override post should appear in articles block.
+    await expect(page).toMatchElement('article:nth-child(1) h4 a', { text: 'Duis posuere' });
+    await expect(page).toMatchElement('article:nth-child(2) h4 a', { text: 'Mauris quis dictum magna' });
+    await expect(page).toMatchElement('article:nth-child(3) h4 a', { text: 'Lorem ipsum dolor sit amet' });
+
+    // The "Load more" should not appear.
+    await expect( page ).not.toMatchElement( '.block-editor .article-load-more' );
+
+    expect( await getEditedPostContent() ).toMatchSnapshot();
+  } , 50000 );
+} );
+

--- a/tests/js/articles.frontend.spec.js
+++ b/tests/js/articles.frontend.spec.js
@@ -1,0 +1,139 @@
+import {
+  createNewPost,
+  enablePageDialogAccept,
+  setPostContent,
+  publishPost,
+} from '@wordpress/e2e-test-utils';
+
+import {
+  selectBlockByName,
+  openSidebarPanelWithTitle,
+  clickElementByText,
+  typeInDropdownWithLabel,
+} from './e2e-tests-helpers';
+
+import 'expect-puppeteer';
+
+const ARTICLES_BLOCK = `
+<!-- wp:planet4-blocks/articles {"article_count":2} -->
+<div class="wp-block-planet4-blocks-articles" data-render="planet4-blocks/articles" data-attributes="{&quot;attributes&quot;:{&quot;article_heading&quot;:&quot;Related Articles&quot;,&quot;article_count&quot;:2,&quot;tags&quot;:[],&quot;posts&quot;:[],&quot;post_types&quot;:[],&quot;read_more_text&quot;:&quot;Load More&quot;,&quot;read_more_link&quot;:&quot;&quot;,&quot;button_link_new_tab&quot;:false,&quot;ignore_categories&quot;:false},&quot;innerBlocks&quot;:[]}"></div>
+<!-- /wp:planet4-blocks/articles -->
+`;
+
+describe( 'Articles block frontend', () => {
+  beforeAll( async () => {
+    // This helps in overriding Wordpress dialogs preventing actions.
+    await enablePageDialogAccept();
+  } );
+
+  it ( 'test post thumbnail behaviour', async () => {
+    // Create new post.
+    await createNewPost({
+      title: 'Test Articles with no thumbnail',
+      content: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+      showWelcomeGuide: false,
+    });
+    await publishPost();
+    await page.waitForSelector( '.post-publish-panel__postpublish' );
+
+    //Create a new page and add newly created post in it.
+    await createNewPost({
+      postType: 'page',
+      title: 'Test Articles block thumbnail',
+      showWelcomeGuide: false,
+    });
+
+    // Add articles block in page.
+    await setPostContent( ARTICLES_BLOCK );
+
+    await selectBlockByName( 'planet4-blocks/articles' );
+
+    await openSidebarPanelWithTitle( 'Setting' );
+
+    // Manually add post(without thumbnail img) in articles blocks.
+    await typeInDropdownWithLabel( 'Manual override', 'Test Articles with no thumbnail' );
+
+    // Manually add post(post with image inside post content, which was set as a feature image
+    // & display as a thumbnail in articles block) in articles blocks.
+    await typeInDropdownWithLabel( 'Manual override', 'Lorem ipsum dolor sit amet' );
+
+    // Publish the page.
+    await publishPost();
+
+    await new Promise((r) => setTimeout(r, 500));
+
+    await page.waitForSelector( '.post-publish-panel__postpublish' );
+
+    // Test articles block on frontend.
+    await clickElementByText( '*[@class="editor-post-publish-panel"]//a', 'View Page' );
+
+    await page.waitForNavigation();
+
+    await page.waitForSelector( '.page-template' );
+
+    // The "Articles Block" should appear on page.
+    await expect( page ).toMatchElement( '.block.articles-block' );
+
+    // If there is no image in the description of the post(also no featured image set),
+    // the blank space display as a thumbnail photo in articles block.
+    await expect(page).toMatchElement('article:nth-child(1) img', { src: ''} );
+    // If no Featured Image set, first image of post is set as a Featured Image &
+    // appear as a thumbnail in articles block.
+    const img_src = await page.$eval('article:nth-child(2) img', el => el.src);
+    expect( img_src ).not.toBeNull();
+  } , 50000 );
+
+  it ( 'should load the right amount of posts when clicking the load more button', async ( done ) => {
+    await createNewPost({
+      postType: 'page',
+      title: 'Test Articles block frontend',
+      showWelcomeGuide: false,
+    });
+
+    // Add the default page content and articles block.
+    await setPostContent( ARTICLES_BLOCK );
+
+    // Publish the page.
+    await publishPost();
+
+    await page.waitForSelector( '.post-publish-panel__postpublish' );
+
+    // Test articles block on frontend.
+    await clickElementByText( '*[@class="editor-post-publish-panel"]//a', 'View Page' );
+
+    await page.waitForNavigation();
+
+    await page.waitForSelector( '.page-template' );
+
+    // Wait for articles block to be loaded.
+    await new Promise((r) => setTimeout(r, 400));
+
+    // The "Articles Block" should appear on page.
+    await expect( page ).toMatchElement( '.block.articles-block' );
+
+    // Number of post in articles block.
+    const articlesCount = await page.evaluate(
+      () =>
+        document.querySelectorAll( '.block.articles-block article' )
+          .length
+    );
+    expect( articlesCount ).toEqual(2);
+
+    await clickElementByText( 'button', 'Load More' );
+
+    // Wait for load more response.
+    await new Promise((r) => setTimeout(r, 300));
+
+    await page.waitForSelector( '.article-load-more' );
+
+    // Number of post in articles block after load more.
+    const updatedArticlesCount = await page.evaluate(
+      () =>
+        document.querySelectorAll( '.block.articles-block article' )
+          .length
+    );
+    expect( updatedArticlesCount ).toEqual(4);
+
+    done();
+  } );
+} );

--- a/tests/js/e2e-tests-helpers.js
+++ b/tests/js/e2e-tests-helpers.js
@@ -52,7 +52,6 @@ export const typeInInputWithLabel = async ( label, value ) => {
   const [ inputEl ] = await page.$x( `//label[@class="components-base-control__label"][contains(text(),"${ label }")]/following-sibling::input[@class="components-text-control__input"]` );
   const propertyHandle = await inputEl.getProperty('id');
   const inputId = await propertyHandle.jsonValue();
-
   await page.type( `#${ inputId }`, value);
 };
 
@@ -128,6 +127,41 @@ export const typeInInputWithCheckbox = async ( name, value ) => {
   const [ element ] = await page.$x( `//*[contains(@class,"p4-custom-control-input")][contains(@name,"${ name }")]` );
   await element.click();
   await page.keyboard.type( value );
+};
+
+/**
+ * Types in an autocomplete input element based on its label.
+ *
+ * @param {string} label Label text of the text input.
+ * @param {string} value Value to be applied to the input.
+ */
+export const typeInDropdownWithLabel = async ( label, value ) => {
+  // Wait for 0.5 sec.
+  await new Promise((r) => setTimeout(r, 500));
+  const [ inputEl ] = await page.$x( `//label[contains(text(),"${ label }")]/following-sibling::div//input[@class="components-form-token-field__input"]` );
+  if ( inputEl ) {
+    const propertyHandle = await inputEl.getProperty('id');
+    const inputId = await propertyHandle.jsonValue();
+    await page.type( `#${ inputId }`, value.slice(0, 4));
+    await page.$eval('span[aria-label="'+value+'"]', (el) => el.click() );
+  }
+};
+
+/**
+ * Remove the existing text of input field, if exists.
+ *
+ * @param {string} label Text of the label before the text input.
+ */
+export const clearPreviousTextWithLabel = async ( label ) => {
+  const [ inputEl ] = await page.$x( `//label[@class="components-base-control__label"][contains(text(),"${ label }")]/following-sibling::input[@class="components-text-control__input"]` );
+
+  const valuePropertyHandle = await inputEl.getProperty('value');
+  const inputValue = await valuePropertyHandle.jsonValue();
+  if ( inputValue ) {
+    await inputEl.click();
+    await pressKeyWithModifier( 'primary', 'a' );
+    await page.keyboard.press( 'Backspace' );
+  }
 };
 
 /**


### PR DESCRIPTION
Ref. [JIRA 5301](https://jira.greenpeace.org/browse/PLANET-5301)

![image](https://user-images.githubusercontent.com/5357471/89406337-a4222e80-d73a-11ea-993e-a846e7837b78.png)

To test, run `npm install` and `npm run test`.
Use `npm run test:watch` to run the tests in slow motion and watch execution in browser.