### PR TITLE
PLANET-5607 No apiFetch on frontend, it breaks wpml and nonces

### DIFF
--- a/assets/src/blocks/Articles/useArticlesFetch.js
+++ b/assets/src/blocks/Articles/useArticlesFetch.js
@@ -1,12 +1,8 @@
 import { useState, useEffect } from '@wordpress/element';
+import { fetchJson } from '../../functions/fetchJson';
 
 const { apiFetch } = wp;
 const { addQueryArgs } = wp.url;
-
-const fetchJson = async(url) => {
-  const response = await fetch(url);
-  return response.json();
-};
 
 export const useArticlesFetch = (attributes, postType, postId, baseUrl = null, postCategories = []) => {
   const { article_count, post_types, posts, tags, ignore_categories } = attributes;

--- a/assets/src/blocks/Gallery/GalleryFrontend.js
+++ b/assets/src/blocks/Gallery/GalleryFrontend.js
@@ -15,7 +15,7 @@ export const GalleryFrontend = ({
   const layout = getGalleryLayout(className, gallery_block_style);
   const postType = document.body.getAttribute('data-post-type');
 
-  const { images } = useGalleryImages({ multiple_image, gallery_block_focus_points }, layout);
+  const { images } = useGalleryImages({ multiple_image, gallery_block_focus_points }, layout, document.body.dataset.nro);
 
   return (
     <section className={`block ${GALLERY_BLOCK_CLASSES[layout]}`}>

--- a/assets/src/blocks/Gallery/useGalleryImages.js
+++ b/assets/src/blocks/Gallery/useGalleryImages.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from '@wordpress/element';
+import { fetchJson } from '../../functions/fetchJson';
 
 const { apiFetch } = wp;
 const { addQueryArgs } = wp.url;
@@ -9,7 +10,7 @@ const GALLERY_IMAGE_SIZES = {
   'grid': 'large'
 };
 
-export const useGalleryImages = ({ multiple_image, gallery_block_focus_points }, layout) => {
+export const useGalleryImages = ({ multiple_image, gallery_block_focus_points }, layout, baseUrl = null) => {
   const [images, setImages] = useState([]);
 
   const imageSize = GALLERY_IMAGE_SIZES[layout];
@@ -23,7 +24,9 @@ export const useGalleryImages = ({ multiple_image, gallery_block_focus_points },
     };
 
     try {
-      const images = await apiFetch({ path: addQueryArgs('planet4/v1/get-gallery-images', args) });
+      const images = baseUrl
+        ? await fetchJson(`${ baseUrl }/wp-json/${ addQueryArgs('planet4/v1/get-gallery-images', args) }`)
+        : await apiFetch({ path: addQueryArgs('planet4/v1/get-gallery-images', args) });
       setImages(images);
     } catch (e) {
       console.log(e);

--- a/assets/src/blocks/Happypoint/useHappypointImageData.js
+++ b/assets/src/blocks/Happypoint/useHappypointImageData.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from '@wordpress/element';
+import { fetchJson } from '../../functions/fetchJson';
 
 const { apiFetch } = wp;
 const { addQueryArgs } = wp.url;
@@ -9,13 +10,15 @@ export const useHappypointImageData = imageId => {
   useEffect(() => {
     const loadImageData = async () => {
       try {
-        const queryArgs = {
-          path: addQueryArgs('/planet4/v1/get-happypoint-data', {
-            id: imageId
-          })
+        const args = {
+          id: imageId
         };
 
-        const data = await apiFetch(queryArgs);
+        const baseUrl = document.body.dataset.nro;
+
+        const data =  baseUrl
+          ? await fetchJson(`${ baseUrl }/wp-json/${ addQueryArgs('planet4/v1/get-happypoint-data', args) }`)
+          : await apiFetch({ path: addQueryArgs('planet4/v1/get-happypoint-data', args) });
         setImageData(data);
       } catch (e) {
         console.log(e);

--- a/assets/src/blocks/Splittwocolumns/SplittwocolumnsFrontend.js
+++ b/assets/src/blocks/Splittwocolumns/SplittwocolumnsFrontend.js
@@ -1,7 +1,3 @@
-import { Component, Fragment } from '@wordpress/element';
-
-const { apiFetch } = wp.apiFetch;
-
 export const SplittwocolumnsFrontend = ({
   title,
   issue_description,
@@ -45,7 +41,7 @@ export const SplittwocolumnsFrontend = ({
           {title && issue_link_path &&
             <h2 className="split-two-column-item-title">
               <a href={issue_link_path} {...analytics('Category Title')}
-                dangerouslySetInnerHTML={{__html: title}} 
+                dangerouslySetInnerHTML={{__html: title}}
               />
             </h2>
           }
@@ -58,8 +54,8 @@ export const SplittwocolumnsFrontend = ({
             />
           }
           {issue_link_text && issue_link_path &&
-            <a className="split-two-column-item-link" 
-               href={issue_link_path} 
+            <a className="split-two-column-item-link"
+               href={issue_link_path}
                {...analytics('Text Link')}
                dangerouslySetInnerHTML={{__html: issue_link_text}}
             />
@@ -77,10 +73,10 @@ export const SplittwocolumnsFrontend = ({
         }
         <div className="split-two-column-item-content">
           {tag_name &&
-            <a className="split-two-column-item-tag" 
+            <a className="split-two-column-item-tag"
                href={tag_link}
                {...analytics('Tag Title')}
-               dangerouslySetInnerHTML={{__html: `<span aria-label="hashtag">#</span>${tag_name}`}} 
+               dangerouslySetInnerHTML={{__html: `<span aria-label="hashtag">#</span>${tag_name}`}}
             />
           }
           {tag_description &&

--- a/assets/src/functions/fetchJson.js
+++ b/assets/src/functions/fetchJson.js
@@ -1,0 +1,18 @@
+/**
+ * Function with a similar signature as WordPress's apiFetch, but doesn't do a bunch of things we don't need and cause
+ * issues. You could as well use what is inside this function directly, but having this in a single function makes it
+ * easier to use in a ternary assignment, as in the editor it still needs to use apiFetch in the same place.
+ *
+ * 1) It will pass a nonce, which is on the page but could have been cached and expired. Even when an endpoint
+ * doesn't require a nonce, passing an invalid one will make it fail. Passing nonces on public endpoints is pretty
+ * pointless regardless.
+ *
+ * 2) It doesn't use the correct language for the API when using WPML. An alternative is to use what we already have in
+ * document.body.dataset.nro, which has the language suffix, so will cause the API to use that language.
+ *
+ * 3) It's yet another blocking script to load.
+ */
+export const fetchJson = async(url) => {
+  const response = await fetch(url);
+  return response.json();
+};

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -398,8 +398,6 @@ final class Loader {
 				'wp-element',
 				// Exports the __() function.
 				'wp-i18n',
-				// Tools to get data from the REST API.
-				'wp-api-fetch',
 				// URL helpers (as addQueryArgs).
 				'wp-url',
 				// Use to translate date.


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5607

`apiFetch` fails if the page is cached with an expired nonce, then it fails to fetch a new nonce. The fix is to not use `apiFetch` on the frontend but a regular `fetch` instead. This probably also prevents an issue with wpml, as we applied the same solution for such an issue in the Articles block previously, and now that block is not experiencing the nonce issue.