### PR TITLE
Add plugin for shorthand css variable syntax

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -64,7 +64,9 @@
     "selector-pseudo-class-case": "lower",
     "selector-pseudo-element-case": "lower",
     "selector-type-case": "lower",
-    "selector-type-no-unknown": true,
+    "selector-type-no-unknown": [true, {
+	  "ignoreTypes": ["/^--[a-z]\\w*(--?[a-z0-9]+)*--$/"]
+	}],
     "selector-max-empty-lines": 0,
 
     "rule-empty-line-before": ["always", {"except": ["first-nested", "after-single-line-comment"]}],

--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -18,7 +18,10 @@
     font-size: $font-size-lg;
     font-family: $roboto;
     font-weight: 700;
-    color: var(--block-columns--column-heading--color, $grey-80);
+
+    --block-columns--column-heading-- {
+      color: $grey-80;
+    }
 
     @include medium-and-up {
       font-size: 1.5rem;

--- a/assets/src/styles/blocks/Covers/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionCovers.scss
@@ -146,12 +146,17 @@
 
     .btn {
       display: block;
-      background-color: var(--cover-card-btn-background-color, $orange);
-      border-color: var(--cover-card-btn-border-color, $orange);
+
+      --block-covers--card-btn-- {
+        background-color: $orange;
+        border-color: $orange;
+      }
 
       &:hover {
-        background-color: var(--cover-card-btn-hover-background-color, $orange-hover);
-        border-color: var(--cover-card-btn-hover-border-color, $orange-hover);
+        --block-covers--card-btn-hover-- {
+          background-color: $orange-hover;
+          border-color: $orange-hover;
+        }
       }
     }
   }
@@ -190,7 +195,11 @@
     padding-top: 0;
     max-width: 80%;
     transition: color 100ms linear;
-    color: var(--cover-card-heading-color, $white);
+
+    --block-covers--heading-- {
+      color: $white;
+    }
+
     text-shadow: 1px 1px 3px $black;
     display: table;
     z-index: 1;
@@ -225,7 +234,11 @@
 }
 
 .cover-card-tag {
-  color: var(--cover-card-tag-color, $yellow);
+
+  --block-covers--card-tag-- {
+    color: $yellow;
+  }
+
   display: inline-block;
   margin-bottom: 8px;
   text-decoration: none;
@@ -237,7 +250,10 @@
 
   &:hover {
     text-decoration: underline;
-    color: var(--cover-card-tag-hover-color, $yellow);
+
+    --block-covers--card-tag-hover-- {
+      color: $yellow;
+    }
   }
 
   @include large-and-up {

--- a/assets/src/styles/blocks/Spreadsheet.scss
+++ b/assets/src/styles/blocks/Spreadsheet.scss
@@ -35,9 +35,12 @@ table.spreadsheet-table {
   }
 
   th {
-    background: var(--spreadsheet-header-background, $table-header-grey);
+    --block-spreadsheet--header-- {
+      background-color: $table-header-grey;
+      border-bottom-color: $table-header-grey;
+    }
     color: $white;
-    border-bottom: 1px solid var(--spreadsheet-header-background, $table-header-grey);
+    border-bottom: 1px solid;
     cursor: pointer;
     font-size: $font-size-sm;
     position: sticky;
@@ -70,8 +73,10 @@ table.spreadsheet-table {
     color: $table-font-color;
 
     td {
+      --block-spreadsheet--even-row-- {
+        background: $table-even-row-grey;
+      }
       padding: 5px 20px;
-      background: var(--spreadsheet-even-row-background, $table-even-row-grey);
       font-size: $font-size-xs;
 
       @include x-large-and-up {
@@ -85,7 +90,9 @@ table.spreadsheet-table {
 
     &:nth-child(odd) {
       td {
-        background: var(--spreadsheet-odd-row-background, $table-odd-row-grey);
+        --block-spreadsheet--odd-row-- {
+          background: $table-odd-row-grey;
+        }
       }
     }
   }
@@ -101,7 +108,10 @@ table.spreadsheet-table {
   max-width: 100%;
   height: 2rem;
   padding: 0 8px;
-  border-color: var(--spreadsheet-header-background, $table-header-grey);
+
+  --block-spreadsheet--header-- {
+    border-color: $table-header-grey;
+  }
   border: 1px solid;
   font-family: $roboto;
 }

--- a/assets/src/styles/editorOverrides.scss
+++ b/assets/src/styles/editorOverrides.scss
@@ -145,7 +145,7 @@
 
 .edit-post-visual-editor .editor-block-list__block-edit,
 .edit-post-visual-editor {
-  font-family: var(--body-font, 'Noto Serif');
+  font-family: var(--body-font, "Noto Serif");
 
   h1, h2, h3, h4, h5 {
     font-family: var(--header-primary-font, $roboto);
@@ -193,7 +193,7 @@ input.describe[type=text][data-setting=caption] {
 }
 
 .wp-embed-responsive .block-editor {
-   .wp-block-embed.wp-has-aspect-ratio .wp-block-embed__wrapper::before {
+  .wp-block-embed.wp-has-aspect-ratio .wp-block-embed__wrapper::before {
     content: none;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1255,6 +1255,43 @@
         }
       }
     },
+    "@greenpeace/dashdash": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@greenpeace/dashdash/-/dashdash-1.0.1.tgz",
+      "integrity": "sha512-j/1AE1Z2fIi37d0VCNkOzzTo0SxCqAVBa1q/7yUV0rYpEX57eApARXih3f+/pZmIecRC7v/jcWNaeQoGS7r5EA==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.32"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "7.0.35",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+          "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "@jest/console": {
       "version": "24.7.1",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:watch": "env JEST_TIMEOUT=30000 PUPPETEER_HEADLESS=false PUPPETEER_SLOWMO=100 WP_USERNAME=admin WP_PASSWORD=admin WP_BASE_URL=https://www.planet4.test wp-scripts test-e2e"
   },
   "devDependencies": {
+    "@greenpeace/dashdash": "^1.0.1",
     "@wordpress/components": "^8.3.2",
     "@wordpress/data": "^4.9.2",
     "@wordpress/e2e-test-utils": "^4.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const TerserJSPlugin = require('terser-webpack-plugin');
 const FixStyleOnlyEntriesPlugin = require("webpack-fix-style-only-entries");
 const RemovePlugin = require('remove-files-webpack-plugin');
+const dashDash = require('@greenpeace/dashdash');
 
 module.exports = {
   ...defaultConfig,
@@ -44,9 +45,10 @@ module.exports = {
             loader: 'postcss-loader',
             options: {
               ident: 'postcss',
-              plugins: function() {
-                return require('autoprefixer');
-              },
+              plugins: () => [
+                dashDash(),
+                require('autoprefixer'),
+              ],
               sourceMap: true
             }
           },


### PR DESCRIPTION
Relevant ADR: https://docs.google.com/document/d/10r5RM1h8tN6Dw8APCJCM7GeRYOaRIOc8QMm2t13AwT8/edit# (advised to read the "Challenges" section, it describes the limitations of SCSS for this use case).

Add webpack plugin that runs after SCSS is transformed to CSS, to transform the shorthand syntax into the corresponding declarations that include variables.

So it should transform any sub-selector that in SCSS starts and ends with 2 dashes into variable declarations that are added to the parent selector. So
```scss
#some .parent[selector] {
  border: 2px;
  --some-meaningful-name-- {
    color: red;
    background-color: green;
  }
}
```
into
```css
#some .parent[selector] {
  border: 2px;
  color: var(--some-meaningful-name--color, red);
  background-color: var(--some-meaningful-name--background-color, green);
}
```

I'm working on applying this shorthand in all places where it requires no other changes to do so.

For some variables the naming needs to change. I'm checking using github search across repo code to see if any variable that needs to be renamed is used in any other repo. None so far were, if I find any I'll exclude those for now.

For that search I'm using this Intellij plugin https://plugins.jetbrains.com/plugin/12678-onlinesearch2 that allows to add custom search URLs similar to "Search with Google" to perform on selected text from the context menu. Very useful in our case as we frequently need to check if a change would break child themes.