### PR TITLE
PLANET-5642 Update ContentCovers heading and links

### DIFF
--- a/assets/src/styles/blocks/Covers/ContentCovers.scss
+++ b/assets/src/styles/blocks/Covers/ContentCovers.scss
@@ -81,42 +81,20 @@
         text-decoration: underline;
       }
 
-      a {
-        color: $blue;
-      }
-
-      h4 {
-        font-size: $font-size-xxs;
-        line-height: 1.2;
-        font-weight: 500;
+      h5 {
         padding: 0;
         margin: 0;
 
-        @include medium-and-up {
-          font-size: 1.125rem;
-          font-weight: 500;
-        }
-
-        @include large-and-up {
-          font-size: $font-size-sm;
-        }
-
-        @include large-and-up {
-          font-size: 1.125rem;
+        > a {
+          color: $grey-80;
         }
       }
 
       p {
-        font-size: $font-size-sm;
         margin-bottom: 0;
 
-        @include large-and-up {
-          font-size: $font-size-xxs;
-          line-height: 1.6;
-        }
-
         @include x-large-and-up {
-          font-size: $font-size-xs;
+          font-size: $font-size-sm;
         }
 
         &.publication-date {
@@ -135,10 +113,6 @@
             font-size: $font-size-xs;
           }
         }
-      }
-
-      .blue-button {
-        width: 100%;
       }
     }
   }

--- a/templates/blocks/content_covers.twig
+++ b/templates/blocks/content_covers.twig
@@ -39,13 +39,16 @@
 									</div>
 									<div class="content-covers-block-information">
 										{% if ( post.post_title ) %}
-											<a
-												href="{{ post.link }}"
-												data-ga-category="Content Covers"
-												data-ga-action="Title"
-												data-ga-label="n/a">
-													<h4>{{ post.post_title|e('wp_kses_post')|raw }}</h4>
-											</a>
+											<h5>
+												<a
+													href="{{ post.link }}"
+													data-ga-category="Content Covers"
+													data-ga-action="Title"
+													data-ga-label="n/a"
+												>
+													{{ post.post_title|e('wp_kses_post')|raw }}
+												</a>
+											</h5>
 										{% endif %}
 										{% if ( post.post_date ) %}
 											<p class="publication-date">{{ post.post_date|date('F Y') }}</p>


### PR DESCRIPTION
See https://jira.greenpeace.org/browse/PLANET-5642

I've also removed the custom color that we had in this block for links, as content links should all follow the color defined in the styleguide.