### PR TITLE
PLANET-5497 Remove Image block caption style picker

### DIFF
--- a/assets/src/ImageBlockExtension.js
+++ b/assets/src/ImageBlockExtension.js
@@ -1,4 +1,4 @@
-import { Button, ButtonGroup, PanelBody, SelectControl } from '@wordpress/components';
+import { Button, ButtonGroup, PanelBody } from '@wordpress/components';
 import assign from 'lodash.assign';
 
 const { addFilter } = wp.hooks;
@@ -95,17 +95,6 @@ const addExtraControls = function() {
               title={ __( 'Planet4 Image Options' ) }
               initialOpen={ true }
             >
-              <SelectControl
-                label={ __( 'Caption Style' ) }
-                value={ captionStyle }
-                options={ captionStyleOptions }
-                onChange={ ( selectedCaptionStyle ) => {
-                  props.setAttributes( {
-                    captionStyle: selectedCaptionStyle,
-                  } );
-                } }
-              />
-
               <label>Caption alignment</label>
               <ButtonGroup>
               {


### PR DESCRIPTION
See https://jira.greenpeace.org/browse/PLANET-5497

The ticket specified to use CSS to hide the picker, but I think that this JS solution makes more sense 🙂 (CSS selector would be quite complicated, or we would need to add a new class just for this purpose)