### PR TITLE
PLANET-5706: Escaped html entities are displayed in the post excerpt in Articles block

### DIFF
--- a/assets/src/blocks/Articles/ArticlePreview.js
+++ b/assets/src/blocks/Articles/ArticlePreview.js
@@ -12,7 +12,7 @@ export class ArticlePreview extends Component {
     const { isCampaign } = this.props;
     const className = `tag-item tag-item--main page-type page-type-${pageType.toLowerCase().replace(' ', '_')}`;
     if (isCampaign) {
-      return <span className={className}>{pageType}</span>;
+      return <span className={className}>{unescape(pageType)}</span>;
     }
     return <a
               className={className}
@@ -159,7 +159,7 @@ export class ArticlePreview extends Component {
 
           {post_excerpt &&
             <p className="article-list-item-content">
-              {post_excerpt.replace('&hellip;', '...')}
+              {unescape(post_excerpt)}
             </p>
           }
         </div>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5706

> Escaped html entities are displayed in the articles text (here, `&nbsp;`).
> The template currently only replaces the entity `&hellip;`

As for some other fields, the post excerpt has to be filtered (unescaped) so that the html entities appear as expected (`&hellip;` as `…`, `&nbsp;` as a non-breakable space, etc.).

![image_from_ios](https://user-images.githubusercontent.com/617346/99939593-ba480f00-2d6a-11eb-9b58-6ee2ab8cc020.jpg)


## Fix 

Same fix used for similar cases, by unescaping the content of `post_excerpt` on the frontend.

## Test

- Find or create  a page with an Articles block
- Edit the excerpt of one of those articles, add a `&` sign
- The Articles block on the frontend should show a `&` sign, not a `&amp;`