### PR TITLE
PLANET-5344: Video block is displayed on top of other blocks in the editor

### DIFF
--- a/assets/src/styles/editorOverrides.scss
+++ b/assets/src/styles/editorOverrides.scss
@@ -213,3 +213,9 @@ input.describe[type=text][data-setting=caption] {
   font-size: 13px;
   color: red;
 }
+
+.wp-embed-responsive .block-editor {
+   .wp-block-embed.wp-has-aspect-ratio .wp-block-embed__wrapper::before {
+    content: none;
+  }
+}

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -140,7 +140,7 @@ const CAMPAIGN_BLOCK_TYPES = [
 	'planet4-blocks/covers',
 	'planet4-blocks/gallery',
 	'planet4-blocks/happypoint',
-	'planet4-blocks/media',
+	'planet4-blocks/media-video',
 	'planet4-blocks/social-media',
 	'planet4-blocks/social-media-cards',
 	'planet4-blocks/spreadsheet',


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5344

> The video block displays over other blocks in the back end making it imposible to edit anything below it.

The iframe seems to ignore the max-(height|width) properties of its parents.


## Fix 

- ~Added an `height` property to the figure so that the inner frame can base its own size on it.  
The height value is arbitrary, but it helps the video to keep a proper size. I couldn't find another solution that would try to keep video ratio, fix overflow on other blocks and follow viewport width.~
- @mleray to the rescue; removing the `::before` content from the wrapper is enough and works a lot better.
- Activated P4 Media block in Campaigns, the block name in the allow-list was incomplete.

<img width="900" alt="Screenshot 2020-08-13 at 12 51 50" src="https://user-images.githubusercontent.com/617346/90129134-617ada80-dd68-11ea-81a0-4c64d20bbf68.png">  
_Pic: before fix / after fix_


## Test

- Insert a Youtube block in a page or a post
- Add a text paragraph after it
- The text should always be visible
- The video should more or less follow the viewport width, but never display over other blocks

Tested with following embeds: Youtube, Vimeo, Dailymotion, Kickstarter