### PR TITLE
Media change listener

### DIFF
--- a/assets/src/blocks/Media/MediaBlock.js
+++ b/assets/src/blocks/Media/MediaBlock.js
@@ -6,27 +6,14 @@ const {__} = wp.i18n;
 
 const BLOCK_NAME = 'planet4-blocks/media-video';
 
-const attributes = {
-  video_title: {
-    type: 'string'
-  },
-  description: {
-    type: 'string'
-  },
-  video_poster_img: {
-    type: 'integer'
-  },
-  embed_html: {
-    type: 'string',
-    default: ''
-  },
-  media_url: {
-    type: 'string'
-  },
-  poster_url: {
-    type: 'string',
-    default: ''
-  },
+// Old content didn't store the poster url and embed html in the props. For the frontend this is caught in the block's
+// backend render method, where we setup a div to be frontend rendered by the same MediaFrontend component as is used for
+// save.
+export const lacksAttributes = attributes => {
+  const lacksEmbedHtml = attributes.media_url && !attributes.media_url.endsWith('.mp4') && !attributes.embed_html;
+  const lacksPosterUrl = attributes.video_poster_img && !attributes.poster_url;
+
+  return lacksEmbedHtml || lacksPosterUrl;
 };
 
 export const registerMediaBlock = () => {
@@ -36,9 +23,38 @@ export const registerMediaBlock = () => {
     title: __('Media block', 'planet4-blocks-backend'),
     icon: 'format-video',
     category: 'planet4-blocks',
-    attributes,
-    save: MediaFrontend,
+    attributes: {
+      video_title: {
+        type: 'string'
+      },
+      description: {
+        type: 'string'
+      },
+      video_poster_img: {
+        type: 'integer'
+      },
+      embed_html: {
+        type: 'string',
+        default: ''
+      },
+      media_url: {
+        type: 'string'
+      },
+      poster_url: {
+        type: 'string',
+        default: ''
+      },
+    },
+    save: ({ attributes }) => {
+      if (lacksAttributes(attributes)) {
+        return null;
+      }
+
+      return <MediaFrontend attributes={attributes} />;
+    },
     edit: MediaEditor,
-    mediaV1,
+    deprecated: [
+      mediaV1,
+    ],
   });
 };

--- a/assets/src/blocks/Media/MediaBlock.js
+++ b/assets/src/blocks/Media/MediaBlock.js
@@ -50,7 +50,7 @@ export const registerMediaBlock = () => {
         return null;
       }
 
-      return <MediaFrontend attributes={attributes} />;
+      return <MediaFrontend {...attributes} />;
     },
     edit: MediaEditor,
     deprecated: [

--- a/assets/src/blocks/Media/MediaEditor.js
+++ b/assets/src/blocks/Media/MediaEditor.js
@@ -28,8 +28,13 @@ const MediaInspectorOptions = ({ attributes, setAttributes }) => {
     setAttributes({ media_url: value, embed_html: embed_html });
   }, 300), []);
 
-  function onSelectImage({id}) {
-    setAttributes({video_poster_img: id});
+  function onSelectImage(image) {
+    const poster_url = image ? image.sizes.large.url : null;
+
+    setAttributes({
+      video_poster_img: image.id,
+      poster_url,
+    });
   }
 
   return <InspectorControls>
@@ -115,29 +120,9 @@ const resolveURL = url => {
 }
 
 export const MediaEditor = (props) => {
-  const { attributes, setAttributes, isSelected } = props;
-  const { video_poster_img } = attributes;
+  const { setAttributes, isSelected } = props;
 
   const toAttribute = attributeName => value => setAttributes({ [attributeName]: value });
-  const poster_url = useSelect(select => {
-    const media = select('core').getMedia(video_poster_img);
-
-    return media ? media.media_details.sizes.large.source_url : null;
-  }, [video_poster_img]);
-
-  // In order to render the block statically with no endpoint calls
-  // we need to store the embed's HTML and the poster image URL.
-  // As that content is fetched when the Media URL or the image ID changes,
-  // the effect itself is more or less a change listener for `embed_html` and `poster_url`,
-  // which are retrieved in the previous useSelect call right before this effect.
-  // Once we know the content of `embed_html` and `poster_url`, we store them as attributes
-  // for the block to render statically.
-  useEffect(() => {
-    setAttributes({
-      poster_url: poster_url || null
-    })
-  },
-  [ poster_url ]);
 
   return (
     <div>

--- a/assets/src/blocks/Media/MediaEditor.js
+++ b/assets/src/blocks/Media/MediaEditor.js
@@ -12,19 +12,12 @@ const { __ } = wp.i18n;
 const { RichText } = wp.blockEditor;
 
 const MediaInspectorOptions = ({ attributes, setAttributes }) => {
-  // Using a state to prevent the input losing the cursor position,
-  // a React issue reported multiple times, see:
-  // https://github.com/facebook/react/issues/14904
-  // https://github.com/facebook/react/issues/955#issuecomment-469352730
-  const [ media_url, setMediaURL ] = useState(attributes.media_url);
+  const { media_url } = attributes;
+  
   const debouncedMediaURLUpdate = useCallback(debounce(value => {
-    setAttributes({ embed_html: null });
-
     const embedPreview = wp.data.select('core').getEmbedPreview(resolveURL(value));
-
     const embed_html = embedPreview ? embedPreview.html : null;
 
-    setMediaURL(value);
     setAttributes({ media_url: value, embed_html: embed_html });
   }, 300), []);
 
@@ -42,10 +35,9 @@ const MediaInspectorOptions = ({ attributes, setAttributes }) => {
         <TextControl
           label={__('Media URL/ID', 'planet4-blocks-backend')}
           placeholder={__('Enter URL', 'planet4-blocks-backend')}
-          value={ media_url }
+          defaultValue={ media_url }
           onChange={
             value => {
-              setMediaURL(value)
               debouncedMediaURLUpdate(value)
             }
           }

--- a/assets/src/blocks/Media/MediaFrontend.js
+++ b/assets/src/blocks/Media/MediaFrontend.js
@@ -17,7 +17,7 @@ const wrapEmbedHTML = embed_html => {
   return wrapperDiv.outerHTML;
 }
 
-export const MediaFrontend = ({ attributes }) => {
+export const MediaFrontend = ( attributes ) => {
   const {
     video_title,
     description,

--- a/assets/src/blocks/Media/MediaFrontend.js
+++ b/assets/src/blocks/Media/MediaFrontend.js
@@ -1,8 +1,6 @@
 import { MediaEmbedPreview } from './MediaEmbedPreview';
 import { MediaElementVideo } from './MediaElementVideo';
 
-const { __ } = wp.i18n;
-
 const wrapEmbedHTML = embed_html => {
   const wrapperDiv = document.createElement('div');
   wrapperDiv.innerHTML = embed_html;

--- a/assets/src/blocks/Media/deprecated/mediaV1.js
+++ b/assets/src/blocks/Media/deprecated/mediaV1.js
@@ -1,4 +1,4 @@
-export const mediaV1 = [{
+export const mediaV1 = {
   attributes: {
     video_title: {
       type: 'string'
@@ -14,6 +14,9 @@ export const mediaV1 = [{
       default: ''
     },
   },
+  isEligible({youtube_id}) {
+    return !!youtube_id;
+  },
   migrate( { youtube_id, ...attributes } ) {
     return {
       ...attributes,
@@ -21,4 +24,4 @@ export const mediaV1 = [{
     };
   },
   save: () => null
-}];
+};


### PR DESCRIPTION
This makes the component set the embed html in the input change listener so that we don't need to set the attributes in an intermediary invalid state until the effect runs, but instead sets both at the same time. This ensures that no render can unintentionally trigger a change to the post content.

Since the backend will still render any block that has no content**, we can make the block return `null` in save whenever it's missing either (or both) `embed_html` or `poster_url`, but does have the corresponding "identifier" prop (`media_url` or `video_poster_img`). Then it uses [`useSelect` in the edit component](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/423/files#diff-c6c91408622162ae2bd090b6d50b303d1de0a3ebff4e385997189643c4a18ce1R124) to get the missing html or url.

We can in a follow up make a migration script to migrate existing content, then after running it we only need to remove a few lines from `MediaEditor` and `save`.

_** well technically it adds the missing attributes for the frontend to render_