### PR TITLE
PLANET-5468 Columns block: Huge image on the 4th column

### DIFF
--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -492,4 +492,8 @@
       }
     }
   }
+
+  .column-wrap {
+    word-break: break-word;
+  }
 }


### PR DESCRIPTION
Added word break for columns description so long words don't cause the column to go oversize.