### PR TITLE
PLANET-5349 Fix sidebar help texts font size

### DIFF
--- a/assets/src/styles/components/HTMLSidebarHelp.scss
+++ b/assets/src/styles/components/HTMLSidebarHelp.scss
@@ -1,5 +1,6 @@
 .HTMLSidebarHelp {
   padding-top: $space-xs;
   padding-bottom: $space-md;
-  font-size: 8pt;
+  font-size: 13px;
+  line-height: 1.5;
 }

--- a/assets/src/styles/editorOverrides.scss
+++ b/assets/src/styles/editorOverrides.scss
@@ -202,3 +202,12 @@ input.describe[type=text][data-setting=caption] {
     content: none;
   }
 }
+
+// Sidebar help texts
+.components-base-control__help,
+.components-form-token-field__help,
+.sidebar-blocks-help ul li,
+.FieldHelp {
+  font-size: 13px;
+  line-height: 1.5;
+}


### PR DESCRIPTION
See https://jira.greenpeace.org/browse/PLANET-5349

#### Tasks
- Override editor sidebar help texts (`components-base-control__help`, `components-form-token-field__help`, `FieldHelp`  classes) font size with WP standards (otherwise it applies [our generic rule for paragraphs](https://github.com/greenpeace/planet4-styleguide/blob/master/src/base/_typography.scss#L18) from `_typography.scss`)
- Override `sidebar-blocks-help ul li` font size with WP standards (otherwise it applies [our generic rule for lists](https://github.com/greenpeace/planet4-styleguide/blob/master/src/base/_typography.scss#L19) from `_typography.scss`)
- The Timeline block uses a custom `HTMLSidebarHelp.scss` file that was setting the font size too small compared to the WP standards, so this override was updated

#### Testing
- Broken version: edit [this page](https://www-dev.greenpeace.org/test-jupiter/test-sidebar-help-texts-broken/) and see the broken sidebar help texts (different sizes, disproportionate to the rest of the sidebar)
- Fixed version: edit [this page](https://www-dev.greenpeace.org/test-phoebe/test-sidebar-help-texts/) and check that all sidebar help texts are now the same font size and look much more proportionate!