### PR TITLE
Less libs

### DIFF
--- a/assets/src/blocks/Articles/ArticlePreview.js
+++ b/assets/src/blocks/Articles/ArticlePreview.js
@@ -1,7 +1,5 @@
 import { Component } from '@wordpress/element';
-import { dateI18n } from '@wordpress/date';
 import { unescape } from '../../functions/unescape';
-const { __ } = wp.i18n;
 
 export class ArticlePreview extends Component {
   constructor(props) {
@@ -100,7 +98,7 @@ export class ArticlePreview extends Component {
         page_type_link,
         post_title,
         post_excerpt,
-        post_date
+        date_formatted,
       }
     } = this.props;
 
@@ -149,10 +147,10 @@ export class ArticlePreview extends Component {
             }
             <p className="article-list-item-meta">
               {this.getAuthorLink()}
-              {post_date &&
-                <time className="article-list-item-date" dateTime="">
-                  {dateI18n(window.p4bk_vars.dateFormat, post_date)}
-                </time>
+              {date_formatted &&
+              <time className="article-list-item-date" dateTime="">
+                {date_formatted}
+              </time>
               }
             </p>
           </header>

--- a/assets/src/blocks/Articles/useArticlesFetch.js
+++ b/assets/src/blocks/Articles/useArticlesFetch.js
@@ -1,8 +1,8 @@
 import { useState, useEffect } from '@wordpress/element';
 import { fetchJson } from '../../functions/fetchJson';
+import { addQueryArgs } from '../../functions/addQueryArgs';
 
 const { apiFetch } = wp;
-const { addQueryArgs } = wp.url;
 
 export const useArticlesFetch = (attributes, postType, postId, baseUrl = null, postCategories = []) => {
   const { article_count, post_types, posts, tags, ignore_categories } = attributes;
@@ -34,11 +34,12 @@ export const useArticlesFetch = (attributes, postType, postId, baseUrl = null, p
       args.categories = postCategories;
     }
 
+    const path = addQueryArgs('planet4/v1/get-posts', args);
 
     try {
       const response = baseUrl
-        ? await fetchJson(`${ baseUrl }/wp-json/${ addQueryArgs('planet4/v1/get-posts', args) }`)
-        : await apiFetch({ path: addQueryArgs('planet4/v1/get-posts', args) });
+        ? await fetchJson(`${ baseUrl }/wp-json/${ path }`)
+        : await apiFetch({ path });
 
       const newPosts = [...prevPosts, ...response.recent_posts];
 

--- a/assets/src/blocks/Gallery/useGalleryImages.js
+++ b/assets/src/blocks/Gallery/useGalleryImages.js
@@ -1,8 +1,8 @@
 import { useState, useEffect } from '@wordpress/element';
 import { fetchJson } from '../../functions/fetchJson';
+import { addQueryArgs } from '../../functions/addQueryArgs';
 
 const { apiFetch } = wp;
-const { addQueryArgs } = wp.url;
 
 const GALLERY_IMAGE_SIZES = {
   'slider': 'retina-large',

--- a/assets/src/blocks/Happypoint/useHappypointImageData.js
+++ b/assets/src/blocks/Happypoint/useHappypointImageData.js
@@ -1,8 +1,8 @@
 import { useState, useEffect } from '@wordpress/element';
 import { fetchJson } from '../../functions/fetchJson';
+import { addQueryArgs } from '../../functions/addQueryArgs';
 
 const { apiFetch } = wp;
-const { addQueryArgs } = wp.url;
 
 export const useHappypointImageData = imageId => {
   const [imageData, setImageData] = useState({});

--- a/assets/src/blocks/Socialmedia/Socialmedia.js
+++ b/assets/src/blocks/Socialmedia/Socialmedia.js
@@ -10,9 +10,6 @@ import {
 import withCharacterCounter from '../../components/withCharacterCounter/withCharacterCounter';
 import {URLInput} from "../../components/URLInput/URLInput";
 
-const {apiFetch} = wp;
-const {addQueryArgs} = wp.url;
-
 const TextControl = withCharacterCounter( BaseTextControl );
 const TextareaControl = withCharacterCounter( BaseTextareaControl );
 

--- a/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
@@ -3,9 +3,9 @@ import { ArrowIcon } from './ArrowIcon';
 import { toDeclarations } from '../toDeclarations';
 import { HighlightMatches } from '../HighlightMatches';
 import { fetchJson } from '../../functions/fetchJson';
+import { addQueryArgs } from '../../functions/addQueryArgs';
 
 const { apiFetch } = wp;
-const { addQueryArgs } = wp.url;
 const { __ } = wp.i18n;
 
 const placeholderData = {

--- a/assets/src/blocks/Takeactionboxout/Takeactionboxout.js
+++ b/assets/src/blocks/Takeactionboxout/Takeactionboxout.js
@@ -14,9 +14,6 @@ import {
 } from '@wordpress/components';
 import withCharacterCounter from '../../components/withCharacterCounter/withCharacterCounter';
 
-const {apiFetch} = wp;
-const {addQueryArgs} = wp.url;
-
 const TextControl = withCharacterCounter( BaseTextControl );
 const TextareaControl = withCharacterCounter( BaseTextareaControl );
 

--- a/assets/src/functions/addQueryArgs.js
+++ b/assets/src/functions/addQueryArgs.js
@@ -1,0 +1,21 @@
+export const addQueryArgs = (path, args) => {
+  if (typeof path !== 'string' || typeof args !== 'object') {
+    return path;
+  }
+
+  Object.keys(args).forEach(k => {
+    const value = args[k];
+    if (typeof value === 'undefined' || value === '') {
+      delete args[k];
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((v, i) => {
+        args[`${ k }[${ i }]`] = v;
+      });
+      delete args[k];
+    }
+  });
+
+  return `${ path }?${ new URLSearchParams(args) }`;
+};

--- a/classes/blocks/class-articles.php
+++ b/classes/blocks/class-articles.php
@@ -230,6 +230,7 @@ class Articles extends Base_Block {
 				$recent['page_type']      = $page_type;
 				$recent['page_type_link'] = get_term_link( $page_type_id );
 				$recent['link']           = get_permalink( $recent['ID'] );
+				$recent['date_formatted'] = get_the_date( '', $recent['ID'] );
 
 				$recent_posts[] = $recent;
 			}

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -397,8 +397,6 @@ final class Loader {
 				'wp-element',
 				// Exports the __() function.
 				'wp-i18n',
-				// URL helpers (as addQueryArgs).
-				'wp-url',
 				'main',
 			],
 			true

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -399,8 +399,6 @@ final class Loader {
 				'wp-i18n',
 				// URL helpers (as addQueryArgs).
 				'wp-url',
-				// Use to translate date.
-				'wp-date',
 				'main',
 			],
 			true


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5503

I started this out as a branch to test a few things while going through the pagespeed report, I don't think these actually require further changes, so it seems safe to merge these already in the context of the analysis ticket.

* Format date in the back end for Articles so we don't need to include an expensive lib on the frontend. (Actually only a small change in the PHP file, but I also made it use `array_map`, hence all the line changes)
* `wp-url` was only needed for `addQueryArgs`. For our use case on the front end this is easily replaceable with a custom function.