### PR TITLE
PLANET-5562: Fix htmlentity character on split two columns titles

### DIFF
--- a/assets/src/blocks/Splittwocolumns/SplittwocolumnsFrontend.js
+++ b/assets/src/blocks/Splittwocolumns/SplittwocolumnsFrontend.js
@@ -44,7 +44,9 @@ export const SplittwocolumnsFrontend = ({
         <div className="split-two-column-item-content">
           {title && issue_link_path &&
             <h2 className="split-two-column-item-title">
-              <a href={issue_link_path} {...analytics('Category Title')}>{title}</a>
+              <a href={issue_link_path} {...analytics('Category Title')}
+                dangerouslySetInnerHTML={{__html: title}} 
+              />
             </h2>
           }
           {title && !issue_link_path &&
@@ -58,9 +60,9 @@ export const SplittwocolumnsFrontend = ({
           {issue_link_text && issue_link_path &&
             <a className="split-two-column-item-link" 
                href={issue_link_path} 
-               {...analytics('Text Link')}>
-              {issue_link_text}
-            </a>
+               {...analytics('Text Link')}
+               dangerouslySetInnerHTML={{__html: issue_link_text}}
+            />
           }
         </div>
       </div>
@@ -77,9 +79,9 @@ export const SplittwocolumnsFrontend = ({
           {tag_name &&
             <a className="split-two-column-item-tag" 
                href={tag_link}
-               {...analytics('Tag Title')}>
-              <span aria-label="hashtag">#</span>{tag_name}
-            </a>
+               {...analytics('Tag Title')}
+               dangerouslySetInnerHTML={{__html: `<span aria-label="hashtag">#</span>${tag_name}`}} 
+            />
           }
           {tag_description &&
             <p className="split-two-column-item-subtitle"
@@ -89,9 +91,9 @@ export const SplittwocolumnsFrontend = ({
           {button_text && button_link &&
             <a className="btn btn-small btn-primary btn-block split-two-column-item-button"
                 href={button_link}
-                {...analytics('Call to Action')}>
-              {button_text}
-            </a>
+                {...analytics('Call to Action')}
+                dangerouslySetInnerHTML={{__html: button_text}}
+            />
           }
         </div>
       </div>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5562

> An & sign is displayed as its htmlentities on the frontend version of the Split 2 Columns block, for the title (left column) and the tag (right column) of the block.

The `&` sign is automatically escaped by the RichText component on input, and saved as an html entity. To display it properly, we have to allow some html entities to be displayed as is.

## Fix

Allows titles to display html characters, the same way it is allowed in text blocks.  
Input is still limited by `allowedFormats`, this fix is only here to compensate for the automatic escaping of `&`.

## Test

- Add a new page with a Split Two Columns block.
- Add a title to this block with an `&` (ie `Foo & Bar`)
- Clicking outside the block should trigger the frontend view, 
  - On the current version, it displays a title `Foo &amp; Bar`
  - On the fixed version, it displays the proper title `Foo & Bar`