### PR TITLE
Add option for updating the counters in the client

### DIFF
--- a/assets/src/blocks/Counter/CounterFrontend.js
+++ b/assets/src/blocks/Counter/CounterFrontend.js
@@ -20,6 +20,11 @@ export class CounterFrontend extends Component {
     window.addEventListener('updateCounter', function () { counter.calculateRemaining(); }, false);
   }
 
+  componentWillUnmount() {
+    let counter = this;
+    window.removeEventListener('updateCounter', function () { counter.calculateRemaining(); }, false);
+  }
+
   componentDidUpdate({ target: prevTarget, completed: prevCompleted, completed_api: prevCompletedApi }) {
     // Update completed and remaining values depending on props
     const { target, completed, completed_api } = this.props;

--- a/assets/src/blocks/Counter/CounterFrontend.js
+++ b/assets/src/blocks/Counter/CounterFrontend.js
@@ -13,16 +13,22 @@ export class CounterFrontend extends Component {
   }
 
   componentDidMount() {
+    const { completed_api } = this.props;
     // Calculate completed and remaining values depending on props
     let counter = this;
     counter.calculateRemaining();
     // Add an eventListener to the window to enable instantly updating counters with supported APIs
-    window.addEventListener('updateCounter', function () { counter.calculateRemaining(); }, false);
+    if (completed_api && completed_api.startsWith('https://')) {
+      window.addEventListener('updateCounter', function () { counter.calculateRemaining(); }, false);
+    }
   }
 
   componentWillUnmount() {
+    const { completed_api } = this.props;
     let counter = this;
-    window.removeEventListener('updateCounter', function () { counter.calculateRemaining(); }, false);
+    if (completed_api && completed_api.startsWith('https://')) {
+      window.removeEventListener('updateCounter', function () { counter.calculateRemaining(); }, false);
+    }
   }
 
   componentDidUpdate({ target: prevTarget, completed: prevCompleted, completed_api: prevCompletedApi }) {

--- a/assets/src/blocks/Counter/CounterFrontend.js
+++ b/assets/src/blocks/Counter/CounterFrontend.js
@@ -14,7 +14,10 @@ export class CounterFrontend extends Component {
 
   componentDidMount() {
     // Calculate completed and remaining values depending on props
-    this.calculateRemaining();
+    let counter = this;
+    counter.calculateRemaining();
+    // Add an eventListener to the window to enable instantly updating counters with supported APIs
+    window.addEventListener('updateCounter', function () { counter.calculateRemaining(); }, false);
   }
 
   componentDidUpdate({ target: prevTarget, completed: prevCompleted, completed_api: prevCompletedApi }) {


### PR DESCRIPTION
For now this adds an eventListener to the counter which in turn executes the calculateRemaining.
This way GPNL (and other NRO's with devs) can use instantly updating counters.
Which might serve as a Proof of Concept for adding in more interactivity.

I will follow up on this PR with another which separates the functions for calling the API and calculating remaining. This improves the code a bit on single responsibility and make sure the instantly updating counter don't hit API's unneeded.