### PR TITLE
PLANET-5490: Running accessibility report with pa11y

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ workflows:
       - php73-tests
       - acceptance-tests:
           context: org-global
+      - a11y-tests:
+          context: org-global
       - rips-test:
           context: rips-scans
           filters:
@@ -64,21 +66,7 @@ job-references:
       - store_test_results:
           path: /tmp/test-results
 
-
-jobs:
-  php72-tests:
-    <<: *php_job
-    docker:
-      - image: greenpeaceinternational/p4-unit-tests:php7.2-develop
-      - image: *mysql_image
-
-  php73-tests:
-    <<: *php_job
-    docker:
-      - image: greenpeaceinternational/p4-unit-tests:php7.3-develop
-      - image: *mysql_image
-
-  acceptance-tests:
+  p4_instance_conf: &p4_instance_conf
     docker:
       - image: greenpeaceinternational/p4-builder:latest
     working_directory: /home/circleci/
@@ -92,8 +80,12 @@ jobs:
       TYPE: "Build"
       WP_DB_NAME: planet4-base_wordpress
       WP_TITLE: Greenpeace Base Development
-    steps:
-      - setup_remote_docker
+
+commands:
+  install-instance:
+    steps:  
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Build - Configure
           command: |
@@ -111,23 +103,24 @@ jobs:
       - run:
           name: Test - Clone planet4-docker-compose
           command: |
-            git clone https://github.com/greenpeace/planet4-docker-compose
-      - run:
-          name: Test - Run tests
-          command: |
-            export BUILD_TAG="build-$(cat /tmp/workspace/var/circle-build-num)"
-            export APP_IMAGE=gcr.io/planet-4-151612/planet4-base-app:${BUILD_TAG}
-            export OPENRESTY_IMAGE=gcr.io/planet-4-151612/planet4-base-openresty:${BUILD_TAG}
-            make -C planet4-docker-compose ci test
+            git clone --depth 1 https://github.com/greenpeace/planet4-docker-compose
 
+  run-tests:
+    parameters:
+      test-name:
+        type: string
+      test-command:
+        type: string
+      extract-command:
+        type: string
+    steps:
+      - run: 
+          name: << parameters.test-name >>
+          command: << parameters.test-command >>
       - run:
           name: Test - Extract test artifacts
           when: always
-          command: |
-            export BUILD_TAG="build-$(cat /tmp/workspace/var/circle-build-num)"
-            export APP_IMAGE=gcr.io/planet-4-151612/planet4-base-app:${BUILD_TAG}
-            export OPENRESTY_IMAGE=gcr.io/planet-4-151612/planet4-base-openresty:${BUILD_TAG}
-            make -C planet4-docker-compose ci-extract-artifacts
+          command: << parameters.extract-command >>
       - persist_to_workspace:
           root: /tmp/workspace
           paths:
@@ -136,6 +129,59 @@ jobs:
           path: planet4-docker-compose/artifacts
       - store_artifacts:
           path: planet4-docker-compose/artifacts
+      - run:
+          name: Build - Notify failure
+          when: on_fail
+          command: notify-job-failure.sh
+
+jobs:
+  php72-tests:
+    <<: *php_job
+    docker:
+      - image: greenpeaceinternational/p4-unit-tests:php7.2-develop
+      - image: *mysql_image
+
+  php73-tests:
+    <<: *php_job
+    docker:
+      - image: greenpeaceinternational/p4-unit-tests:php7.3-develop
+      - image: *mysql_image
+
+  acceptance-tests:
+    <<: *p4_instance_conf
+    steps:
+      - install-instance
+      - run-tests:
+          test-name: Test - Run acceptance tests
+          test-command: |
+            export BUILD_TAG="build-$(cat /tmp/workspace/var/circle-build-num)"
+            export APP_IMAGE=gcr.io/planet-4-151612/planet4-base-app:${BUILD_TAG}
+            export OPENRESTY_IMAGE=gcr.io/planet-4-151612/planet4-base-openresty:${BUILD_TAG}
+            make -C planet4-docker-compose ci test
+          extract-command: |
+            export BUILD_TAG="build-$(cat /tmp/workspace/var/circle-build-num)"
+            export APP_IMAGE=gcr.io/planet-4-151612/planet4-base-app:${BUILD_TAG}
+            export OPENRESTY_IMAGE=gcr.io/planet-4-151612/planet4-base-openresty:${BUILD_TAG}
+            make -C planet4-docker-compose ci-extract-artifacts
+
+  a11y-tests:
+    <<: *p4_instance_conf
+    steps:
+      - install-instance
+      - run-tests:
+          test-name: Test - Run accessibility tests
+          test-command: |
+            export BUILD_TAG="build-$(cat /tmp/workspace/var/circle-build-num)"
+            export APP_IMAGE=gcr.io/planet-4-151612/planet4-base-app:${BUILD_TAG}
+            export OPENRESTY_IMAGE=gcr.io/planet-4-151612/planet4-base-openresty:${BUILD_TAG}
+            make -C planet4-docker-compose ci test-pa11y-ci
+          extract-command: |
+            export BUILD_TAG="build-$(cat /tmp/workspace/var/circle-build-num)"
+            export APP_IMAGE=gcr.io/planet-4-151612/planet4-base-app:${BUILD_TAG}
+            export OPENRESTY_IMAGE=gcr.io/planet-4-151612/planet4-base-openresty:${BUILD_TAG}
+            make -C planet4-docker-compose ci-extract-a11y-artifacts
+            errors=$(jq '.["results"] | .[] | unique_by(.["type"]) | map(select(.["type"] == "error")) | .[]' planet4-docker-compose/artifacts/pa11y/pa11y-ci-results.json)
+            if [ ! -z "${errors}" ]; then echo "Errors found, see report in artifacts." && exit 1; else echo "No errors, report available in artifacts."; fi
 
   rips-test:
     docker:


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5275
Ref: https://jira.greenpeace.org/browse/PLANET-5490

> pa11y is a tool that parses html documents in specific urls and discovers accessibility issues.

New accessibility test added to this repository, parallel to acceptance tests.  

Follows the same method as https://github.com/greenpeace/planet4-master-theme/pull/1165:
- Factorization of instance conf, install and test run
- New a11y job with report in artifacts

Result is there:
- https://app.circleci.com/pipelines/github/greenpeace/planet4-plugin-gutenberg-blocks/2533/workflows/01e681c0-e7f8-426a-a90e-bc6fc06ea415
- https://6788-196357997-gh.circle-artifacts.com/0/planet4-docker-compose/artifacts/pa11y/index.html