### PR TITLE
PLANET-4732 Articles Block: Show articles count option for Manual override post setting

### DIFF
--- a/assets/src/blocks/Articles/ArticlesEditor.js
+++ b/assets/src/blocks/Articles/ArticlesEditor.js
@@ -45,18 +45,18 @@ const renderEdit = (attributes, toAttribute) => {
             checked={attributes.button_link_new_tab}
             onChange={toAttribute('button_link_new_tab')}
           />
+          <TextControl
+            label={__('Articles count', 'planet4-blocks-backend')}
+            help={__('Number of articles', 'planet4-blocks-backend')}
+            type="number"
+            min={1}
+            value={attributes.article_count}
+            onChange={value =>
+              toAttribute('article_count')(Number(value))
+            }
+          />
           {attributes.posts !== 'undefined' && attributes.posts.length === 0 &&
             <Fragment>
-              <TextControl
-                label={__('Articles count', 'planet4-blocks-backend')}
-                help={__('Number of articles', 'planet4-blocks-backend')}
-                type="number"
-                min={1}
-                value={attributes.article_count}
-                onChange={value =>
-                  toAttribute('article_count')(Number(value))
-                }
-              />
               <TagSelector
                 value={attributes.tags}
                 onChange={toAttribute('tags')}


### PR DESCRIPTION

Ref: [JIRA 4732](https://jira.greenpeace.org/browse/PLANET-4732)

---

**Task:**
- Allow editor to choose articles counts option for manual override post setting.

**Testing:**
- Add articles block on page/post with manual override posts option
- Add articles count value, test on frontend