### PR TITLE
PLANET-5500 Columns Block: Use full width on buttons

### DIFF
--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -7,7 +7,7 @@
     }
 
     &.btn-primary, &.btn-secondary {
-      text-decoration: none !important;
+      width: 100%;
     }
   }
 


### PR DESCRIPTION
Also removed text-decoration, because buttons already inherit that from the styleguide.

Ref: https://jira.greenpeace.org/browse/PLANET-5500