### PR TITLE
PLANET-5732: Happy Point background image missing

### DIFF
--- a/classes/blocks/class-happypoint.php
+++ b/classes/blocks/class-happypoint.php
@@ -84,7 +84,7 @@ class Happypoint extends Base_Block {
 		$image_id                    = $id ? $id : $p4_happy_point_bg_image;
 		$img_meta                    = wp_get_attachment_metadata( $image_id );
 		$image_alt                   = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
-		$data['background_src']      = wp_get_attachment_image_src( $image_id, 'retina-large' );
+		$data['background_src']      = wp_get_attachment_image_src( $image_id, 'retina-large' )[0] ?? false;
 		$data['background_srcset']   = wp_get_attachment_image_srcset( $image_id, 'retina-large', $img_meta );
 		$data['background_sizes']    = wp_calculate_image_sizes( 'retina-large', null, null, $image_id );
 		$data['engaging_network_id'] = $options['engaging_network_form_id'] ?? '';


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5732

> At the upper left corner it shows "happy point planting" probably the alt information of the image.
> But the image is missing from the background.

HappyPoint uses a malformed URL for background image src. The issue doesn't appear on most websites because the `srcset` attribute is usually properly filled, here it has no alternative set.

## Issue

```html
<picture>
  <img style="object-position: 0% 0%; opacity: 0.2;" 
       loading="lazy" 
       src="https://www.greenpeace.org/static/planet4-greece-stateless/2018/02/0-Planting-2048x1365.jpg,2048,1366,true"
       alt="HAPPY-Point-Planting" 
       srcset="false" 
       sizes="false">
</picture>
```

Endpoint is returning an array as `background_src`, which is then used concatenated as a URL
```
GET https://www.greenpeace.org/greece/wp-json/planet4/v1/get-happypoint-data?id=4098

{
  "background_src":[
    "https:\/\/www.greenpeace.org\/static\/planet4-greece-stateless\/2018\/02\/0-Planting-2048x1365.jpg",
    2048,
    1366,
    true
  ],
  "background_srcset":false,
  "background_sizes":false,
  "engaging_network_id":"https:\/\/act.greenpeace.org\/page\/20498\/subscribe\/1",
  "default_image":"https:\/\/www.greenpeace.org\/greece\/wp-content\/themes\/planet4-master-theme\/images\/happy-point-block-bg.jpg",
  "background_alt":"HAPPY-Point-Planting"
}
```

## Fix 

`wp_get_attachment_image_src()` returns an array, we make the endpoint return only the first entry, which is the img URL.
`background_src` now contains `string|false`.

## Test

- Add a HappyPoint in a page
- Check the source of the page on the frontend to verify the `src` attribute of the image is correct.