### PR TITLE
PLANET-5479 Add page showing posts with "classic blocks"

### DIFF
--- a/classes/controller/menu/class-classic-blocks-usage.php
+++ b/classes/controller/menu/class-classic-blocks-usage.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Blocks Usage class
+ *
+ * @package P4BKS\Controllers\Menu
+ * @since 1.40.0
+ */
+
+namespace P4GBKS\Controllers\Menu;
+
+/**
+ * Show posts using classic blocks.
+ */
+class Classic_Blocks_Usage extends Controller {
+	/**
+	 * Create menu/submenu entry.
+	 */
+	public function create_admin_menu() {
+
+		$current_user = wp_get_current_user();
+
+		if ( in_array( 'administrator', $current_user->roles, true ) && current_user_can( 'manage_options' ) ) {
+			add_submenu_page(
+				P4GBKS_PLUGIN_SLUG_NAME,
+				__( 'Classic block usage', 'planet4-blocks-backend' ),
+				__( 'Classic block usage', 'planet4-blocks-backend' ),
+				'manage_options',
+				'classic_block_usage',
+				[ $this, 'classic_block_usage' ]
+			);
+		}
+	}
+
+	/**
+	 * Show all posts that use classic "blocks", which isn't really a block but the absence of one.
+	 * All consecutive content that is not inside of a block comment is regarded as a single classic block when parsed.
+	 * So in order to find classic blocks, we parse the content as blocks and then check for all blocks where the name
+	 * is null and the content is more than just whitespace.
+	 */
+	public function classic_block_usage(): void {
+		$all_posts = get_posts(
+			[
+				'post_type'   => [ 'post', 'page', 'campaign' ],
+				'numberposts' => - 1,
+			]
+		);
+
+		$has_classic_block = static function ( $post ) {
+			$blocks = parse_blocks( $post->post_content );
+			foreach ( $blocks as $block ) {
+				if ( null === $block['blockName'] && '' !== trim( $block['innerHTML'] ) ) {
+					return true;
+				}
+			}
+
+			return false;
+		};
+
+		$with_classic_blocks = array_filter( $all_posts, $has_classic_block );
+
+		// Copied this code from https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/add-classic-block-to-report/classes/controller/menu/class-blocks-usage-controller.php#L107-L107.
+		// So disabling CS here as well as this is only a temporary dev tool.
+		//phpcs:disable
+		echo '<hr>';
+		echo '<h2>Posts using classic blocks</h2>';
+		echo '<p>Following posts are detected to use classic blocks. It is recommended to convert them to new blocks.</p>';
+		echo '<p>You can convert classic blocks in the post editor by following the steps described in <a target="_blank" href="https://planet4.greenpeace.org/create/manage/convert-posts-to-gutenberg-editor/">this article</a>.</p>';
+		echo '<table>';
+		echo '<tr style="text-align: left">
+							<th>' . __( 'ID', 'planet4-blocks-backend' ) . '</th>
+							<th>' . __( 'Title', 'planet4-blocks-backend' ) . '</th>
+					</tr>';
+		foreach ( $with_classic_blocks as $post_with_classic ) {
+			echo  '<tr><td><a href="' . get_permalink( $post_with_classic->ID ) . '" >' . $post_with_classic->ID . '</a></td>';
+			echo  '<td><a href="post.php?post=' . $post_with_classic->ID . '&action=edit" >' . $post_with_classic->post_title . '</a></td></tr>';
+		}
+		echo '</table>';
+		//phpcs:enable
+	}
+}

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -346,6 +346,7 @@ P4GBKS\Loader::get_instance(
 		// 'P4GBKS\Controllers\Blocks\NewCovers_Controller'
 		\P4GBKS\Controllers\Menu\Settings_Controller::class,
 		\P4GBKS\Controllers\Menu\Blocks_Usage_Controller::class,
+		\P4GBKS\Controllers\Menu\Classic_Blocks_Usage::class,
 		\P4GBKS\Controllers\Menu\Reusable_Blocks_Controller::class,
 		\P4GBKS\Controllers\Menu\Archive_Import::class,
 		\P4GBKS\Controllers\Menu\Postmeta_Check_Controller::class,


### PR DESCRIPTION
Since this block can be hard to support, it would be nice to know where it's still being used. (EDIT: I said "still" but actually new ones can be created using the code editor, which probably happens.)

We can't add this to the block report with the other core block types, as a classic block is not a real block as it's not inside a block comment, but is created on the fly when wordpress finds html that is not inside a block in a post.

https://k8s.p4.greenpeace.org/test-deimos/wp-admin/admin.php?page=classic_block_usages