### PR TITLE
PLAENT-5731 Cookie notice button on campaigns is too narrow

### DIFF
--- a/assets/src/styles/campaigns/base/_mixins.scss
+++ b/assets/src/styles/campaigns/base/_mixins.scss
@@ -22,13 +22,16 @@
   transition: background $transition ease-in-out;
   padding: 0 40px;
   display: inline-block;
-  width: auto;
 
   &:not(:disabled):not(.disabled) {
     &:active {
       color: $foreground;
       background: $background;
     }
+  }
+
+  &.article-load-more, &.btn-load-more-posts-click {
+    width: auto;
   }
 }
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5731

---

Fixed campaign styles forcing cookie button to be too narrow
