### PR TITLE
Planet 5501 - Consistent styles for buttons

### DIFF
--- a/assets/src/blocks/Splittwocolumns/SplittwocolumnsFrontend.js
+++ b/assets/src/blocks/Splittwocolumns/SplittwocolumnsFrontend.js
@@ -85,7 +85,7 @@ export const SplittwocolumnsFrontend = ({
             />
           }
           {button_text && button_link &&
-            <a className="btn btn-small btn-primary btn-block split-two-column-item-button"
+            <a className="btn btn-primary btn-block split-two-column-item-button"
                 href={button_link}
                 {...analytics('Call to Action')}
                 dangerouslySetInnerHTML={{__html: button_text}}

--- a/assets/src/blocks/Splittwocolumns/SplittwocolumnsInPlaceEdit.js
+++ b/assets/src/blocks/Splittwocolumns/SplittwocolumnsInPlaceEdit.js
@@ -4,7 +4,7 @@ import { debounce } from 'lodash';
 const { __ } = wp.i18n;
 
 /**
- * WYSIWYG in-place editor 
+ * WYSIWYG in-place editor
  */
 export const SplittwocolumnsInPlaceEdit = ({attributes, charLimit, setAttributes}) => {
   const {
@@ -67,7 +67,7 @@ export const SplittwocolumnsInPlaceEdit = ({attributes, charLimit, setAttributes
             characterLimit={charLimit.description}
             multiline="false"
             allowedFormats={['core/bold', 'core/italic']}
-            />  
+            />
           {issue_link_path &&
             <RichText
               tagName="a"
@@ -113,7 +113,7 @@ export const SplittwocolumnsInPlaceEdit = ({attributes, charLimit, setAttributes
             />
           <RichText
             tagName="a"
-            className="btn btn-small btn-primary btn-block split-two-column-item-button"
+            className="btn btn-primary btn-block split-two-column-item-button"
             placeholder={__('Enter button text', 'planet4-blocks-backend')}
             keepPlaceholderOnFocus={true}
             value={button_text}
@@ -128,4 +128,3 @@ export const SplittwocolumnsInPlaceEdit = ({attributes, charLimit, setAttributes
     </section>
   )
 }
- 

--- a/assets/src/styles/blocks/CarouselHeader.scss
+++ b/assets/src/styles/blocks/CarouselHeader.scss
@@ -306,17 +306,12 @@ $slide-transition-speed: 1s;
       }
 
       .btn {
-        font-size: $font-size-xxs;
-        line-height: 2.8;
-
         html[dir="rtl"] & {
           font-size: 1.175rem;
           line-height: 2.5;
         }
 
         @include medium-and-up {
-          font-size: $font-size-sm;
-          line-height: 3;
           width: auto;
 
           html[dir="rtl"] & {

--- a/assets/src/styles/blocks/CarouselHeader.scss
+++ b/assets/src/styles/blocks/CarouselHeader.scss
@@ -306,18 +306,8 @@ $slide-transition-speed: 1s;
       }
 
       .btn {
-        html[dir="rtl"] & {
-          font-size: 1.175rem;
-          line-height: 2.5;
-        }
-
         @include medium-and-up {
           width: auto;
-
-          html[dir="rtl"] & {
-            font-size: 1.3rem;
-            line-height: 2.5;
-          }
         }
 
         @include large-and-up {

--- a/assets/src/styles/blocks/CarouselHeader_full_width_classic.scss
+++ b/assets/src/styles/blocks/CarouselHeader_full_width_classic.scss
@@ -579,16 +579,9 @@ $medium-image-height: 600px;
           }
 
           .btn {
-            font-size: $font-size-xxs;
-            line-height: 58px;
             width: auto;
             min-width: 240px;
             max-width: 100%;
-            padding-left: 24px;
-            padding-right: 24px;
-            height: 60px;
-            letter-spacing: 1px;
-            font-weight: 900;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
@@ -598,13 +591,7 @@ $medium-image-height: 600px;
               line-height: 2.5;
             }
 
-            @include small-and-up {
-              height: 54px;
-              line-height: 51px;
-            }
-
             @include medium-and-up {
-              font-size: $font-size-sm;
               min-width: 280px;
 
               html[dir="rtl"] & {

--- a/assets/src/styles/blocks/CarouselHeader_full_width_classic.scss
+++ b/assets/src/styles/blocks/CarouselHeader_full_width_classic.scss
@@ -586,18 +586,8 @@ $medium-image-height: 600px;
             overflow: hidden;
             text-overflow: ellipsis;
 
-            html[dir="rtl"] & {
-              font-size: 1.175rem;
-              line-height: 2.5;
-            }
-
             @include medium-and-up {
               min-width: 280px;
-
-              html[dir="rtl"] & {
-                font-size: 1.3rem;
-                line-height: 2.5;
-              }
             }
           }
         }

--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -1,6 +1,8 @@
 .columns-block {
   a {
-    font-weight: inherit;
+    &:not(.btn) {
+      font-weight: inherit;
+    }
 
     &.btn-primary {
       color: $white;

--- a/assets/src/styles/campaigns/base/_mixins.scss
+++ b/assets/src/styles/campaigns/base/_mixins.scss
@@ -14,7 +14,6 @@
   border: 0;
   text-decoration: none !important;
   box-sizing: content-box;
-  text-transform: uppercase;
   box-shadow: none;
   font-family: $font;
   height: 50px;

--- a/assets/src/styles/campaigns/themes/_theme_antarctic.scss
+++ b/assets/src/styles/campaigns/themes/_theme_antarctic.scss
@@ -14,7 +14,6 @@ body.theme-antarctic {
 
   @mixin antarctic-button($background: $antarctic-purple, $foreground: white) {
     @include button($background, $foreground, $montserrat, 60);
-    font-weight: $bold;
     line-height: 50px;
   }
 
@@ -49,7 +48,7 @@ body.theme-antarctic {
     @include page-section-header($sanctuary, $antarctic-blue);
   }
 
-  .page-template a {
+  .page-template a:not(.btn) {
     color: $antarctic-purple;
     text-transform: uppercase;
 

--- a/assets/src/styles/campaigns/themes/_theme_arctic.scss
+++ b/assets/src/styles/campaigns/themes/_theme_arctic.scss
@@ -14,7 +14,6 @@ body.theme-arctic {
   @mixin arctic-button($background: $arctic-faded-red, $foreground: white) {
     //todo: check letter spacing
     @include button($background, $foreground, $save-the-arctic, 60);
-    font-weight: $bold;
     line-height: 50px;
   }
 
@@ -53,11 +52,13 @@ body.theme-arctic {
   }
 
   .page-template a {
-    color: $arctic-faded-red;
-    text-transform: uppercase;
+    &:not(.btn) {
+      color: $arctic-faded-red;
+      text-transform: uppercase;
 
-    &:hover {
-      color: $arctic-red;
+      &:hover {
+        color: $arctic-red;
+      }
     }
 
     &.btn-primary {

--- a/assets/src/styles/campaigns/themes/_theme_climate.scss
+++ b/assets/src/styles/campaigns/themes/_theme_climate.scss
@@ -29,8 +29,6 @@ body.theme-climate {
 
   @mixin climate-button($background: $climate-gradient-standard, $foreground: white) {
     @include button($background, $foreground, $jost, -30);
-
-    font-weight: $semi-bold;
     transition: none;
     line-height: 54px;
   }
@@ -85,11 +83,13 @@ body.theme-climate {
   }
 
   .page-template a {
-    color: $climate-blue;
-    text-transform: uppercase;
+    &:not(.btn) {
+      color: $climate-blue;
+      text-transform: uppercase;
 
-    &:hover {
-      color: $climate-purple-2;
+      &:hover {
+        color: $climate-purple-2;
+      }
     }
   }
 

--- a/assets/src/styles/campaigns/themes/_theme_forest.scss
+++ b/assets/src/styles/campaigns/themes/_theme_forest.scss
@@ -31,7 +31,7 @@ body.theme-forest {
   }
 
   .page-template {
-    a {
+    a:not(.btn) {
       color: $forest-dark-green;
       text-transform: uppercase;
 
@@ -42,7 +42,6 @@ body.theme-forest {
 
     .btn-primary {
       @include forest-button;
-      font-weight: bold !important;
       font-family: $open-sans !important;
     }
 
@@ -51,7 +50,6 @@ body.theme-forest {
       border: 1px solid $forest-dark-green;
       box-sizing: border-box;
       text-decoration: none;
-      font-weight: bold;
 
       &:hover {
         color: white;

--- a/assets/src/styles/campaigns/themes/_theme_oceans.scss
+++ b/assets/src/styles/campaigns/themes/_theme_oceans.scss
@@ -18,8 +18,6 @@ body.theme-oceans {
     //todo: check letter spacing
     //todo: sort out transition
     @include button($background, $foreground, $montserrat, 60);
-    font-weight: $bold;
-    border-radius: 25px;
     position: relative;
 
     &:hover {

--- a/assets/src/styles/campaigns/themes/_theme_oil.scss
+++ b/assets/src/styles/campaigns/themes/_theme_oil.scss
@@ -26,8 +26,6 @@ body.theme-oil {
 
   @mixin oil-button($background: $oil-red, $foreground: black) {
     @include button($background, $foreground, $open-sans, -30);
-
-    font-weight: $semi-bold;
     transition: none;
     line-height: 54px;
   }
@@ -44,7 +42,7 @@ body.theme-oil {
   }
 
   .page-template {
-    a {
+    a:not(.btn) {
       color: $oil-blue;
       text-transform: uppercase;
 

--- a/assets/src/styles/campaigns/themes/_theme_plastic.scss
+++ b/assets/src/styles/campaigns/themes/_theme_plastic.scss
@@ -20,8 +20,6 @@ body.theme-plastic {
     //todo: check letter spacing
     //todo: sort out transition
     @include button($background, $foreground, $montserrat, 60);
-    font-weight: $extra-bold;
-    border-radius: 25px;
   }
 
   .btn-primary {

--- a/assets/src/styles/editorOverrides.scss
+++ b/assets/src/styles/editorOverrides.scss
@@ -50,10 +50,9 @@
   font-family: $roboto;
   text-align: center;
   text-decoration: none;
-  text-transform: uppercase;
   color: $white;
-  font-weight: 500;
-  border-radius: 0;
+  font-weight: bold;
+  border-radius: 4px;
   border: 1px solid transparent;
   cursor: pointer;
   line-height: 3;
@@ -62,6 +61,12 @@
   transition-property: color, background-color, border-color;
   transition-duration: 150ms;
   transition-timing-function: linear;
+  text-transform: capitalize;
+  font-size: $font-size-sm;
+}
+
+.wp-block-button.text-transform-none .wp-block-button__link[role="textbox"] {
+  text-transform: none;
 }
 
 .wp-block-button.is-style-secondary .wp-block-button__link[role="textbox"],
@@ -70,7 +75,6 @@
   border-color: var(--btn-secondary-border-color, $dark-blue);
   color: var(--btn-secondary-color, $dark-blue);
   box-shadow: none;
-  font-size: $font-size-xxs;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -78,13 +82,13 @@
   padding: 2px $n30;
 
   html[dir="rtl"] & {
-    font-size: $font-size-sm;
     line-height: 2.5;
   }
 }
 
 .wp-block-button.is-style-cta .wp-block-button__link[role="textbox"] {
   background-color: var(--btn-primary-background-color, $orange);
+  border-color: var(--btn-secondary-border-color, $orange);
   color: var(--btn-primary-color, $white);
   box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
 }
@@ -92,7 +96,6 @@
 .wp-block-button.is-style-donate .wp-block-button__link[role="textbox"] {
   background-color: var(--btn-donate-background-color, $aquamarine);
   color: var(--btn-donate-color, $grey);
-  font-size: $font-size-sm;
   line-height: 1.65;
   min-width: 180px;
   margin: 0;

--- a/templates/blocks/carousel_header_full-width-classic.twig
+++ b/templates/blocks/carousel_header_full-width-classic.twig
@@ -49,7 +49,7 @@
 												{% if slide.link_text %}
 													<a href="{{ slide.link_url }}"
 															{{  'true' == slide.link_url_new_tab ? 'target="_blank"' }}
-														class="btn btn-small btn-medium btn-primary btn-block"
+														class="btn btn-small btn-primary btn-block"
 														data-ga-category="Carousel Header"
 														data-ga-action="Call to Action"
 														data-ga-label="Slide {{ loop.index }}">

--- a/templates/blocks/carousel_header_full-width-classic.twig
+++ b/templates/blocks/carousel_header_full-width-classic.twig
@@ -49,7 +49,7 @@
 												{% if slide.link_text %}
 													<a href="{{ slide.link_url }}"
 															{{  'true' == slide.link_url_new_tab ? 'target="_blank"' }}
-														class="btn btn-small btn-primary btn-block"
+														class="btn btn-primary btn-block"
 														data-ga-category="Carousel Header"
 														data-ga-action="Call to Action"
 														data-ga-label="Slide {{ loop.index }}">

--- a/templates/blocks/columns_tasks.twig
+++ b/templates/blocks/columns_tasks.twig
@@ -53,7 +53,7 @@
 								{% endif %}
 								{% if ( col.cta_text and col.cta_link ) %}
 									<a
-										class="btn btn-small btn-medium {{ is_campaign ? 'btn-primary' : 'btn-secondary' }}"
+										class="btn btn-small {{ is_campaign ? 'btn-primary' : 'btn-secondary' }}"
 										href="{{ col.cta_link|e('esc_url') }}"
 										{{  col.link_new_tab  ? 'target="_blank"' }}
 										data-ga-category="Columns Block"


### PR DESCRIPTION
See https://jira.greenpeace.org/browse/PLANET-5501

- Remove any custom button properties in campaign themes
- Update button styles in the editor (WYSIWYG)
- Remove `btn-medium` class as it just duplicates the "regular" button styles
- Remove CarouselHeader button style overrides
- Remove Splittwocolumns button style overrides
- Remove some of the RTL-related overrides

#### Related PRs
- [styleguide](https://github.com/greenpeace/planet4-styleguide/pull/80)
- [master-theme](https://github.com/greenpeace/planet4-master-theme/pull/1205)