### PR TITLE
PLANET-5733 Provide srcset for split two columns

### DIFF
--- a/assets/src/blocks/Splittwocolumns/SplittwocolumnsFrontend.js
+++ b/assets/src/blocks/Splittwocolumns/SplittwocolumnsFrontend.js
@@ -1,3 +1,5 @@
+import IMAGE_SIZES from './imageSizes';
+
 export const SplittwocolumnsFrontend = ({
   title,
   issue_description,
@@ -34,7 +36,9 @@ export const SplittwocolumnsFrontend = ({
             <img src={issue_image_src}
                  srcSet={issue_image_srcset}
                  alt={issue_image_title || ''}
-                 style={{objectPosition: focus_issue_image}} />
+                 style={{objectPosition: focus_issue_image}}
+                 sizes={IMAGE_SIZES.columnLeft}
+            />
           </div>
         }
         <div className="split-two-column-item-content">
@@ -68,7 +72,9 @@ export const SplittwocolumnsFrontend = ({
             <img src={tag_image_src}
                  srcSet={tag_image_srcset}
                  alt={tag_image_title || ''}
-                 style={{objectPosition: focus_tag_image}} />
+                 style={{objectPosition: focus_tag_image}}
+                 sizes={IMAGE_SIZES.columnRight}
+            />
           </div>
         }
         <div className="split-two-column-item-content">

--- a/assets/src/blocks/Splittwocolumns/SplittwocolumnsSettings.js
+++ b/assets/src/blocks/Splittwocolumns/SplittwocolumnsSettings.js
@@ -47,7 +47,6 @@ export const SplittwocolumnsSettings = ({attributes, charLimit, setAttributes}) 
   }, []);
 
   const onIssueChange = (issue_id) => {
-    issue_id = parseInt(issue_id);
     const issue = issuesList.find(issue => issue.id === issue_id) || null;
 
     setAttributes({
@@ -68,7 +67,6 @@ export const SplittwocolumnsSettings = ({attributes, charLimit, setAttributes}) 
   }
 
   const onTagChange = (tag_id) => {
-    tag_id = parseInt(tag_id);
     const tag = tagsList.find(tag => tag.id === tag_id);
 
     setAttributes({
@@ -90,14 +88,16 @@ export const SplittwocolumnsSettings = ({attributes, charLimit, setAttributes}) 
     setAttributes({
       [`${image_type}_id`]: parseInt(image?.id) ?? 0,
       [`${image_type}_src`]: image?.url ?? image?.source_url ?? '',
-      [`${image_type}_srcset`]: '',
       [`${image_type}_title`]: image?.title?.raw ?? image?.title ?? '',
-      edited: {...edited, ...{[`${image_type}_id`]: true}}
+      edited: {
+        ...edited,
+        [`${ image_type }_id`]: true,
+      },
     });
   }
 
   const onFocalChange = (focal_name, {x,y}) => {
-    setAttributes({[focal_name]: `${parseInt(x*100)}% ${parseInt(y*100)}%`});
+    setAttributes({ [focal_name]: `${ x * 100 }% ${ y * 100 }%` });
   }
 
   const issueOptions = [
@@ -109,8 +109,8 @@ export const SplittwocolumnsSettings = ({attributes, charLimit, setAttributes}) 
     ...tagsList.map((tag) => ({ label: tag.name, value: tag.id })),
   ];
 
-  const focus_issue_image_obj = convertFocalStringToObj(focus_issue_image || null);
-  const focus_tag_image_obj = convertFocalStringToObj(focus_tag_image || null);
+  const focus_issue_image_obj = convertFocalStringToObj(focus_issue_image);
+  const focus_tag_image_obj = convertFocalStringToObj(focus_tag_image);
   const focal_picker_dimensions = {width: 400, height: 100};
 
   return (
@@ -215,10 +215,11 @@ export const SplittwocolumnsSettings = ({attributes, charLimit, setAttributes}) 
  * @param {string} focal_str
  */
 const convertFocalStringToObj = (focal_str) => {
-  if (!focal_str || focal_str.length <= 0) {
+  if (!focal_str) {
     return {x: 0.5,y: 0.5};
   }
-  let [x, y] = focal_str.replace(/\%/g, '').split(' ');
+  const [x, y] = focal_str.replace(/%/g, '').split(' ');
+
   return {x: (parseInt(x)/100), y: (parseInt(y)/100)};
 }
 

--- a/assets/src/blocks/Splittwocolumns/imageSizes.js
+++ b/assets/src/blocks/Splittwocolumns/imageSizes.js
@@ -1,0 +1,10 @@
+export default {
+  columnLeft: `
+  (min-width: 580px) 80vw,
+  100vw
+  `,
+  columnRight: `
+  (min-width: 580px) 75vw,
+  1vw
+  `,
+};

--- a/assets/src/components/ImageOrButton/ImageOrButton.js
+++ b/assets/src/components/ImageOrButton/ImageOrButton.js
@@ -1,56 +1,56 @@
-import {Component} from '@wordpress/element';
 import {Button} from '@wordpress/components';
 import {MediaUpload,MediaUploadCheck} from '@wordpress/block-editor';
 
-export class ImageOrButton extends Component {
-  constructor(props) {
-    super(props);
-  }
+export const ImageOrButton = props => {
+  const {__} = wp.i18n;
+  const {
+    disabled = false,
+    imageId,
+    imageUrl,
+    imgClass,
+    buttonLabel,
+    help,
+    title,
+    onSelectImage,
+  } = props;
 
-  render() {
-    const {__} = wp.i18n;
-    const disabled = this.props.disabled ?? false;
+  const getImageOrButton = (openEvent) => {
+    if (imageId) {
 
-    const getImageOrButton = (openEvent) => {
-      if ( this.props.imageId ) {
-
-        return (
-
-          <img
-            src={ this.props.imageUrl }
-            onClick={ openEvent }
-            className={ this.props.imgClass }
-          />
-
-        );
-      }
-      else {
-        return (
-          <div className='button-container'>
-            <Button
-              onClick={ openEvent }
-              className='button'
-              disabled={ disabled }>
-              { this.props.buttonLabel }
-            </Button>
-
-            <div>{ this.props.help }</div>
-          </div>
-        );
-      }
-    };
-
-    return <div className='ImageOrButton'>
-      <MediaUploadCheck>
-        <MediaUpload
-          title={this.props.title}
-          type='image'
-          onSelect={this.props.onSelectImage}
-          value={this.props.imageId}
-          allowedTypes={['image']}
-          render={ ({ open }) => getImageOrButton(open) }
+      return (
+        <img
+          src={ imageUrl }
+          onClick={ openEvent }
+          className={ imgClass }
         />
-      </MediaUploadCheck>
-    </div>;
-  }
+
+      );
+    }
+
+    return (
+      <div className='button-container'>
+        <Button
+          onClick={ openEvent }
+          className='button'
+          disabled={ disabled }>
+          { buttonLabel }
+        </Button>
+
+        <div>{ help }</div>
+      </div>
+    );
+  };
+
+  return <div className='ImageOrButton'>
+    <MediaUploadCheck>
+      <MediaUpload
+        title={title}
+        type='image'
+        onSelect={onSelectImage}
+        value={imageId}
+        allowedTypes={['image']}
+        render={ ({ open }) => getImageOrButton(open) }
+      />
+    </MediaUploadCheck>
+  </div>;
 }

--- a/classes/blocks/class-base-block.php
+++ b/classes/blocks/class-base-block.php
@@ -80,4 +80,16 @@ abstract class Base_Block {
 		}
 		return false;
 	}
+
+	/**
+	 * Update the attributes of a block to the latest version.
+	 *
+	 * @param array $fields The old version of the block attributes.
+	 *
+	 * @return array|null The new version of the block attributes.
+	 * @throws NotImplemented If no implementation is given by the subclass.
+	 */
+	public static function update_data( array $fields ): ?array {
+		throw new NotImplemented( 'Method update_data is not implemented for ' . static::class );
+	}
 }

--- a/classes/blocks/class-base-block.php
+++ b/classes/blocks/class-base-block.php
@@ -83,13 +83,15 @@ abstract class Base_Block {
 
 	/**
 	 * Update the attributes of a block to the latest version.
+	 * It returns an array with the new version of the block attributes.
+	 * PHPCS does not allow me to add the return type if there is no return statement, but here we always throw an
+	 * exception, so adding a return after triggers another CS rule. Disabling the violated rule,
+	 * Squiz.Commenting.FunctionComment.InvalidNoReturn, is not working in the doc comment.
 	 *
 	 * @param array $fields The old version of the block attributes.
-	 *
-	 * @return array|null The new version of the block attributes.
 	 * @throws NotImplemented If no implementation is given by the subclass.
 	 */
-	public static function update_data( array $fields ): ?array {
+	public static function update_data( array $fields ) {
 		throw new NotImplemented( 'Method update_data is not implemented for ' . static::class );
 	}
 }

--- a/classes/blocks/class-splittwocolumns.php
+++ b/classes/blocks/class-splittwocolumns.php
@@ -81,7 +81,7 @@ class SplitTwoColumns extends Base_Block {
 				'attributes'      => static::$attributes,
 				'render_callback' => function ( $attributes ) {
 					$json = \wp_json_encode(
-						[ 'attributes' => $this->update_data( $attributes ) ]
+						[ 'attributes' => self::update_data( $attributes ) ]
 					);
 
 					return '<div

--- a/classes/blocks/class-splittwocolumns.php
+++ b/classes/blocks/class-splittwocolumns.php
@@ -33,7 +33,7 @@ class SplitTwoColumns extends Base_Block {
 	/**
 	 * @var array Block attributes.
 	 */
-	private static $attributes = [
+	private const ATTRIBUTES = [
 		'version'            => [ 'type' => 'integer' ],
 		'select_issue'       => [ 'type' => 'integer' ],
 		'title'              => [ 'type' => 'string' ],
@@ -41,9 +41,9 @@ class SplitTwoColumns extends Base_Block {
 		'issue_link_text'    => [ 'type' => 'string' ],
 		'issue_link_path'    => [ 'type' => 'string' ],
 		'issue_image_id'     => [ 'type' => 'integer' ],
-		'issue_image_src'    => [ 'type' => 'integer' ],
-		'issue_image_srcset' => [ 'type' => 'integer' ],
-		'issue_image_title'  => [ 'type' => 'integer' ],
+		'issue_image_src'    => [ 'type' => 'string' ],
+		'issue_image_srcset' => [ 'type' => 'string' ],
+		'issue_image_title'  => [ 'type' => 'string' ],
 		'focus_issue_image'  => [ 'type' => 'string' ],
 		'select_tag'         => [ 'type' => 'integer' ],
 		'tag_name'           => [ 'type' => 'string' ],
@@ -52,9 +52,9 @@ class SplitTwoColumns extends Base_Block {
 		'button_text'        => [ 'type' => 'string' ],
 		'button_link'        => [ 'type' => 'string' ],
 		'tag_image_id'       => [ 'type' => 'integer' ],
-		'tag_image_src'      => [ 'type' => 'integer' ],
-		'tag_image_srcset'   => [ 'type' => 'integer' ],
-		'tag_image_title'    => [ 'type' => 'integer' ],
+		'tag_image_src'      => [ 'type' => 'string' ],
+		'tag_image_srcset'   => [ 'type' => 'string' ],
+		'tag_image_title'    => [ 'type' => 'string' ],
 		'focus_tag_image'    => [ 'type' => 'string' ],
 		'edited'             => [ 'type' => 'object' ],
 	];
@@ -78,7 +78,7 @@ class SplitTwoColumns extends Base_Block {
 			self::BLOCK_NAME,
 			[
 				'editor_script'   => 'planet4-blocks',
-				'attributes'      => static::$attributes,
+				'attributes'      => self::ATTRIBUTES,
 				'render_callback' => function ( $attributes ) {
 					$json = \wp_json_encode(
 						[ 'attributes' => self::update_data( $attributes ) ]
@@ -116,8 +116,8 @@ class SplitTwoColumns extends Base_Block {
 			return $fields;
 		}
 
-		$issue_id       = (int) ( $fields['select_issue'] ?? 0 );
-		$tag_id         = (int) ( $fields['select_tag'] ?? 0 );
+		$issue_id       = (int) ( $fields['select_issue'] ?? null );
+		$tag_id         = (int) ( $fields['select_tag'] ?? null );
 		$issue_image_id = (int) ( $fields['issue_image'] ?? $fields['issue_image_id'] ?? get_post_thumbnail_id( $issue_id ) ?? 0 );
 		$tag_image_id   = (int) ( $fields['tag_image'] ?? $fields['tag_image_id'] ?? get_term_meta( $tag_id, 'tag_attachment_id', true ) ?? 0 );
 
@@ -128,20 +128,23 @@ class SplitTwoColumns extends Base_Block {
 			'issue_link_text'   => ! empty( $fields['issue_link_text'] ),
 			'tag_description'   => ! empty( $fields['tag_description'] ),
 			'button_text'       => ! empty( $fields['button_text'] ),
-			'issue_image_id'    => $issue_image_id > 0,
-			'tag_image_id'      => $tag_image_id > 0,
+			'issue_image_id'    => null !== $issue_image_id,
+			'tag_image_id'      => null !== $tag_image_id,
 		];
 
-		$fields                      = array_filter( $fields );
-		$fields['issue_image_src']   = $issue_image_id ? wp_get_attachment_url( $issue_image_id ) : '';
-		$fields['issue_img_srcset']  = $issue_image_id ? wp_get_attachment_image_srcset( $issue_image_id, 'large' ) : '';
-		$fields['issue_image_title'] = $issue_image_id ? get_post_meta( $issue_image_id, '_wp_attachment_image_alt', true ) : '';
-		$fields['tag_image_src']     = $tag_image_id ? wp_get_attachment_url( $tag_image_id ) : '';
-		$fields['tag_img_srcset']    = $tag_image_id ? wp_get_attachment_image_srcset( $tag_image_id, 'large' ) : '';
-		$fields['tag_image_title']   = $tag_image_id ? get_post_meta( $tag_image_id, '_wp_attachment_image_alt', true ) : '';
+		$fields = array_filter( $fields );
+
+		$fields['issue_image_src']    = $issue_image_id ? wp_get_attachment_url( $issue_image_id ) : '';
+		$fields['issue_image_title']  = $issue_image_id ? get_post_meta( $issue_image_id, '_wp_attachment_image_alt', true ) : '';
+		$fields['issue_image_srcset'] = $issue_image_id ? wp_get_attachment_image_srcset( $issue_image_id, 'large' ) : '';
+
+		$fields['tag_image_src']    = $tag_image_id ? wp_get_attachment_url( $tag_image_id ) : '';
+		$fields['tag_img_srcset']   = $tag_image_id ? wp_get_attachment_image_srcset( $tag_image_id, 'large' ) : '';
+		$fields['tag_image_title']  = $tag_image_id ? get_post_meta( $tag_image_id, '_wp_attachment_image_alt', true ) : '';
+		$fields['tag_image_srcset'] = $tag_image_id ? wp_get_attachment_image_srcset( $tag_image_id, 'large' ) : '';
 
 		if ( $issue_id ) {
-			$issue_meta_data             = get_post_meta( (int) $issue_id );
+			$issue_meta_data             = get_post_meta( $issue_id );
 			$fields['title']             = $fields['title'] ?? $issue_meta_data['p4_title'][0] ?? get_the_title( $issue_id );
 			$fields['issue_description'] = wp_trim_words( $fields['issue_description'] ?? $issue_meta_data['p4_description'][0] ?? '', 25 );
 			$fields['issue_link_path']   = $fields['issue_link_path'] ?? get_permalink( $issue_id );
@@ -164,17 +167,17 @@ class SplitTwoColumns extends Base_Block {
 		$updated = array_filter(
 			$fields,
 			static function ( $key ) {
-				return isset( static::$attributes[ $key ] );
+				return isset( self::ATTRIBUTES[ $key ] );
 			},
 			\ARRAY_FILTER_USE_KEY
 		);
-		// Typehint ids.
+
 		$updated['version']        = self::VERSION;
 		$updated['select_issue']   = $issue_id;
 		$updated['select_tag']     = $tag_id;
 		$updated['issue_image_id'] = $issue_image_id;
 		$updated['tag_image_id']   = $tag_image_id;
-		// Edition status.
+
 		$updated['edited'] = $edited;
 
 		return $updated;

--- a/classes/exception/class-notimplemented.php
+++ b/classes/exception/class-notimplemented.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Check class comment below.
+ *
+ * @package P4GBKS
+ */
 
 namespace P4GBKS\Blocks;
 

--- a/classes/exception/class-notimplemented.php
+++ b/classes/exception/class-notimplemented.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace P4GBKS\Blocks;
+
+use Exception;
+
+/**
+ * A method is not implemented by a child class.
+ */
+class NotImplemented extends Exception { }

--- a/classes/rest/class-rest-api.php
+++ b/classes/rest/class-rest-api.php
@@ -173,10 +173,10 @@ class Rest_Api {
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => static function ( WP_REST_Request $request ) {
-						$blocks      = [
+						$blocks     = [
 							SplitTwoColumns::BLOCK_NAME => SplitTwoColumns::class,
 						];
-						$block_name  = $request->get_param( 'blockname' );
+						$block_name = $request->get_param( 'blockname' );
 						/**
 						 * @var Base_Block $block_class
 						 */


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5733
Deployed on https://www-dev.greenpeace.org/test-deimos/vaer-med/verdenshavene/

**Some context on srcset and sizes** can be found in the description of https://jira.greenpeace.org/browse/PLANET-5810. We'll probably do something similar like is done in this PR for all other images, though most will probably not be as straightforward as this PR. I used https://github.com/ausi/respimagelint for diagnosing the images, which seems to work reliably in most cases.

Before we made Split Two Columns wysiwyg, it was using an srcset in the twig template. In the newer version it doesn't use the srcset when saving in JS, though the backend does set it if an older version of the block is handled.

After investigating the sizes attribute, I found that it was relatively straightforward to provide it for this block, so I added it too [in the last commit](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/469/commits/4b130f2e410e2844c5cf75096a62f112c9e75f24).

I also converted ImageOrButton into a function component, since it doesn't use state this was a quick win ([ignore whitespace for review](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/469/files?diff=split&w=1#diff-8f3145db65a33fc48087cfc31177789516dbbc5ece88e95e450c05e3cbff134d) advised).

I also made `update_data` into a method of Base_Block and added a type hint so that the usage gets detected. (realized now that these last 2 changes were probably better done in a separate PR, but at least they're in separate commits :sweat_smile: ).