### PR TITLE
PLANET-5345 - Firebase + ControlShift PoC - Connect to an emulator instance

### DIFF
--- a/assets/src/blocks/ControlShift/ControlShiftEvents.js
+++ b/assets/src/blocks/ControlShift/ControlShiftEvents.js
@@ -1,10 +1,10 @@
 import { useState } from '@wordpress/element';
 import { useCollection } from 'react-firebase-hooks/firestore';
-import firebase from './firebase';
+import { db } from './firebase';
 
 export const ControlShiftEvents = () => {
   const [eventsCollection, loading, error] = useCollection(
-    firebase.firestore().collection('p4-test-event'), {}
+    db.collection('p4-test-event'), {}
   );
 
   const events = eventsCollection ? eventsCollection.docs.map((e) => {

--- a/assets/src/blocks/ControlShift/firebase.js
+++ b/assets/src/blocks/ControlShift/firebase.js
@@ -16,4 +16,12 @@ const devConfig = {
 firebase.initializeApp(devConfig);
 firebase.analytics();
 
+export const db = firebase.firestore();
+if (location.host === 'www.planet4.test') {
+  db.settings({
+    host: "localhost:8081",
+    ssl: false
+  });
+};
+
 export default firebase;


### PR DESCRIPTION
This hijacks the DB config on the initialized App object to connect to a local emulator instance. This way we can play with the data without touching the production instances. It also enables us to run CI workflows using the emulators with test data.

See: https://firebase.google.com/docs/emulator-suite/connect_firestore#instrument_your_app_to_talk_to_the_emulators

Ref: https://jira.greenpeace.org/browse/PLANET-5345