### PR TITLE
PLANET-5774 EN Form(Thank you page): Strip share on mail button body text

### DIFF
--- a/classes/blocks/class-enform.php
+++ b/classes/blocks/class-enform.php
@@ -226,7 +226,7 @@ class ENForm extends Base_Block {
 		}
 		$social = [
 			'title'       => esc_attr( $og_title ),
-			'description' => esc_attr( $og_description ),
+			'description' => esc_attr( wp_strip_all_tags( $og_description ) ),
 			'link'        => esc_url( $link ),
 		];
 


### PR DESCRIPTION

Ref: [JIRA 5774](https://jira.greenpeace.org/browse/PLANET-5774)

---

**Issue:**
- If the OG description (open graph) field of post have a html tag in it, it will breaks the EN form's Thank you page "Share on mail" button functionality.

Before fixing the issue the mail to is -
```
mailto:?subject=Ikke%20mere%20beskidt%20palmeolie%21%20-%20Greenpeace%20Danmark&body=&lt;p&gt;VIS DIN STØTTE FOR REGNSKOVEN. Værdifulde skovområder bliver ødelagt, lokale indbyggere mister deres hjem og orangutang risikerer at uddø. Skriv under og vær med via @greenpeacedk&lt;/p&gt; https://www.greenpeace.org/denmark/campaign/beskidt-palmeolie-truer-regnskoven/
```

After fix -
```
mailto:?subject=Ikke%20mere%20beskidt%20palmeolie%21%20-%20Greenpeace%20Danmark&body=VIS DIN STØTTE FOR REGNSKOVEN. Værdifulde skovområder bliver ødelagt, lokale indbyggere mister deres hjem og orangutang risikerer at uddø. Skriv under og vær med via @greenpeacedk https://www.greenpeace.org/denmark/campaign/beskidt-palmeolie-truer-regnskoven/
```

**Testing:**
- Open [this](https://www-dev.greenpeace.org/test-nix/campaign/beskidt-palmeolie-truer-regnskoven/) post in browser, inspect the EN form in browser console
- To view a Thank you page, remove `display:none` style tag from div having class `thankyou`
- Click on "Share on mail" button, it should display a proper mail subject and mail body in system mail client interface.
