### PR TITLE
Remove text transform on buttons in editor

### DIFF
--- a/assets/src/styles/editorOverrides.scss
+++ b/assets/src/styles/editorOverrides.scss
@@ -61,7 +61,6 @@
   transition-property: color, background-color, border-color;
   transition-duration: 150ms;
   transition-timing-function: linear;
-  text-transform: capitalize;
   font-size: $font-size-sm;
 }
 


### PR DESCRIPTION
We can already deploy this part so people can see in the editor which buttons need to have capitalization fixed.