### PR TITLE
PLANET-5472 Use existing thumbnail format

### DIFF
--- a/classes/blocks/class-articles.php
+++ b/classes/blocks/class-articles.php
@@ -200,7 +200,7 @@ class Articles extends Base_Block {
 					$dimensions                = wp_get_attachment_metadata( $img_id );
 					$recent['thumbnail_ratio'] = ( isset( $dimensions['height'] ) && $dimensions['height'] > 0 ) ? $dimensions['width'] / $dimensions['height'] : 1;
 					$recent['alt_text']        = get_post_meta( $img_id, '_wp_attachment_image_alt', true );
-					$recent['thumbnail_url']   = get_the_post_thumbnail_url( $recent['ID'], 'medium-large' );
+					$recent['thumbnail_url']   = get_the_post_thumbnail_url( $recent['ID'], 'articles-medium-large' );
 				}
 
 				// TODO - Update this method to use P4_Post functionality to get Tags/Terms.


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5472

This is (almost) the same issue as [this one](https://github.com/greenpeace/planet4-master-theme/pull/1075/files), so I went ahead and applied the same fix. Now it uses the correct image size (https://github.com/greenpeace/planet4-master-theme/blob/ef1e3f3de1d65b672877febcb0d53b7088a15bde/src/MasterSite.php#L387-L387)  @pablocubico We can still keep the ticket if we want to look into srcset, but I guess this simple fix can make it into next deploy?