### PR TITLE
PLANET-5439 Search only in post types that could have blocks

### DIFF
--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -8,6 +8,7 @@
 
 namespace P4GBKS\Controllers\Menu;
 
+use P4\MasterTheme\SqlParameters;
 use WP_Block_Type_Registry;
 
 if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
@@ -104,6 +105,8 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 				$type = 'text';
 			}
 
+			$types_with_blocks = self::get_post_types_with_blocks();
+
 			// phpcs:disable
 			foreach ( $block_types as $block_type ) {
 				if ( 'planet4-blocks/carousel-header' === $block_type ) {
@@ -111,15 +114,18 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 				}
 				$block_comment = '%<!-- wp:' . $wpdb->esc_like( $block_type ) . ' %';
 
-				$sql = $wpdb->prepare(
-					"SELECT ID, post_title
+				$params = new SqlParameters();
+
+				$sql = "SELECT ID, post_title
 					FROM `wp_posts`
 					WHERE post_status = 'publish'
-					AND `post_content` LIKE %s
-					ORDER BY post_title",
-					$block_comment );
+					AND post_type IN (" . $params->string_array( $types_with_blocks ) . ")
+					AND `post_content` LIKE " . $params->string( $block_comment ) . "
+					ORDER BY post_title";
 
-				$results = $wpdb->get_results( $sql );
+				$results = $wpdb->get_results(
+					$wpdb->prepare( $sql, $params->get_values() )
+				);
 
 				if ( !$results ) { continue; }
 
@@ -311,6 +317,22 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 			if ( 'json' === $type ) {
 				return $report;
 			}
+		}
+
+		/**
+		 * Get all registered post types that "support blocks". This actually is not explicitly defined by itself, but
+		 * depends on 2 things: type is registered with `show_in_rest => true` and the type supports `editor`. If both
+		 * conditions are met the block editor is shown. If something weird and custom is done so that a post type does
+		 * have blocks without these conditions being true then the blocks will not be picked up by the report.
+		 *
+		 * @return array All posts types that support blocks.
+		 */
+		private static function get_post_types_with_blocks(): array {
+			$supports_editor = static function ( $type ) {
+				return post_type_supports( $type, 'editor' );
+			};
+
+			return array_filter( get_post_types( [ 'show_in_rest' => true ] ), $supports_editor );
 		}
 
 		/**

--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -8,6 +8,7 @@
 
 namespace P4GBKS\Controllers\Menu;
 
+use P4\MasterTheme\Exception\SqlInIsEmpty;
 use P4\MasterTheme\SqlParameters;
 use WP_Block_Type_Registry;
 
@@ -93,6 +94,8 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 		 * Finds blocks usage in pages/posts.
 		 *
 		 * @param String $type The Block report type.
+		 *
+		 * @throws SqlInIsEmpty Should not happen in practice as everyone has types with blocks.
 		 */
 		public function plugin_blocks_report( $type = 'text' ) {
 			global $wpdb;
@@ -119,7 +122,7 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 				$sql = "SELECT ID, post_title
 					FROM " . $params->identifier( $wpdb->posts ) . "
 					WHERE post_status = 'publish'
-					AND post_type IN (" . $params->string_list( $types_with_blocks ) . ")
+					AND post_type IN " . $params->string_list( $types_with_blocks ) . "
 					AND `post_content` LIKE " . $params->string( $block_comment ) . "
 					ORDER BY post_title";
 

--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -117,9 +117,9 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 				$params = new SqlParameters();
 
 				$sql = "SELECT ID, post_title
-					FROM `wp_posts`
+					FROM " . $params->identifier( $wpdb->posts ) . "
 					WHERE post_status = 'publish'
-					AND post_type IN (" . $params->string_array( $types_with_blocks ) . ")
+					AND post_type IN (" . $params->string_list( $types_with_blocks ) . ")
 					AND `post_content` LIKE " . $params->string( $block_comment ) . "
 					ORDER BY post_title";
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5439

Blocked by https://github.com/greenpeace/planet4-master-theme/pull/1175 as it uses a function introduced there.

Especially since we added archived posts as a post type, this extra condition is needed because we're regex matching each post's content.

~~Maybe we should double check whether any NRO has custom post types that can contain blocks. If so maybe we can invert the where to exclude certain post types instead (would mainly be archive posts, but there may be others).~~ Actually we can figure out which posts types are registered that support the block editor, so we don't need to have a fixed list.

Before (GPI staging): https://release.k8s.p4.greenpeace.org/international/wp-admin/admin.php?page=plugin_blocks_report
After (Test instance with GPI data): https://k8s.p4.greenpeace.org/test-nix/wp-admin/admin.php?page=plugin_blocks_report