### PR TITLE
PLANET-5732: Happy Point background image missing

### DIFF
--- a/assets/src/blocks/Happypoint/HappypointFrontend.js
+++ b/assets/src/blocks/Happypoint/HappypointFrontend.js
@@ -33,8 +33,8 @@ export const HappypointFrontend = ({
   };
 
   if (background_src) {
-    imgProps.srcSet = background_srcset || 'false';
-    imgProps.sizes = background_sizes || 'false';
+    imgProps.srcSet = background_srcset || null;
+    imgProps.sizes = background_sizes || null;
   }
 
   return (


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5732

Did you know that if `srcset` is wrong, it still has priority over `src` ?
Me neither.

## Issue

We fixed the invalid URL in `src`, but the happypoint background still doesn't appear. 
If there's a problem with the srcset, the `srcset` attribute contains a string `'false'`, which blocks the `src` from being used.

## Fix

Setting `srcSet` to `null` in the React component will not include it in the `img` element, allowing `src` to be used.

## Test

You can set `background_srcset` to false there https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/0b227e81a65598702ab04f715155b0f9cdedee41/classes/blocks/class-happypoint.php#L88 to see the problem, no background image will appear.
This branch should display a background image.