### PR TITLE
PLANET-5323 Added JS acceptance tests for Submenu block

### DIFF
--- a/tests/js/__snapshots__/submenu.spec.js.snap
+++ b/tests/js/__snapshots__/submenu.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Submenu block is inserted into the Editor 1`] = `"<!-- wp:planet4-blocks/submenu /-->"`;
+
+exports[`Submenu block should work with "Long full-width" style 1`] = `"<!-- wp:planet4-blocks/submenu {\\"title\\":\\"Submenu title\\",\\"levels\\":[{\\"heading\\":2,\\"link\\":true,\\"style\\":\\"none\\"},{\\"heading\\":3,\\"link\\":true,\\"style\\":\\"bullet\\"},{\\"heading\\":4,\\"link\\":true,\\"style\\":\\"number\\"}],\\"className\\":\\"is-style-long\\"} /-->"`;
+
+exports[`Submenu block should work with "Short full-width" style 1`] = `"<!-- wp:planet4-blocks/submenu {\\"title\\":\\"Submenu title\\",\\"levels\\":[{\\"heading\\":2,\\"link\\":true,\\"style\\":\\"none\\"},{\\"heading\\":3,\\"link\\":true,\\"style\\":\\"bullet\\"},{\\"heading\\":4,\\"link\\":true,\\"style\\":\\"number\\"}],\\"className\\":\\"is-style-short\\"} /-->"`;
+
+exports[`Submenu block should work with "Short sidebar" style 1`] = `"<!-- wp:planet4-blocks/submenu {\\"title\\":\\"Submenu title\\",\\"levels\\":[{\\"heading\\":2,\\"link\\":true,\\"style\\":\\"none\\"},{\\"heading\\":3,\\"link\\":true,\\"style\\":\\"bullet\\"},{\\"heading\\":4,\\"link\\":true,\\"style\\":\\"number\\"}],\\"className\\":\\"is-style-sidebar\\"} /-->"`;

--- a/tests/js/e2e-tests-helpers.js
+++ b/tests/js/e2e-tests-helpers.js
@@ -1,6 +1,7 @@
 import {
   getAllBlocks,
   selectBlockByClientId,
+  pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -81,7 +82,12 @@ export const openSidebarPanelWithTitle = async ( title ) => {
  * @param {string} name Style name.
  */
 export const selectStyleByName = async ( name ) => {
-  const [ element ] = await page.$x( `//div[contains(@class,"edit-post-sidebar")]//div[contains(@aria-label,"${ name }")]` );
+  let [ element ] = await page.$x( `//div[contains(@class,"edit-post-sidebar")]//div[contains(@aria-label,"${ name }")]` );
+
+  if ( ! element ) {
+    [ element ] = await page.$x( `//div[@class="block-editor-block-styles"]//span[contains(text(),"${ name }")]` );
+  }
+
   await element.click();
 };
 
@@ -122,4 +128,22 @@ export const typeInInputWithCheckbox = async ( name, value ) => {
   const [ element ] = await page.$x( `//*[contains(@class,"p4-custom-control-input")][contains(@name,"${ name }")]` );
   await element.click();
   await page.keyboard.type( value );
+};
+
+/**
+ * Remove the existing text of richtext field, if exists.
+ *
+ * @param {string} placeholder Text of the richtext input.
+ */
+export const clearPreviousTextWithPlaceholder = async ( placeholder ) => {
+  const [ inputEl ] = await page.$x( `//*[contains(@class,"block-editor-rich-text__editable")][contains(@aria-label,"${ placeholder }")]` );
+  await inputEl.click();
+  let inputValue = await page.evaluate(
+    () => document.activeElement.textContent
+  );
+
+  if ( inputValue ) {
+    await pressKeyWithModifier( 'primary', 'a' );
+    await page.keyboard.press( 'Backspace' );
+  }
 };

--- a/tests/js/submenu.frontend.spec.js
+++ b/tests/js/submenu.frontend.spec.js
@@ -1,0 +1,133 @@
+import {
+  createNewPost,
+  enablePageDialogAccept,
+  setPostContent,
+  publishPost,
+} from '@wordpress/e2e-test-utils';
+
+import {
+  clickElementByText,
+} from './e2e-tests-helpers';
+
+import 'expect-puppeteer';
+
+const PAGE_CONTENT = `
+  <!-- wp:heading {"level":2} -->
+  <h2>H2 no 1</h2>
+  <!-- /wp:heading -->
+  <!-- wp:paragraph -->
+  <p>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>This is the text of \`H2 no 1\`<br>
+  <br>This is quite a long text so that stuff below is definitely out of the viewport without scrolling</p>
+  <!-- /wp:paragraph -->
+  <!-- wp:heading {"level":3} -->
+  <h3>H2.H3 no 1</h3>
+  <!-- /wp:heading -->
+  <!-- wp:heading {"level":3} -->
+  <p>This is the text of \`H2.H3 no 1\`</p>
+  <!-- /wp:paragraph -->
+  <!-- wp:heading {"level":3} -->
+  <h3>H2.H3 no 2</h3>
+  <!-- /wp:heading -->
+  <!-- wp:heading {"level":3} -->
+  <p>This is the text of \`H2.H3 no 2\`</p>
+  <!-- /wp:paragraph -->
+  <!-- wp:heading {"level":4} -->
+  <h4>H2.H3.H4 no 1</h4>
+  <!-- /wp:heading -->
+  <!-- wp:paragraph -->
+  <p>This is the text of \`H2.H3.H4 no 1\`</p>
+  <!-- /wp:paragraph -->
+  <!-- wp:heading {"level":4} -->
+  <h4>H2.H3.H4 no 2</h4>
+  <!-- /wp:heading -->
+  <!-- wp:paragraph -->
+  <p>This is the text of \`H2.H3.H4 no 2\`</p>
+  <!-- /wp:paragraph -->
+  <!-- wp:heading -->
+  <h2>H2 no 2</h2>
+  <!-- /wp:heading -->
+  <!-- wp:paragraph -->
+  <p>This is the text of \`H2 no 2\`<br>H2 no 2<br>H2 no 2</p>
+  <!-- /wp:paragraph -->
+  <!-- wp:heading -->
+  <h2>H2 no 3</h2>
+  <!-- /wp:heading -->
+  <!-- wp:paragraph -->
+  <p>This is the text of \`H2 no 3\`</p>
+  <!-- /wp:paragraph -->
+`;
+
+const SUBMENU_BLOCK = `
+<!-- wp:planet4-blocks/submenu {"title":"Submenu block title","levels":[{"heading":2,"link":true,"style":"none"},{"heading":3,"link":true,"style":"bullet"},{"heading":4,"link":true,"style":"number"}]} /-->
+`;
+
+describe( 'Submenu block', () => {
+  beforeAll( async () => {
+    // This helps in overriding Wordpress dialogs preventing actions
+    await enablePageDialogAccept();
+  } );
+
+  it( 'should work on frontend', async ( done ) => {
+    // Create a new page.
+    await createNewPost({
+      postType: 'page',
+      title: 'Test Submenu block on frontend',
+      showWelcomeGuide: false,
+    });
+
+    // Add the default page content and submenu block.
+    await setPostContent( SUBMENU_BLOCK + PAGE_CONTENT );
+
+    // Publish the page.
+    await publishPost();
+
+    await page.waitForSelector( '.components-snackbar__action' );
+
+    // Wait for page update.
+    await new Promise((r) => setTimeout(r, 300));
+
+    // Test submenu block on frontend.
+    await clickElementByText( 'a', 'View Page' );
+
+    await page.waitForNavigation();
+
+    // Wait for page load.
+    await new Promise((r) => setTimeout(r, 300));
+
+    // The "Submenu Block" should appear on page.
+    await expect( page ).toMatchElement( '.block.submenu-block' );
+
+    // Check the block title
+    await expect(page).toMatchElement('.submenu-block h2', { text: 'Submenu block title' });
+
+    // Check the submenu links for 3 levels and their corresponding list styles.
+    await expect(page).toMatchElement('li.list-style-none a[href=\\#h2-no-1]', { text: 'H2 no 1' });
+    await expect(page).toMatchElement('li.list-style-bullet a[href=\\#h2\\.h3-no-2]', { text: 'H2.H3 no 2' });
+    await expect(page).toMatchElement('li.list-style-number a[href=\\#h2\\.h3\\.h4-no-1]', { text: 'H2.H3.H4 no 1' });
+
+    // On click of submenu link, Move focus to actual header text.
+    await clickElementByText( 'a', 'H2.H3 no 1' );
+
+    const heightFromTop = await page.evaluate(
+      () => document.getElementById('h2.h3-no-1').getBoundingClientRect().top
+    );
+
+    // Test the height of element from browser top.
+    expect( heightFromTop ).toBe( 100 );
+
+    const heightFromTopBeforeClick = await page.evaluate(
+      () => document.getElementById('h2-no-3').getBoundingClientRect().top
+    );
+
+    // On click of submenu link, Move focus to actual header.
+    await clickElementByText( 'a', 'H2 no 3' );
+
+    const heightFromTopAfterClick = await page.evaluate(
+      () => document.getElementById('h2-no-3').getBoundingClientRect().top
+    );
+
+    expect( heightFromTopBeforeClick ).toBeGreaterThan( heightFromTopAfterClick );
+
+    done();
+  }, 80000 );
+} );

--- a/tests/js/submenu.spec.js
+++ b/tests/js/submenu.spec.js
@@ -1,0 +1,161 @@
+import {
+  createNewPost,
+  enablePageDialogAccept,
+  getEditedPostContent,
+  insertBlock,
+  clickButton,
+} from '@wordpress/e2e-test-utils';
+
+import {
+  selectBlockByName,
+  openSidebarPanelWithTitle,
+  selectStyleByName,
+  typeInInputWithPlaceholderLabel,
+} from './e2e-tests-helpers';
+
+import 'expect-puppeteer';
+
+const LEVELS = [
+  {
+    heading: '2',
+    link: true,
+    style: 'none',
+  },
+  {
+    heading: '3',
+    link: true,
+    style: 'bullet',
+  },
+  {
+    heading: '4',
+    link: true,
+    style: 'number',
+  }
+];
+
+describe( 'Submenu block', () => {
+  beforeAll( async () => {
+    // This helps in overriding Wordpress dialogs preventing actions
+    await enablePageDialogAccept();
+  } );
+  beforeEach( async () => {
+    // Before running each test, go to the create post page
+    await createNewPost({
+      postType: 'page',
+      title: 'Test Submenu block',
+      showWelcomeGuide: false,
+    });
+
+    // Insert block by title
+    await insertBlock( 'Submenu' );
+    await page.waitForSelector( '.submenu-block' );
+  } , 40000);
+
+  // On the basis of level and position return the html element id.
+  const getSubmenuElementId = async ( level, position ) => {
+    let [ inputEl ] = await page.$x( `//p[contains(text(),"${ level }")]/following-sibling::div[${ position }]//select` );
+    if (! inputEl ) {
+      [ inputEl ] = await page.$x( `//p[contains(text(),"${ level }")]/following-sibling::div[${ position }]//input` );
+    }
+    const propertyHandle = await inputEl.getProperty('id');
+    return await propertyHandle.jsonValue();
+  };
+
+  // This is the first test, tests starts with it().
+  it( 'is inserted into the Editor', async () => {
+    // Check if block was inserted
+    expect( await page.$( '[data-type="planet4-blocks/submenu"]' ) ).not.toBeNull();
+
+    expect( await getEditedPostContent() ).toMatchSnapshot();
+  });
+
+  it( 'should work with "Long full-width" style', async () => {
+    await selectBlockByName( 'planet4-blocks/submenu' );
+
+    await typeInInputWithPlaceholderLabel( 'Enter title', 'Submenu title' );
+
+    // Select style.
+    await openSidebarPanelWithTitle( 'Styles' );
+    await selectStyleByName( 'Long full-width' );
+
+    // Add Setting inputs
+    await openSidebarPanelWithTitle( 'Setting' );
+
+    // Add 3 levels inputs of submenu.
+    for (let i = 0; i < 3; i++) {
+      let level = i + 1;
+      let selectorId = await getSubmenuElementId( 'Level ' + level, 1 );
+      await page.select('select#' + selectorId , LEVELS[i].heading);
+      if ( LEVELS[i].link ) {
+        selectorId = await getSubmenuElementId( 'Level ' + level, 2 );
+        await page.click('input#' + selectorId);
+      }
+      selectorId = await getSubmenuElementId( 'Level ' + level, 3 );
+      await page.select('select#' + selectorId , LEVELS[i].style);
+
+      await clickButton( 'Add level' );
+    }
+
+    expect( await getEditedPostContent() ).toMatchSnapshot();
+  } );
+
+  it( 'should work with "Short full-width" style', async () => {
+    await selectBlockByName( 'planet4-blocks/submenu' );
+
+    await typeInInputWithPlaceholderLabel( 'Enter title', 'Submenu title' );
+
+    // Select style.
+    await openSidebarPanelWithTitle( 'Styles' );
+    await selectStyleByName( 'Short full-width' );
+
+    // Add Setting inputs
+    await openSidebarPanelWithTitle( 'Setting' );
+
+    // Add 3 levels inputs of submenu.
+    for (let i = 0; i < 3; i++) {
+      let level = i + 1;
+      let selectorId = await getSubmenuElementId( 'Level ' + level, 1 );
+      await page.select('select#' + selectorId , LEVELS[i].heading);
+      if ( LEVELS[i].link ) {
+        selectorId = await getSubmenuElementId( 'Level ' + level, 2 );
+        await page.click('input#' + selectorId);
+      }
+      selectorId = await getSubmenuElementId( 'Level ' + level, 3 );
+      await page.select('select#' + selectorId , LEVELS[i].style);
+
+      await clickButton( 'Add level' );
+    }
+
+    expect( await getEditedPostContent() ).toMatchSnapshot();
+  } );
+
+  it( 'should work with "Short sidebar" style', async () => {
+    await selectBlockByName( 'planet4-blocks/submenu' );
+
+    await typeInInputWithPlaceholderLabel( 'Enter title', 'Submenu title' );
+
+    // Select style.
+    await openSidebarPanelWithTitle( 'Styles' );
+    await selectStyleByName( 'Short sidebar' );
+
+    // Add Setting inputs
+    await openSidebarPanelWithTitle( 'Setting' );
+
+    // Add 3 levels inputs of submenu.
+    for (let i = 0; i < 3; i++) {
+      let level = i + 1;
+      let selectorId = await getSubmenuElementId( 'Level ' + level, 1 );
+      await page.select('select#' + selectorId , LEVELS[i].heading);
+      if ( LEVELS[i].link ) {
+        selectorId = await getSubmenuElementId( 'Level ' + level, 2 );
+        await page.click('input#' + selectorId);
+      }
+      selectorId = await getSubmenuElementId( 'Level ' + level, 3 );
+      await page.select('select#' + selectorId , LEVELS[i].style);
+
+      await clickButton( 'Add level' );
+    }
+
+    expect( await getEditedPostContent() ).toMatchSnapshot();
+  } );
+} );


### PR DESCRIPTION
Ref. [PLANET 5353](https://jira.greenpeace.org/browse/PLANET-5323)

![image](https://user-images.githubusercontent.com/5357471/91836272-2d5c5080-ec68-11ea-8227-76061f61e14e.png)

To test, run `npm install` and `npm run test`.
Use `npm run test:watch` to run the tests in slow motion and watch execution in browser.