### PR TITLE
PLANET-5235 Header Carousel: Header text cuts off at 32 characters

### DIFF
--- a/assets/src/blocks/Carouselheader/CarouselHeaderSlide.js
+++ b/assets/src/blocks/Carouselheader/CarouselHeaderSlide.js
@@ -114,7 +114,7 @@ export class CarouselHeaderSlide extends Component {
                     placeholder={__('Enter header', 'p4ge')}
                     value={this.props.header}
                     onChange={(e) => this.props.onHeaderChange(this.props.index, e)}
-                    characterLimit={40}
+                    characterLimit={32}
                   />
                 </div>
                 <div className="col">


### PR DESCRIPTION
Changed the limit indicator for the carousel header to match the actual limit of 32.