### PR TITLE
PLANET-5791 Fix last issues for Take Action boxout A/B test

### DIFF
--- a/assets/src/styles/blocks/Covers/TakeActionBoxoutBottom.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionBoxoutBottom.scss
@@ -48,7 +48,7 @@
     color: $grey-80;
     font-size: 28px;
     line-height: 1;
-    margin-top: -60px;
+    bottom: 140px;
     position: absolute;
     left: 0;
 
@@ -149,7 +149,7 @@
 
     .cover-card-more {
       font-size: 40px;
-      margin-top: -80px;
+      bottom: 230px;
     }
   }
 

--- a/assets/src/styles/blocks/Covers/TakeActionBoxoutScroll.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionBoxoutScroll.scss
@@ -10,7 +10,7 @@
   display: none;
   padding: 12px;
   height: 136px;
-  z-index: 1;
+  z-index: 3;
 
   &.hidden {
     display: none !important;
@@ -186,7 +186,7 @@
     .cover-card-more {
       position: absolute;
       margin-bottom: 0;
-      top: -195px;
+      bottom: 320px;
       left: 0;
       font-size: 28px;
       color: $black;

--- a/classes/blocks/class-takeactionboxout.php
+++ b/classes/blocks/class-takeactionboxout.php
@@ -125,6 +125,7 @@ class TakeActionBoxout extends Base_Block {
 
 			if ( ! empty( $fields['background_image'] ) ) {
 				list( $src ) = wp_get_attachment_image_src( $fields['background_image'], 'large' );
+				$alt_text    = get_post_meta( $fields['background_image'], '_wp_attachment_image_alt', true );
 			}
 
 			$block = [
@@ -135,6 +136,7 @@ class TakeActionBoxout extends Base_Block {
 				'new_tab'   => $fields['custom_link_new_tab'] ?? false,
 				'link_text' => $fields['custom_link_text'] ?? '',
 				'image'     => $src ?? '',
+				'image_alt' => $alt_text ?? '',
 			];
 
 			$data = [
@@ -175,6 +177,12 @@ class TakeActionBoxout extends Base_Block {
 
 		$options = get_option( 'planet4_options' );
 
+		if ( has_post_thumbnail( $page ) ) {
+			$image     = get_the_post_thumbnail_url( $page, 'large' );
+			$img_id    = get_post_thumbnail_id( $page );
+			$image_alt = get_post_meta( $img_id, '_wp_attachment_image_alt', true );
+		}
+
 		// Populate variables.
 		$block = [
 			'campaigns' => $tags ?? [],
@@ -183,7 +191,8 @@ class TakeActionBoxout extends Base_Block {
 			'link'      => null === $page ? '' : get_permalink( $page ),
 			'new_tab'   => false,
 			'link_text' => $options['take_action_covers_button_text'] ?? __( 'Take action', 'planet4-blocks' ),
-			'image'     => null === $page ? '' : get_the_post_thumbnail_url( $page, 'large' ),
+			'image'     => $image ?? '',
+			'image_alt' => $image_alt ?? '',
 		];
 
 		$data = [

--- a/templates/blocks/take_action_boxout.twig
+++ b/templates/blocks/take_action_boxout.twig
@@ -13,9 +13,9 @@
 				class="cover-card-overlay"
 				href="{{ boxout.link|default('#') }}" {{ boxout.new_tab and boxout.link ? 'target="_blank"' }}
 			></a>
-			<img src={{ boxout.image }} />
+			<img src={{ boxout.image }} alt="{{ boxout.image_alt }}" />
+			<div class="cover-card-more">{{ __( 'Want to do more?', 'planet4-blocks' ) }}</div>
 			<div class="cover-card-content">
-				<div class="cover-card-more">{{ __( 'Want to do more?', 'planet4-blocks' ) }}</div>
 				{% if ( boxout.campaigns ) %}
 					{% for campaign in boxout.campaigns %}
 						<a


### PR DESCRIPTION
### Description
See https://jira.greenpeace.org/browse/PLANET-5791

- Move `cover-card-more` element outside of `cover-card-content` to fix the absolute positioning
- Use `bottom` instead of `top` positioning to adapt to potential longer translation strings for "Want to do more?"
- Add alt text to the image