### PR TITLE
PLANET-4660: EN Form block - Adjust Thank you message font

### DIFF
--- a/assets/src/styles/campaigns/themes/_theme_antarctic.scss
+++ b/assets/src/styles/campaigns/themes/_theme_antarctic.scss
@@ -48,7 +48,7 @@ body.theme-antarctic {
     @include page-section-header($sanctuary, $antarctic-blue);
   }
 
-  .page-template a:not(.btn) {
+  .page-template a:not(.btn):not(.share-btn) {
     color: $antarctic-purple;
     text-transform: uppercase;
 

--- a/assets/src/styles/campaigns/themes/_theme_arctic.scss
+++ b/assets/src/styles/campaigns/themes/_theme_arctic.scss
@@ -52,7 +52,7 @@ body.theme-arctic {
   }
 
   .page-template a {
-    &:not(.btn) {
+    &:not(.btn):not(.share-btn) {
       color: $arctic-faded-red;
       text-transform: uppercase;
 

--- a/assets/src/styles/campaigns/themes/_theme_climate.scss
+++ b/assets/src/styles/campaigns/themes/_theme_climate.scss
@@ -72,7 +72,7 @@ body.theme-climate {
   }
 
   .page-section-header {
-    @include page-section-header($jost, $grey-80, 800, 2rem);
+    @include page-section-header($jost, $grey-80, 800, 1.38);
     margin-bottom: $space-md;
     font-size: $font-size-xl;
     text-transform: capitalize;
@@ -83,7 +83,7 @@ body.theme-climate {
   }
 
   .page-template a {
-    &:not(.btn) {
+    &:not(.btn):not(.share-btn) {
       color: $climate-blue;
       text-transform: uppercase;
 

--- a/assets/src/styles/campaigns/themes/_theme_forest.scss
+++ b/assets/src/styles/campaigns/themes/_theme_forest.scss
@@ -31,7 +31,7 @@ body.theme-forest {
   }
 
   .page-template {
-    a:not(.btn) {
+    a:not(.btn):not(.share-btn) {
       color: $forest-dark-green;
       text-transform: uppercase;
 

--- a/assets/src/styles/campaigns/themes/_theme_oil.scss
+++ b/assets/src/styles/campaigns/themes/_theme_oil.scss
@@ -42,7 +42,7 @@ body.theme-oil {
   }
 
   .page-template {
-    a:not(.btn) {
+    a:not(.btn):not(.share-btn) {
       color: $oil-blue;
       text-transform: uppercase;
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4660

We agreed in the ticket to follow the generic rule of our typography for h2 titles, `line-height: 1.38`.
While testing, I also found a color issue for social icons.

![Screenshot from 2020-12-07 13-34-53](https://user-images.githubusercontent.com/617346/101376961-8e23a680-38b1-11eb-85e2-1e6a0359b906.png)
_blue icons issue_

## Fix

Fixes for EN Form Thank you message:
- Fix line-height of Thank you message title
- Fix social icons color

## Test

- On a campaign page with theme "climate emergency", display an EN Form block
- The _Thank you_ message can be revealed by editing the div with class `thankyou ` in the browser inspector, it's `display: none;` by default.
- Social icons should be visible, message title should fit the requirements (on a regular width)
```
font: Jost Bold
font-size: 2.5rem
line_height: 1.38
```