### PR TITLE
PLANET-5426 Image block - Removed the blue caption style

### DIFF
--- a/assets/src/ImageBlockExtension.js
+++ b/assets/src/ImageBlockExtension.js
@@ -11,10 +11,6 @@ const targetBlocks = [
 
 const captionStyleOptions = [
   {
-  label: __( 'Blue Overlay (default)' ),
-  value: 'blue-overlay',
-  },
-  {
   label: __( 'Medium' ),
   value: 'medium',
   },

--- a/assets/src/ImageBlockExtension.js
+++ b/assets/src/ImageBlockExtension.js
@@ -1,4 +1,4 @@
-import { Button, ButtonGroup, PanelBody, SelectControl } from '@wordpress/components';
+import { Button, ButtonGroup, PanelBody } from '@wordpress/components';
 import assign from 'lodash.assign';
 
 const { addFilter } = wp.hooks;
@@ -95,17 +95,6 @@ const addExtraControls = function() {
               title={ __( 'Planet4 Image Options' ) }
               initialOpen={ true }
             >
-              <SelectControl
-                label={ __( 'Caption Style' ) }
-                value={ captionStyle }
-                options={ captionStyleOptions }
-                onChange={ ( selectedCaptionStyle ) => {
-                  props.setAttributes( {
-                    captionStyle: selectedCaptionStyle,
-                  } );
-                } }
-              />
-
               <label>Caption alignment</label>
               <ButtonGroup>
               {

--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -48,37 +48,7 @@
     margin-bottom: 0;
   }
 
-  &.caption-style-blue-overlay {
-    .image-desc {
-      display: block;
-    }
-
-    figcaption {
-      display: block;
-      caption-side: bottom;
-      color: $white;
-      width: 100%;
-      margin: 0;
-      max-width: 100%;
-      background: linear-gradient(210deg, transparentize($med-blue, .8) 0%, $med-blue 100%);
-      padding: $n10 $n20;
-
-      @include medium-and-up {
-        display: table-caption;
-        position: absolute;
-        left: 0;
-        bottom: 0;
-        padding: $n20 $n30;
-        height: auto;
-      }
-
-      @include large-and-up {
-        padding: $n20 $n30;
-      }
-    }
-  }
-
-  &.caption-style-medium {
+  &.caption-style-medium, &.caption-style-blue-overlay {
     figcaption {
       color: $grey-60;
     }

--- a/assets/src/styles/editorOverrides.scss
+++ b/assets/src/styles/editorOverrides.scss
@@ -29,29 +29,6 @@
       display: block;
     }
   }
-
-  &.caption-style-blue-overlay {
-    overflow: hidden;
-
-    figcaption {
-      // This is to take into account the image resizer handle
-      margin-bottom: 8px;
-    }
-
-    .editor-rich-text {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-
-      .editor-format-toolbar {
-        margin-top: 48px;
-        box-shadow: 0 2px 8px black;
-        z-index: 99999;
-      }
-    }
-  }
 }
 
 .components-panel__body label {


### PR DESCRIPTION
Ref. [JIRA 5426](https://jira.greenpeace.org/browse/PLANET-5426)

- Removed the "Blue Caption" style option from Image block backend(block Editor option)
- Removed blue caption styles code
- Added fallback solution for existing Image blocks with "blue-caption" style

**e.g.**
Page: https://k8s.p4.greenpeace.org/test-titan/test-image-block-with-blue-captionpage/
Post: https://k8s.p4.greenpeace.org/test-titan/story/28934/test-image-block-with-blue-captionpost/
Campaign:  https://k8s.p4.greenpeace.org/test-titan/campaign/image-block-with-blue-captioncampaign/

### How to fix the existing Image blocks which are using the “blue-caption” style?
**Proposed solution:** Add a migration script which check all page, post, campaigns for Image blocks with blue caption style and update them with medium caption style value. 

**The fallback solution:** make alias of “caption-style-medium” css class to “caption-style-blue-overlay”. This way if the image block having “blue-caption” style will work same as medium caption style.

Any thoughts/suggestions on above would be welcome :)