### PR TITLE
Use a percentile width to show a bit of the third card

### DIFF
--- a/assets/src/styles/blocks/Covers/ContentCovers.scss
+++ b/assets/src/styles/blocks/Covers/ContentCovers.scss
@@ -7,7 +7,7 @@
 
   .col-md-4 {
     outline: none;
-    width: 180px;
+    width: 45%;
 
     @include medium-and-up {
       width: 157px;


### PR DESCRIPTION
Ref: https://github.com/greenpeace/planet4/issues/128

This change is to show a bit of the third card in a row of content covers as shown here:

![image](https://user-images.githubusercontent.com/340766/101820057-d4bd0f00-3b04-11eb-93f0-0b11c4a04da1.png)

The trick is to set the width to something under 50%, like 45%, so the first two cards would take 90% of the screen width.

Note:
The content covers styles are affecting some Bootstrap styles, this is something I would like to change in the Grid System issues, for now I'll leave it as it is. 
Also, this block still needs to be converted to WYSIWYG so we could revisit the layout there.