### PR TITLE
PLANET-5400: Articles block editor CSS rule scope is not specific enough

### DIFF
--- a/assets/src/styles/blocks/ArticlesEditor.scss
+++ b/assets/src/styles/blocks/ArticlesEditor.scss
@@ -2,7 +2,7 @@
   margin-top: 10px;
 }
 
-.editor-styles-wrapper {
+.wp-block[data-type="planet4-blocks/articles"] {
   .article-list-item-meta {
     margin: 0;
   }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5400

> A rule in the ArticlesEditor.scss file is not specific enough and applies to all `a` elements in the editor, causing various problems in other blocks.

## Fix 

Used a more specific selector `.wp-block[data-type="planet4-blocks/articles"]` based on block name, so that it never applies outside of its block.

## Test


The usage of Articles block in the editor should not change 🤷  
More specifically, clicking on a link inside this block in the editor should not lead to the linked page, but just put you into edit mode.