### PR TITLE
PLANET-5633: Gallery block 3 Columns style overly zoom on images

### DIFF
--- a/assets/src/styles/blocks/Gallery_content_three_column.scss
+++ b/assets/src/styles/blocks/Gallery_content_three_column.scss
@@ -25,7 +25,7 @@
       position: relative;
       left: -35%;
       max-width: inherit;
-      object-fit: none;
+      object-fit: cover;
 
       @include mobile-only {
         width: 200px;

--- a/classes/blocks/class-gallery.php
+++ b/classes/blocks/class-gallery.php
@@ -130,7 +130,9 @@ class Gallery extends Base_Block {
 		];
 
 		foreach ( $exploded_images as $image_id ) {
-			$image_size = $fields['gallery_image_size'] ? $fields['gallery_image_size'] : $image_sizes[ $fields['gallery_block_style'] ];
+			$image_size = $fields['gallery_image_size'] ? $fields['gallery_image_size'] : (
+				$fields['gallery_block_style'] ? $image_sizes[ $fields['gallery_block_style'] ] : null
+			);
 			$image_data = [];
 
 			$image_data_array           = wp_get_attachment_image_src( $image_id, $image_size );


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5633

> On both the front and back ends the 3-column style of the gallery block is not working as expected. 
> The images are overly zoomed and the centre function in the wysiwyg is not functioning.

## Fix 

- Switching object-fit property from none to cover, to give each image more visibility and more moving space with focus.
- Fixing a small notice `Undefined index` on dev env that would break the ajax request when gallery_block_style is not specified.

Before:
![Screenshot from 2020-11-04 15-28-33](https://user-images.githubusercontent.com/617346/98123668-71f7a880-1eb2-11eb-850c-4c0133502139.png)

After:
![Screenshot from 2020-11-04 15-27-35](https://user-images.githubusercontent.com/617346/98123681-78862000-1eb2-11eb-897b-59a4d5e685bf.png)


## Test

- Insert a Gallery block in a page, add at least 3 images
- Select the style "3 columns"
- You should see more parts of the image, and the focus point should have an effect on the part of the image visible.
