### PR TITLE
Manually specify master for other repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,11 @@ commands:
           command: |
             echo "Plugin gutenberg blocks branch is ${CIRCLE_BRANCH}"
             sleep 10
-            PLUGIN_GUTENBERG_BLOCKS_BRANCH=dev-${CIRCLE_BRANCH} MERGE_SOURCE=git@github.com:greenpeace/planet4-base-fork.git MERGE_REF=develop make
+            PLUGIN_GUTENBERG_BLOCKS_BRANCH=dev-${CIRCLE_BRANCH} \
+            MASTER_THEME_BRANCH=dev-master \
+            MERGE_SOURCE=git@github.com:greenpeace/planet4-base-fork.git \
+            MERGE_REF=develop \
+            make
       - run:
           name: Test - Clone planet4-docker-compose
           command: |


### PR DESCRIPTION
* Due to an issue the assets are not building for the tag. This is a
quick fix to allow tests to pass again while we further check the issue.