### PR TITLE
PLANET-5388 Fix related articles issue on Post

### DIFF
--- a/assets/src/blocks/Articles/ArticlesFrontend.js
+++ b/assets/src/blocks/Articles/ArticlesFrontend.js
@@ -18,7 +18,9 @@ export const ArticlesFrontend = (props) => {
 
   const postId = !postIdClass ? null : postIdClass.split('-')[1];
 
-  const { posts, loadNextPage, hasMorePages, loading } = useArticlesFetch(props, postType, postId, document.body.dataset.nro);
+  const postCategories = props.post_categories || [];
+
+  const { posts, loadNextPage, hasMorePages, loading } = useArticlesFetch(props, postType, postId, document.body.dataset.nro, postCategories);
 
   return (
     <section className="block articles-block">

--- a/assets/src/blocks/Articles/useArticlesFetch.js
+++ b/assets/src/blocks/Articles/useArticlesFetch.js
@@ -8,7 +8,7 @@ const fetchJson = async(url) => {
   return response.json();
 };
 
-export const useArticlesFetch = (attributes, postType, postId, baseUrl = null) => {
+export const useArticlesFetch = (attributes, postType, postId, baseUrl = null, postCategories = []) => {
   const { article_count, post_types, posts, tags, ignore_categories } = attributes;
 
   const [totalPosts, setTotalPosts] = useState(null);
@@ -35,6 +35,7 @@ export const useArticlesFetch = (attributes, postType, postId, baseUrl = null) =
 
     if (postType === 'post') {
       args.exclude_post_id = postId;
+      args.categories = postCategories;
     }
 
 

--- a/classes/blocks/class-articles.php
+++ b/classes/blocks/class-articles.php
@@ -278,11 +278,7 @@ class Articles extends Base_Block {
 		$ignore_categories = $fields['ignore_categories'];
 
 		// Get page categories.
-		$post_categories   = get_the_category();
-		$category_id_array = [];
-		foreach ( $post_categories as $category ) {
-			$category_id_array[] = $category->term_id;
-		}
+		$category_id_array = $fields['categories'] ?? [];
 
 		// If any p4_page_type was selected extract the term's slug to be used in the wp query below.
 		// post_types attribute filtering.

--- a/tests/js/articles.frontend.spec.js
+++ b/tests/js/articles.frontend.spec.js
@@ -136,4 +136,62 @@ describe( 'Articles block frontend', () => {
 
     done();
   } );
+
+  it ( 'should load current post tags and categories articles on post page', async () => {
+    // Create new post.
+    await createNewPost({
+      title: 'Lorem Ipsum - tags:Oil and Forests, Categories:Nature',
+      content: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+      showWelcomeGuide: false,
+    });
+
+    await openSidebarPanelWithTitle( 'Tags' );
+    await typeInDropdownWithLabel( 'Add New Tag', 'Oil' );
+    await typeInDropdownWithLabel( 'Add New Tag', 'Forests' );
+
+    await openSidebarPanelWithTitle( 'Categories' );
+    // Wait for panel details.
+    await new Promise((r) => setTimeout(r, 300));
+    await clickElementByText( 'label', 'Nature' );
+
+    // Publish the post.
+    await publishPost();
+    await page.waitForSelector( '.post-publish-panel__postpublish' );
+
+    //Create a new post and add same tags & categories in it.
+    await createNewPost({
+      title: 'Test Articles block on Post',
+      content: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+      showWelcomeGuide: false,
+    });
+
+    await openSidebarPanelWithTitle( 'Tags' );
+    await typeInDropdownWithLabel( 'Add New Tag', 'Oil' );
+    await typeInDropdownWithLabel( 'Add New Tag', 'Forests' );
+
+    await openSidebarPanelWithTitle( 'Categories' );
+    // Wait for panel details.
+    await new Promise((r) => setTimeout(r, 300));
+    await clickElementByText( 'label', 'Nature' );
+
+    // Publish the post.
+    await publishPost();
+
+    await page.waitForSelector( '.components-snackbar__action' );
+
+    // Wait for post update.
+    await new Promise((r) => setTimeout(r, 300));
+
+    // Test articles block on frontend.
+    await clickElementByText( 'a', 'View Post' );
+
+    await page.waitForNavigation();
+
+    // The "Articles Block" should appear on post.
+    await expect( page ).toMatchElement( '.block.articles-block' );
+
+    await page.waitForSelector( '.article-list-item' );
+
+    await expect(page).toMatchElement('article:nth-child(1) h4 a', { text: 'Lorem Ipsum - tags:Oil and Forests, Categories:Nature' });
+  } , 90000 );
 } );


### PR DESCRIPTION
[JIRA 5388](https://jira.greenpeace.org/browse/PLANET-5388)

Issue -
- The articles block on Post page not showing the current page tags and categories related articles

Before fix - https://www.greenpeace.org/international/story/44543/fading-memories-of-atomic-bombing-hiroshima-75-years-later/
After fix    - https://k8s.p4.greenpeace.org/test-jupiter/story/44543/fading-memories-of-atomic-bombing-hiroshima-75-years-later/
(Please check the articles block at the bottom of page, The articles display in block should belongs to current post tags and categories)
