### PR TITLE
Revert "PLANET-5142 Add twig filter(cf_img_url) on carousal header

### DIFF
--- a/templates/blocks/carousel_header_full-width-classic.twig
+++ b/templates/blocks/carousel_header_full-width-classic.twig
@@ -26,8 +26,8 @@
 							<div class="background-holder">
 								{% if slide.image %}
 									<img
-										src="{{ slide.image|cf_img_url(slide.image_srcset) }}"
-										srcset="{{ slide.image_srcset|cf_img_url }}"
+										src="{{ slide.image }}"
+										srcset="{{ slide.image_srcset }}"
 										sizes="{{ slide.image_sizes }}"
 										data-background-position="{{ slide.focus_image }}"
 										loading="lazy"


### PR DESCRIPTION
This reverts commit 143a2c31d7b458ca4bbac4bbf64000117e7cf5df.

Since [PLANET-5584](https://jira.greenpeace.org/browse/PLANET-5584) we no longer need that. Need to revert the code before disabling it on Cloudflare, in case some re-enabled the feature.