### PR TITLE
PLANET-5292 Check EN feature toggle

### DIFF
--- a/assets/src/blocks/Counter/CounterBlock.js
+++ b/assets/src/blocks/Counter/CounterBlock.js
@@ -81,7 +81,7 @@ export class CounterBlock {
 
       ]
 
-    if (window.p4ge_vars.planet4_options.feature_engaging_networks) {
+    if (window.p4ge_vars.features.feature_engaging_networks) {
       styles.push({
         name: 'en-forms-bar',
         label: __('Progress Bar inside EN Form', 'planet4-blocks')

--- a/assets/src/blocks/Counter/CounterBlock.js
+++ b/assets/src/blocks/Counter/CounterBlock.js
@@ -64,10 +64,7 @@ export class CounterBlock {
     // Remove the default style since it's the same as "text only"
     unregisterBlockStyle(BLOCK_NAME, 'default');
 
-    // Add our custom styles
-    registerBlockStyle(
-      BLOCK_NAME,
-      [
+    const styles = [
         {
           name: 'plain',
           label: __( 'Text Only', 'planet4-blocks' ),
@@ -81,11 +78,16 @@ export class CounterBlock {
           name: 'arc',
           label: __( 'Progress Dial', 'planet4-blocks' )
         },
-        {
-          name: 'en-forms-bar',
-          label: __( 'Progress Bar inside EN Form', 'planet4-blocks' )
-        }
+
       ]
-    );
+
+    if (window.p4ge_vars.planet4_options.feature_engaging_networks) {
+      styles.push({
+        name: 'en-forms-bar',
+        label: __('Progress Bar inside EN Form', 'planet4-blocks')
+      });
+    }
+    // Add our custom styles
+    registerBlockStyle( BLOCK_NAME, styles);
   };
 }

--- a/assets/src/blocks/ENForm/ENFormBlock.js
+++ b/assets/src/blocks/ENForm/ENFormBlock.js
@@ -2,6 +2,9 @@ import {ENForm} from './ENForm.js';
 
 export class ENFormBlock {
   constructor() {
+    if (!window.p4ge_vars.planet4_options.feature_engaging_networks) {
+      return;
+    }
     const {registerBlockType} = wp.blocks;
 
     registerBlockType('planet4-blocks/enform', {

--- a/assets/src/blocks/ENForm/ENFormBlock.js
+++ b/assets/src/blocks/ENForm/ENFormBlock.js
@@ -2,7 +2,7 @@ import {ENForm} from './ENForm.js';
 
 export class ENFormBlock {
   constructor() {
-    if (!window.p4ge_vars.planet4_options.feature_engaging_networks) {
+    if (!window.p4ge_vars.features.feature_engaging_networks) {
       return;
     }
     const {registerBlockType} = wp.blocks;

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -8,6 +8,9 @@
 
 namespace P4GBKS;
 
+use P4\MasterTheme\Features;
+use P4\MasterTheme\MigrationLog;
+use P4\MasterTheme\Migrations\M001EnableEnFormFeature;
 use WP_CLI;
 use P4GBKS\Command\Controller;
 use P4GBKS\Controllers\Ensapi_Controller;
@@ -341,9 +344,15 @@ final class Loader {
 		// Variables reflected from PHP to JS.
 		$option_values = get_option( 'planet4_options' );
 
+		$en_active = ! MigrationLog::from_wp_options()->already_ran( M001EnableEnFormFeature::get_id() )
+					|| Features::is_active( Features::ENGAGING_NETWORKS );
+
 		$reflection_vars = [
 			'home'            => P4GBKS_PLUGIN_URL . '/public/',
 			'planet4_options' => $option_values,
+			'features'        => [
+				'feature_engaging_networks' => $en_active,
+			],
 		];
 		wp_localize_script( 'planet4-blocks-script', 'p4ge_vars', $reflection_vars );
 

--- a/classes/controller/menu/class-en-settings-controller.php
+++ b/classes/controller/menu/class-en-settings-controller.php
@@ -9,6 +9,8 @@
 
 namespace P4GBKS\Controllers\Menu;
 
+use P4\MasterTheme\Features;
+
 /**
  * Class Settings_Controller
  */
@@ -19,7 +21,7 @@ class En_Settings_Controller extends Controller {
 	 */
 	public function create_admin_menu() {
 
-		if ( current_user_can( 'manage_options' ) ) {
+		if ( Features::is_active(Features::ENGAGING_NETWORKS) && current_user_can( 'manage_options' ) ) {
 			add_menu_page(
 				'EngagingNetworks',
 				'EngagingNetworks',

--- a/classes/controller/menu/class-en-settings-controller.php
+++ b/classes/controller/menu/class-en-settings-controller.php
@@ -10,6 +10,8 @@
 namespace P4GBKS\Controllers\Menu;
 
 use P4\MasterTheme\Features;
+use P4\MasterTheme\MigrationLog;
+use P4\MasterTheme\Migrations\M001EnableEnFormFeature;
 
 /**
  * Class Settings_Controller
@@ -20,8 +22,12 @@ class En_Settings_Controller extends Controller {
 	 * Create menu/submenu entry.
 	 */
 	public function create_admin_menu() {
+		// We need to check if the migration already ran, as the EN block is on by default, but we cannot give an option
+		// that was added using CMB2 a default value of 'on', because then it can't be turned off.
+		$migration_ran     = MigrationLog::from_wp_options()->already_ran( M001EnableEnFormFeature::get_id() );
+		$feature_is_active = ! $migration_ran || Features::is_active( Features::ENGAGING_NETWORKS );
 
-		if ( Features::is_active(Features::ENGAGING_NETWORKS) && current_user_can( 'manage_options' ) ) {
+		if ( $feature_is_active && current_user_can( 'manage_options' ) ) {
 			add_menu_page(
 				'EngagingNetworks',
 				'EngagingNetworks',

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -16,6 +16,10 @@
  */
 
 // Exit if accessed directly.
+use P4\MasterTheme\Features;
+use P4\MasterTheme\MigrationLog;
+use P4\MasterTheme\Migrations\M001EnableEnFormFeature;
+
 defined( 'ABSPATH' ) || die( 'Direct access is forbidden !' );
 
 
@@ -225,10 +229,17 @@ function set_allowed_block_types( $allowed_block_types, $post ) {
 	];
 	// phpcs:enable
 
+	$migration_ran = MigrationLog::from_wp_options()->already_ran( M001EnableEnFormFeature::get_id() );
+
+	$enform_active = ! $migration_ran || Features::is_active( Features::ENGAGING_NETWORKS );
+
+	$page_block_types     = array_merge( PAGE_BLOCK_TYPES, ! $enform_active ? [] : [ 'planet4-blocks/enform' ] );
+	$campaign_block_types = array_merge( CAMPAIGN_BLOCK_TYPES, ! $enform_active ? [] : [ 'planet4-blocks/enform' ] );
+
 	$all_allowed_p4_block_types = [
 		'post'     => POST_BLOCK_TYPES,
-		'page'     => PAGE_BLOCK_TYPES,
-		'campaign' => CAMPAIGN_BLOCK_TYPES,
+		'page'     => $page_block_types,
+		'campaign' => $campaign_block_types,
 	];
 
 	$allowed_p4_block_types = $all_allowed_p4_block_types[ $post->post_type ];


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5292
Needs to be merged after https://github.com/greenpeace/planet4-master-theme/pull/1160 ! It uses classes introduced in that PR. The acceptance tests for this PR will fail until that is merged anyway.

Check the feature toggle of the EN block for the following cases:
* Whether the block can be used in the editor
* Whether the Engaging Networks admin menu item is displayed.
* Whether you can use the "Progress Bar inside EN Form" style on the counter block.

Because CMB2 interprets a falsy value on a boolean setting as "it should not store a record", it's not possible to set the default value to true, as that would make the field always true. So we need to run a script to turn the feature on everywhere instead. This is done in a post-deploy script (as part of the `p4-run-activator` command). There is a gap between when code is on production and when the post-deploy script runs. So to ensure the block is available before this script has run, we check whether the script has already run, which is stored in the db. That check can be removed in a subsequent deploy.