### PR TITLE
PLANET-5640: Update Timeline lib to resolve google api version problems

### DIFF
--- a/assets/src/blocks/Timeline/Timeline.js
+++ b/assets/src/blocks/Timeline/Timeline.js
@@ -3,7 +3,7 @@ import { useStyleSheet } from '../../components/useStyleSheet/useStyleSheet';
 import { useRef, useEffect } from 'react';
 import { uniqueId } from 'lodash';
 
-const TIMELINE_JS_VERSION = '3.6.6';
+const TIMELINE_JS_VERSION = '3.8.10';
 
 export const Timeline = (props) => {
 	const {
@@ -16,7 +16,7 @@ export const Timeline = (props) => {
 	const timelineNode = useRef(null);
 
 	const [stylesLoaded, stylesError] = useStyleSheet(
-    `https://cdnjs.cloudflare.com/ajax/libs/timelinejs/${TIMELINE_JS_VERSION}/css/timeline.css`
+    `https://cdn.knightlab.com/libs/timeline3/${TIMELINE_JS_VERSION}/css/timeline.css`
 	);
 
   const setupTimeline = function() {
@@ -30,7 +30,7 @@ export const Timeline = (props) => {
 	}
 
 	const [scriptLoaded, scriptError] = useScript(
-		`https://cdnjs.cloudflare.com/ajax/libs/timelinejs/${TIMELINE_JS_VERSION}/js/timeline-min.js`
+    `https://cdn.knightlab.com/libs/timeline3/${TIMELINE_JS_VERSION}/js/timeline-min.js`
 	);
 
 	useEffect(


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5640

> The timeline block in GPSEA 20th Anniversary campaign page suddenly doesn't show

The timeline block seems to be broken for some sheets urls.
The version 3.6.6 (introduced in https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/368) calls a different url than 3.6.3 for the same document, and that url gets a 403 instead of the document itself.
For the same spreadsheet url given:
```
3.6.3: https://spreadsheets.google.com/feeds/list/1tYlLd_Fx0T_7ZEaf2y9dLfRnr5HzEOW_s0wELp5-j4s/1/public/values?alt=json
3.6.6: https://sheets.googleapis.com/v4/spreadsheets/1tYlLd_Fx0T_7ZEaf2y9dLfRnr5HzEOW_s0wELp5-j4s/values/A1:R1000?key=AIzaSyCInR0kjJJ2Co6aQAXjLBQ14CEHam3K0xg
```

## Fix 

Updating Timeline version to 3.8.10 solves this issue, and introduces 2 new ones:
- CDNJS doesn't have the lib, so we fetch it uncompressed (and unminified for CSS) from Knightlab CDN
- This version uses a proxy that we don't control for all spreadsheet calls (`https://sheets-proxy.knightlab.com/proxy/{doc}`)

## Test

- Insert a Timeline block in a Page [following the handbook](https://planet4.greenpeace.org/handbook/block-timeline)
  The spreadsheet URL or the URL given in the "File > Publish to the web" popup should work (making the [handbook recommendation on point 3](https://planet4.greenpeace.org/handbook/block-timeline/#setup-the-timeline) obsolete ?)
- The timeline should appear, in the editor and on the frontend, and no 403 response should be received in the network tab
  It should work locally, if you run your local instance on `https`

Test instance is on https://www-dev.greenpeace.org/test-venus/  
[GPI campaign timeline failing in production](https://www-dev.greenpeace.org/test-iocaste/campaign/people-vs-oil/) is working on https://www-dev.greenpeace.org/test-venus/campaign/people-vs-oil/