### PR TITLE
PLANET-5424 Spreadsheet block: URL vanishes after page being published

### DIFF
--- a/assets/src/blocks/Spreadsheet/SpreadsheetEditor.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetEditor.js
@@ -45,7 +45,7 @@ export class SpreadsheetEditor extends Component {
     this.state = {
       invalidSheetId: false,
       errorFetchingSpreadsheet: false,
-      url: '',
+      url: props.attributes.url,
     };
 
     this.debounceSearch = debounce(url => {


### PR DESCRIPTION
set url value to attributes.url as opposed to state.url