### PR TITLE
PLANET-5373 Remove the "by" string in Articles block author names

### DIFF
--- a/assets/src/blocks/Articles/ArticlePreview.js
+++ b/assets/src/blocks/Articles/ArticlePreview.js
@@ -41,7 +41,7 @@ export class ArticlePreview extends Component {
 
     if (authorName) {
       return (
-        <span className="article-list-item-author">{__('by', 'planet4-blocks')}{' '}
+        <span className="article-list-item-author">
           {!isLink ?
             authorName
             :


### PR DESCRIPTION
Rel. to [JIRA # 5373](https://jira.greenpeace.org/browse/PLANET-5373)