### PR TITLE
PLANET-5775: Covers block: invalid attribute type breaks editor

### DIFF
--- a/classes/blocks/class-covers.php
+++ b/classes/blocks/class-covers.php
@@ -73,7 +73,7 @@ class Covers extends Base_Block {
 						'default' => '',
 					],
 					'description' => [
-						'type'    => 'description',
+						'type'    => 'string',
 						'default' => '',
 					],
 					'tags'        => [


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5775

> On some older Covers blocks, a _doing_it_wrong is raised from rest_validate_value_from_schema, because of an invalid attribute type declared in class-covers.php

## Error

> Notice: rest_validate_value_from_schema was called incorrectly. The "type" schema keyword for can only be one of the built-in types: array, object, string, number, integer, boolean, and null.

## Fix

- Set description type as string.