### PR TITLE
PLANET-5347 Added JS acceptance tests for Cookies block

### DIFF
--- a/tests/js/__snapshots__/cookies.spec.js.snap
+++ b/tests/js/__snapshots__/cookies.spec.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cookies block is inserted into the Editor 1`] = `"<!-- wp:planet4-blocks/cookies /-->"`;
+
+exports[`Cookies block should work with all inputs 1`] = `"<!-- wp:planet4-blocks/cookies {\\"title\\":\\"Cookies block\\",\\"description\\":\\"Test description\\",\\"necessary_cookies_name\\":\\"Necessary cookies\\",\\"necessary_cookies_description\\":\\"Lorem Ipsum is simply dummy text of the printing and typesetting industry.\\",\\"all_cookies_name\\":\\"Other Cookies\\",\\"all_cookies_description\\":\\"Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.\\"} /-->"`;

--- a/tests/js/cookies.spec.js
+++ b/tests/js/cookies.spec.js
@@ -1,0 +1,55 @@
+import {
+  createNewPost,
+  enablePageDialogAccept,
+  getEditedPostContent,
+  insertBlock,
+} from '@wordpress/e2e-test-utils';
+
+import {
+  selectBlockByName,
+  typeInInputWithPlaceholderLabel,
+  typeInInputWithCheckbox,
+} from './e2e-tests-helpers';
+
+import 'expect-puppeteer';
+
+describe( 'Cookies block', () => {
+  beforeAll( async () => {
+    // This helps in overriding Wordpress dialogs preventing actions
+    await enablePageDialogAccept();
+  } );
+  beforeEach( async () => {
+    // Before running each test, go to the create post page
+    await createNewPost( {
+      postType: 'page',
+      title: 'Test Cookies block',
+    } );
+
+    // Insert block by title
+    await insertBlock( 'Cookies' );
+  } );
+
+  // This is the first test, tests starts with it().
+  it( 'is inserted into the Editor', async () => {
+    // Check if block was inserted
+    expect( await page.$( '[data-type="planet4-blocks/cookies"]' ) ).not.toBeNull();
+
+    expect( await getEditedPostContent() ).toMatchSnapshot();
+  }, 25000);
+
+  it( 'should work with all inputs', async () => {
+    await selectBlockByName( 'planet4-blocks/cookies' );
+
+    // Add richtext inputs.
+    await typeInInputWithPlaceholderLabel( 'Enter title', 'Cookies block' );
+    await typeInInputWithPlaceholderLabel( 'Enter description', 'Test description' );
+
+    await typeInInputWithCheckbox( 'necessary_cookies', 'Necessary cookies' );
+    await typeInInputWithPlaceholderLabel( 'Enter necessary cookies description', 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.' );
+
+    await typeInInputWithCheckbox( 'all_cookies', 'Other Cookies' );
+    await typeInInputWithPlaceholderLabel( 'Enter all cookies description', 'Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.' );
+
+    expect( await getEditedPostContent() ).toMatchSnapshot();
+  });
+} );

--- a/tests/js/e2e-tests-helpers.js
+++ b/tests/js/e2e-tests-helpers.js
@@ -112,3 +112,14 @@ export const typeInTextareaWithLabel = async ( label, value ) => {
   await page.type( `#${ inputId }`, value);
 };
 
+/**
+ * Types in an inline checkbox input element(richtext) based on its name.
+ *
+ * @param {string} name Name of checkbox input.
+ * @param {string} value Value to be applied to the input.
+ */
+export const typeInInputWithCheckbox = async ( name, value ) => {
+  const [ element ] = await page.$x( `//*[contains(@class,"p4-custom-control-input")][contains(@name,"${ name }")]` );
+  await element.click();
+  await page.keyboard.type( value );
+};


### PR DESCRIPTION
Ref. [PLANET-5347](https://jira.greenpeace.org/browse/PLANET-5347)

![image](https://user-images.githubusercontent.com/5357471/91433415-ded23f00-e880-11ea-908d-68d18db2abc0.png)


To test, run npm install and npm run test.
Use npm run test:watch to run the tests in slow motion and watch execution in browser.
(Note: in case of timeout error try - `npm run env JEST_TIMEOUT=30000 WP_USERNAME=admin WP_PASSWORD=admin WP_BASE_URL=https://www.planet4.test wp-scripts test-e2e`)