### PR TITLE
PLANET-5442: Unordered list font size bigger than paragraph in the editor

### DIFF
--- a/assets/src/styles/editorOverrides.scss
+++ b/assets/src/styles/editorOverrides.scss
@@ -13,8 +13,14 @@
   }
 }
 
-.edit-post-visual-editor .wp-block {
-  max-width: 90%;
+.edit-post-visual-editor {
+  .wp-block {
+    max-width: 90%;
+  }
+
+  li {
+    font-size: unset;
+  }
 }
 
 .wp-block-image {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5442

> In the editor the unordered list font size is bigger than paragraphs (at least on large screens, smaller screens seem fine), see screenshot. It should be the same font size for both. Ordered lists seem fine too but it's worth double checking. In the frontend however it's all good!

_Some work was done on lists in editor in https://github.com/greenpeace/planet4-styleguide/pull/72, so the difference left was less than reported at the time._

Lists were a little bit bigger on large screen, and smaller on small screens.

| before | after |
| --- | --- |
| ![Screenshot from 2020-11-25 17-40-46](https://user-images.githubusercontent.com/617346/100256713-62b1cb00-2f45-11eb-80fa-81865077860f.png) | ![Screenshot from 2020-11-25 17-39-32](https://user-images.githubusercontent.com/617346/100256545-372ee080-2f45-11eb-880f-9da0a603e096.png) |

## Fix

Unset font-size modifications set [by the styleguide](https://github.com/greenpeace/planet4-styleguide/blob/b27c77400a9a94398cf6ec263859de7ec2df1597/src/base/_typography.scss#L21).

## Test

- Write a paragraph and an unordered list in the post editor.
- Put the editor in mobile size and in large screen size (>1200px)
- Text in paragraph and list should have the same size.