### PR TITLE
PLANET-5503 Remove slick dep and pubslider

### DIFF
--- a/classes/blocks/class-covers.php
+++ b/classes/blocks/class-covers.php
@@ -123,7 +123,6 @@ class Covers extends Base_Block {
 		// Enqueue js for the frontend.
 		if ( ! $this->is_rest_request() ) {
 			\P4GBKS\Loader::enqueue_local_script( 'covers', 'public/js/load_more.js', [ 'jquery' ] );
-			\P4GBKS\Loader::enqueue_local_script( 'pubslider', 'public/js/pubslider.js', [ 'jquery' ] );
 		}
 
 		$data = [

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -383,7 +383,6 @@ final class Loader {
 			P4GBKS_PLUGIN_URL . 'assets/build/style.min.css',
 			[
 				'bootstrap',
-				'slick',
 				'parent-style',
 			],
 			self::file_ver( P4GBKS_PLUGIN_DIR . '/assets/build/style.min.css' )


### PR DESCRIPTION
* Slick was added as a dependency of the plugin's styles, even though
it's not needed.
* It turns out the pubslider.js script is currently not doing anything
as it uses a wrong selector, so doesn't match anything. It's also the
only usage of slick slider. I'll keep the script itself in as we might
fix it in a follow up ticket.