### PR TITLE
PLANET-4590: Image block: Photo credit/copyright is not visible in the editor

### DIFF
--- a/assets/src/BlockFilters.js
+++ b/assets/src/BlockFilters.js
@@ -2,11 +2,13 @@ const { addFilter } = wp.hooks;
 
 import P4ButtonEdit from './components/p4_button/edit';
 import P4TableEdit from './components/p4_table/edit';
+import { ImageBlockEdit } from './components/Image/ImageBlockEdit';
 
 export const addBlockFilters = () => {
   addFileBlockFilter();
   addButtonBlockFilter();
   addTableBlockFilter();
+  addImageBlockFilter();
 };
 
 const addFileBlockFilter = () => {
@@ -63,3 +65,5 @@ const addTableBlockFilter = () => {
 
   addFilter('blocks.registerBlockType', 'planet4-blocks/filters/table', updateTableBlockEditMethod);
 };
+
+const addImageBlockFilter = () => addFilter('editor.BlockEdit', 'core/image/edit', ImageBlockEdit);

--- a/assets/src/components/Image/ImageBlockEdit.js
+++ b/assets/src/components/Image/ImageBlockEdit.js
@@ -1,0 +1,38 @@
+const { useSelect } = wp.data;
+
+/**
+ * Return an editable image block
+ *
+ * - display image credits in caption during edition
+ */
+export const ImageBlockEdit = (BlockEdit) => {
+  return (props) => {
+    if ( 'core/image' !== props.name ) {
+      return <BlockEdit { ...props } />;
+    }
+
+    const { attributes, clientId } = props;
+    const { id, caption } = attributes;
+
+    // Get image data
+    const image = useSelect(select => id ? select('core').getMedia(id) : null);
+    const credits = image?.meta?._credit_text;
+    // Compile data for insertion
+    const image_credits = credits && credits.length > 0 && ! caption.includes(credits)
+      ? (credits.includes('©') ? credits : `© ${credits}`)
+      : null;
+    const block_id = clientId ? `block-${clientId}` : null;
+
+    return (
+      <>
+        <BlockEdit { ...props } />
+        { block_id && image_credits &&
+          <style dangerouslySetInnerHTML={{__html:
+            `#${block_id} figcaption::after { content: " ${image_credits}"; }`
+          }}>
+          </style>
+        }
+      </>
+    );
+  }
+}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4590
Linked to: https://github.com/greenpeace/planet4-master-theme/pull/1259

> In the editor, when an Image is added to post, the caption is there but the credit/copyright text is missing.
> It's visible though in the frontend. That can be confusing for editors.


## Fix 

- Adding a hook to BlockEdit allows to append the image caption with the credits.
- Another PR on master-theme adds the `credit_text` in the response of the rest API.

### Why don't you use other filters

...like [`blocks.getBlockAttributes` or `blocks.getSaveElement`](https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/filters/block-filters.md#filters) ? 

This fix uses `useSelect` to fetch image details and get the credits. 
Hooks in those filters gives an error `Error: Invalid hook call. Hooks can only be called inside of the body of a function component.`, I couldn't find another suitable filter for this that would accept hooks.

## Test

Both PR are testable on https://www-dev.greenpeace.org/test-pandora/
- Add an image block, the image should have some text on the "Credit" field of the Attachment details.
- Credit should appear in the image caption, in the editor and on the frontend.
- It is not possible to remove the credits


![Screenshot from 2020-12-10 20-12-49](https://user-images.githubusercontent.com/617346/101818417-1e692200-3b24-11eb-9bfd-3a35a5e6a78f.png)
_Credits in the editor_

![Screenshot from 2020-12-10 20-11-15](https://user-images.githubusercontent.com/617346/101818431-21fca900-3b24-11eb-9d10-ee88bbf93297.png)
_Credits on the site_
