### PR TITLE
PLANET-5840 Use FB graph API to serve the FB & IG oembed in social me…

### DIFF
--- a/assets/src/blocks/Socialmedia/Socialmedia.js
+++ b/assets/src/blocks/Socialmedia/Socialmedia.js
@@ -21,11 +21,13 @@ export class Socialmedia extends Component {
   componentDidMount() {
     this.checkTwitterScript();
     this.checkInstagramScript();
+    this.checkFacebookScript();
   }
 
   componentDidUpdate() {
     this.checkTwitterScript();
     this.checkInstagramScript();
+    this.checkFacebookScript();
   }
 
   /**
@@ -65,6 +67,24 @@ export class Socialmedia extends Component {
   }
 
   /**
+   * Check if facebook embeds script is loaded and initiliaze it.
+   */
+  checkFacebookScript() {
+    if (this.props.social_media_url.includes('facebook')) {
+      let fbScript = document.querySelector('script[src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v9.0"]');
+
+      if (null === fbScript) {
+        let scriptLoaded = this.loadScriptAsync('https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v9.0');
+        scriptLoaded.then(function () {
+          this.initializeFacebookEmbeds();
+        }.bind(this));
+      } else {
+        this.initializeFacebookEmbeds();
+      }
+    }
+  }
+
+  /**
    * Initialize twitter embeds.
    */
   initializeTwitterEmbeds() {
@@ -82,6 +102,17 @@ export class Socialmedia extends Component {
     setTimeout(function () {
       if ('undefined' !== window.instgrm) {
         window.instgrm.Embeds.process();
+      }
+    }, 3000);
+  }
+
+  /**
+   * Initialize facebook embeds.
+   */
+  initializeFacebookEmbeds() {
+    setTimeout(function () {
+      if ('undefined' !== window.FB) {
+        window.FB.XFBML.parse();
       }
     }, 3000);
   }

--- a/classes/blocks/class-socialmedia.php
+++ b/classes/blocks/class-socialmedia.php
@@ -23,6 +23,14 @@ class SocialMedia extends Base_Block {
 		'instagram',
 	];
 
+	private const FB_API_BASE_URL  = 'https://graph.facebook.com/v9.0';
+	private const FB_PAGE_OEMBED   = self::FB_API_BASE_URL . '/oembed_page';
+	private const FB_POST_OEMBED   = self::FB_API_BASE_URL . '/oembed_post';
+	private const FB_VIDEO_OEMBED  = self::FB_API_BASE_URL . '/oembed_video';
+	private const INSTAGRAM_OEMBED = self::FB_API_BASE_URL . '/instagram_oembed';
+	private const FB_CACHE_TTL     = 3600;            // Time in seconds to cache the response of an FB api call.
+	private const FB_CALL_TIMEOUT  = 10;              // Seconds after which the api call will timeout if not responded.
+
 	/**
 	 * Register shortcake shortcode.
 	 *
@@ -123,7 +131,12 @@ class SocialMedia extends Base_Block {
 					$url = add_query_arg( [ 'omit_script' => true ], $url );
 				}
 				if ( in_array( $provider, self::ALLOWED_OEMBED_PROVIDERS, true ) ) {
-					$data['embed_code'] = wp_oembed_get( $url );
+
+					if ( 'twitter' === $provider ) {
+						$data['embed_code'] = wp_oembed_get( $url );
+					} else {
+						$data['embed_code'] = $this->get_fb_oembed_html( rawurlencode( $url ), $provider );
+					}
 				}
 			} elseif ( 'facebook_page' === $embed_type ) {
 				$data['facebook_page_url'] = $url;
@@ -132,5 +145,98 @@ class SocialMedia extends Base_Block {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Gets Facebook, Instagram oembed html.
+	 *
+	 * @param String $url The facebook/Instagram post/page/video url.
+	 * @param String $provider The provider name such as facebook/instagram.
+	 *
+	 * @return String The oembed html or a message if something goes wrong.
+	 */
+	public function get_fb_oembed_html( $url, $provider ): string {
+		$from_cache = get_transient( 'fb_oembed_response_' . $url );
+		if ( $from_cache ) {
+			return $from_cache;
+		}
+
+		$fb_oembed_url = $this->get_fb_oembed_url( $url, $provider );
+
+		// With the safe version of wp_safe_remote_{VERB) functions, the URL is validated to avoid redirection and request forgery attacks.
+		$response = wp_safe_remote_get(
+			$fb_oembed_url,
+			[
+				'headers' => [
+					'Content-Type' => 'application/json; charset=UTF-8',
+				],
+				'timeout' => self::FB_CALL_TIMEOUT,
+			]
+		);
+
+		$body = json_decode( $response['body'], true );
+
+		if ( is_wp_error( $response ) ) {
+			return $response->get_error_message() . ' ' . $response->get_error_code();
+
+		} elseif ( is_array( $response ) && \WP_Http::OK !== $response['response']['code'] ) {
+			return $response['response']['message'] . ' ' . $response['response']['code'] . ' ' . $body['error']['message'];
+		}
+
+		set_transient( 'fb_oembed_response_' . $url, (string) $body['html'], self::FB_CACHE_TTL );
+
+		return $body['html'];
+	}
+
+	/**
+	 * Construct & return facebook oembed API url.
+	 *
+	 * @param String $url The facebook/Instagram post/page/video url.
+	 * @param String $provider The provider name such as facebook/instagram.
+	 *
+	 * @return string A facebook oembed API url.
+	 */
+	public function get_fb_oembed_url( $url, $provider ): string {
+		$options             = get_option( 'planet4_options' );
+		$fb_app_access_token = $options['fb_app_access_token'] ?? '';
+
+		if ( 'instagram' === $provider ) {
+			$url = self::INSTAGRAM_OEMBED . '?url=' . $url . '&access_token=' . $fb_app_access_token;
+		} elseif ( 'facebook' === $provider ) {
+			/**
+			 * Check if url is a facebook post, page or video.
+			 * Examples:
+			 *
+			 * Pages
+			 * https://www.facebook.com/{page-name}
+			 * https://www.facebook.com/{page-id}
+			 *
+			 * Posts
+			 * https://www.facebook.com/{page-name}/posts/{post-id}
+			 * https://www.facebook.com/{username}/posts/{post-id}
+			 * https://www.facebook.com/{username}/activity/{activity-id}
+			 * https://www.facebook.com/photo.php?fbid={photo-id}
+			 * https://www.facebook.com/photos/{photo-id}
+			 * https://www.facebook.com/permalink.php?story_fbid={post-id}&id={page-or-user-id}
+			 * https://www.facebook.com/media/set?set={set-id}
+			 * https://www.facebook.com/questions/{question-id}
+			 * https://www.facebook.com/notes/{username}/{note-url}/{note-id}
+			 *
+			 * Videos
+			 * https://www.facebook.com/{page-name}/videos/{video-id}/
+			 * https://www.facebook.com/{username}/videos/{video-id}/
+			 * https://www.facebook.com/video.php?id={video-id}
+			 * https://www.facebook.com/video.php?v={video-id}
+			 */
+			if ( preg_match( '/(\/posts\/|\/activity\/|\/photo|\/permalink\.php|\/media\/|\/questions\/|\/notes\/)/', urldecode( $url ) ) ) {
+				$url = self::FB_POST_OEMBED . '?url=' . $url . '&access_token=' . $fb_app_access_token;
+			} elseif ( preg_match( '/(\/videos\/|\/video\.php)/', urldecode( $url ) ) ) {
+				$url = self::FB_VIDEO_OEMBED . '?url=' . $url . '&access_token=' . $fb_app_access_token;
+			} else {
+				$url = self::FB_PAGE_OEMBED . '?url=' . $url . '&access_token=' . $fb_app_access_token;
+			}
+		}
+
+		return $url;
 	}
 }


### PR DESCRIPTION
…dia block

Ref: [JIRA 5840](https://jira.greenpeace.org/browse/PLANET-5840) 
---

**Testing steps:**
On local dev env., use the demo **App Access Token** used on [this instance](https://www-dev.greenpeace.org/test-titan/wp-admin/admin.php?page=planet4_settings_social).
- Make sure you have a Facebook app access token added in Planet4 >> Social settings 
- Create a [new page](https://www-dev.greenpeace.org/test-titan/wp-admin/post-new.php?post_type=page) and add Social media block
- Select embed type as a oembed, add FB/IG page/post/video link in Url field 

eg. 
https://www-dev.greenpeace.org/test-titan/28965-2/

**Note:**
While testing the Instagram oembed, use non private Instagram account posts.(Posts on private, inactive, and age-restricted Instagram accounts are not supported)

**Reference links:**
https://developers.facebook.com/docs/plugins/oembed
https://developers.facebook.com/docs/instagram/oembed/

Steps to generate **App Access Token** using **App ID** & **App Secret** (We could move this step in code but in that case we need to add 2 fields in P4 setting)
https://developers.facebook.com/docs/facebook-login/access-tokens#apptokens

Related PR: [#1271](https://github.com/greenpeace/planet4-master-theme/pull/1271)