### PR TITLE
PLANET-5270 Hide default style picker

### DIFF
--- a/assets/src/styles/editorOverrides.scss
+++ b/assets/src/styles/editorOverrides.scss
@@ -154,6 +154,9 @@
 }
 
 .edit-post-sidebar {
+  .block-editor-block-styles + .components-base-control {
+    display: none;
+  }
 
   // By default all but the first .component-base-control have margin-bottom, causing weird spacing.
   .components-base-control {


### PR DESCRIPTION
See https://jira.greenpeace.org/browse/PLANET-5270

I first tried using the `defaultStylePicker` setting available in Gutenberg according to the [docs](https://developer.wordpress.org/block-editor/developers/block-api/block-registration/#supports-optional), but that wasn't working... After a bit of research, this feature is still marked as "unreleased" in their [changelog](https://github.com/WordPress/gutenberg/blob/master/packages/blocks/CHANGELOG.md) (but that doesn't seem up to date, since it stops at version `6.13.0` and latest release is `9.0.0`) The entry in the docs was added at version `7.8.0`, so it's very strange that it's not working 🤔 

Anyway, I went instead for this CSS approach, which actually has the advantage of applying directly to all blocks (instead of having to update each block one by one) 🙂 Considering the selector, it shouldn't affect any other elements also having the `components-base-control` class!
<img width="633" alt="Screenshot 2020-09-17 at 11 18 16" src="https://user-images.githubusercontent.com/6949075/93451466-84ecf400-f8d7-11ea-9991-1b4b95a6292b.png">
