### PR TITLE
PLANET-5728: Carousel Gallery: Slider not working

### DIFF
--- a/assets/src/blocks/Gallery/GalleryCarousel.js
+++ b/assets/src/blocks/Gallery/GalleryCarousel.js
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef } from '@wordpress/element';
-import _uniqueId from 'lodash/uniqueId';
 
 const { __ } = wp.i18n;
 
@@ -24,8 +23,8 @@ export const GalleryCarousel = ({ images }) => {
   }
 
   const goToSlide = newSlide => {
-    const nextElement = document.getElementById(`${idRef.current}-slide${newSlide}`);
-    const activeElement = document.getElementById(`${idRef.current}-slide${currentSlide}`);
+    const nextElement = slidesRef.current[newSlide];
+    const activeElement = slidesRef.current[currentSlide];
     if (newSlide !== currentSlide && nextElement && activeElement && !sliding) {
       setSliding(true);
       const order = getOrder(newSlide);
@@ -53,7 +52,7 @@ export const GalleryCarousel = ({ images }) => {
   const goToPrevSlide = () => goToSlide(currentSlide === 0 ? lastSlide : currentSlide - 1);
 
   const timerRef = useRef(null);
-  const idRef = useRef(null);
+  const slidesRef = useRef([]);
 
   // Set up the autoplay for the slides
   useEffect(() => {
@@ -65,13 +64,6 @@ export const GalleryCarousel = ({ images }) => {
       return () => clearTimeout(timerRef.current);
     }
   }, [currentSlide, images]);
-
-  // Set up the unique id for the carousel
-  useEffect(() => {
-    if (!idRef.current) {
-      idRef.current = `gallery-${_uniqueId()}`;
-    }
-  }, []);
 
   return (
     <div className="carousel slide">
@@ -97,7 +89,7 @@ export const GalleryCarousel = ({ images }) => {
           <div
             key={image.image_src}
             className={`carousel-item ${index === currentSlide ? 'active' : ''}`}
-            id={`${idRef.current}-slide${index}`}
+            ref={element => slidesRef.current[index] = element}
           >
             <img
               src={image.image_src}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5728

Alright, so apparently this was caused by the removal of the `useGalleryImages` effect here: 

https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/commit/735d0d10f7bab6a745cec6df0d684638258094b1

As that was causing aditional renders, `idRef.current` was available on subsequent renders, now that the endpoint is gone, the ref is initialized as `null` and that's what goes into the markup, so `document.getElementById` can't find it:

![null-slides](https://user-images.githubusercontent.com/340766/100298563-319ac000-2f70-11eb-92d3-8a4eca89cfa4.png)

So the change was to avoid relying on an ID ref and DOM methods and use a collection of refs instead.