### PR TITLE
Include gallery data in page, add missing srcset

### DIFF
--- a/assets/src/blocks/Gallery/GalleryFrontend.js
+++ b/assets/src/blocks/Gallery/GalleryFrontend.js
@@ -2,20 +2,16 @@ import { GalleryCarousel } from './GalleryCarousel';
 import { GalleryThreeColumns } from './GalleryThreeColumns';
 import { GalleryGrid } from './GalleryGrid';
 import { getGalleryLayout, GALLERY_BLOCK_CLASSES } from './getGalleryLayout';
-import { useGalleryImages } from './useGalleryImages';
 
 export const GalleryFrontend = ({
   gallery_block_title,
   gallery_block_description,
   className,
   gallery_block_style,
-  multiple_image,
-  gallery_block_focus_points
+  images,
 }) => {
   const layout = getGalleryLayout(className, gallery_block_style);
   const postType = document.body.getAttribute('data-post-type');
-
-  const { images } = useGalleryImages({ multiple_image, gallery_block_focus_points }, layout, document.body.dataset.nro);
 
   return (
     <section className={`block ${GALLERY_BLOCK_CLASSES[layout]}`}>

--- a/assets/src/blocks/Gallery/GalleryGrid.js
+++ b/assets/src/blocks/Gallery/GalleryGrid.js
@@ -5,6 +5,7 @@ export const GalleryGrid = ({ images }) => (
         <div key={image.image_src} className="grid-item">
           <img
             src={image.image_src}
+            srcSet={image.image_srcset}
             style={{ objectPosition: image.focus_image }}
             alt={image.alt_text}
           />

--- a/classes/blocks/class-gallery.php
+++ b/classes/blocks/class-gallery.php
@@ -44,7 +44,10 @@ class Gallery extends Base_Block {
 				'editor_script'   => 'planet4-blocks',
 				// todo: Remove when all content is migrated.
 				'render_callback' => static function ( $attributes ) {
+					$attributes['images'] = self::get_images( $attributes );
+
 					$json = wp_json_encode( [ 'attributes' => $attributes ] );
+
 					return '<div data-render="planet4-blocks/gallery" data-attributes="' . htmlspecialchars( $json ) . '"></div>';
 				},
 				'attributes'      => [
@@ -130,9 +133,10 @@ class Gallery extends Base_Block {
 		];
 
 		foreach ( $exploded_images as $image_id ) {
-			$image_size = $fields['gallery_image_size'] ? $fields['gallery_image_size'] : (
+			$image_size = $fields['gallery_image_size'] ?? (
 				$fields['gallery_block_style'] ? $image_sizes[ $fields['gallery_block_style'] ] : null
 			);
+
 			$image_data = [];
 
 			$image_data_array           = wp_get_attachment_image_src( $image_id, $image_size );


### PR DESCRIPTION
That way it doesn't require an endpoint call to render.

I also noticed that a lot of our pages were getting the "properly size images" warning in pagespeed tests. Turns out that for the Gallery Grid view, which is the smallest way to show the image, it wasn't specifying srcset, even though it's available at that point. 

As a result it was using an image that is 1200px wide while only 222px is displayed (the actual display size is a bit bigger as we cut off a part with the focal point, but not that much).

![Screenshot from 2020-11-16 16-53-57](https://user-images.githubusercontent.com/7604138/99276325-d7da1d80-282c-11eb-9447-ad77b1a80d77.png)
