### PR TITLE
PLANET-5652: Articles block: Tags containing an ampersand are displayed escaped

### DIFF
--- a/assets/src/blocks/Articles/ArticlePreview.js
+++ b/assets/src/blocks/Articles/ArticlePreview.js
@@ -1,5 +1,6 @@
 import { Component } from '@wordpress/element';
 import { dateI18n } from '@wordpress/date';
+import { unescape } from '../../functions/unescape';
 const { __ } = wp.i18n;
 
 export class ArticlePreview extends Component {
@@ -19,7 +20,7 @@ export class ArticlePreview extends Component {
               data-ga-category="Articles Block"
               data-ga-action="Post Type Tag"
               data-ga-label="n/a">
-                {pageType}
+                {unescape(pageType)}
            </a>
   }
 
@@ -126,7 +127,7 @@ export class ArticlePreview extends Component {
                       data-ga-action="Navigation Tag"
                       data-ga-label="n/a">
                         <span aria-label="hashtag">#</span>
-                        {tag.name}
+                        {unescape(tag.name)}
                     </a>
                   )}
                 </div>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5652

> In the Articles block, tags listed on top of each article are escaped and will display an ampersand as &amp;

## Fix 

Using `unescape()` function to fix tag names

Before fix:
![Screenshot from 2020-11-06 10-50-24](https://user-images.githubusercontent.com/617346/98352161-f0bd2480-201d-11eb-8762-18b7be499dc7.png)

After fix:
![Screenshot from 2020-11-06 10-49-31](https://user-images.githubusercontent.com/617346/98352175-f4e94200-201d-11eb-93df-c69730178cdb.png)

## Test

- Find an Articles block (Related articles) listing some articles with tags
- Edit one of those tags to add a character `&` in its title
- It should appear as `&` in the tag list of the related articles
