### PR TITLE
Update README for WYSIWYG blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,26 +42,22 @@ Wordpress provides a single dependency for the whole build setup including:
 
 1. Create a new class that extends `Base_Block` ( `P4GBKS\Blocks\Base_Block` ) inside directory _classes/blocks_. The class name should follow naming convention, for example **Blockname** and its file name should be class-**blockname**.php.
 
-1. Implement its parent's class abstract method. In block's **constructor** you need to define the block's details (fields, schema) using `register_block_type` and in method **prepare_data()** you need to prepare the data which will be used for rendering.
+1. Implement its parent's class abstract method. In block's **constructor** you need to define the block's details (fields, schema) using `register_block_type` and add (required) empty method **prepare_data()**.
 
-1. Create the template file that will be used to render your block inside directory _templates/blocks_. If the name of the file is **blockname**.twig then
-you need to set the BLOCK_NAME constant as **'blockname'** It also works with html templates. Just add 'php' as the 3rd argument of the block() method.
+1. Create a new folder inside [src/blocks](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/tree/master/assets/src/blocks) named after your block **Blockname**, and add there the components that will be used to render your block. In this folder you will usually need three files:
 
-1. Add your new class name to the array inside Loader's ( `P4GBKS\Loader` ) constructor.
+    - **BlocknameBlock.js** should be a class that uses WordPress [registerBlockType](https://developer.wordpress.org/block-editor/developers/block-api/block-registration/) to define the block's attributes, schema, styles and `edit()`/`save()` functions. `edit()` function should return a React component that will be used for rendering the block in the editor. The
+    `save()` function should return a React component that will be used for rendering the block in the frontend.
 
-1. Create a new folder inside _react-blocks/src/blocks_ named after your block **Blockname** (first letter capital - rest lowercase). Create two new files inside that folder named **Blockname.js**  and **BlocknameBlock.js**.
+    - **BlocknameEditor.js** should be a class that defines a React component that implements `renderEdit()` and `renderView()`.
+    `renderEdit()` should be used to render the block in the editor, to define editor-specific things such as sidebar options. `renderView()` will be used to render the static parts and the in-place editable parts of the block, to make it look as close to the end result as possible.
 
-	 **BlocknameBlock.js** should be a class that uses wordpress [registerBlockType](https://developer.wordpress.org/block-editor/developers/block-api/block-registration/) to define the block's attributes, schema and `edit()` function.
- `edit()` function should return a react component that will be used for rendering the block in the editor.
-`save()` function should return null as we use server side rendering currently.
-
-	**Blockname.js** should be a class that defines a React component that implements `renderEdit()` and `renderView()`.
-`renderEdit()` should be used to render the block in the editor, to define editor-specific things as sidebar options, in-place edit components, and so on. `renderView()` will be used both in the editor and in the frontend site to render the block's contents, as we are rendering blocks using React in the frontend too.
+    - **BlocknameFrontend.js** should be a React component that will be used to render the block in the frontend. It needs to be added to the [frontendIndex](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/assets/src/frontendIndex.js) if you used [frontendRendered](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/assets/src/blocks/frontendRendered.js) in the `save()` function from **BlocknameBlock.js**.
 
 	To learn more details about the render logic, refer to the [blocks page in Planet 4 Gitbook](https://support.greenpeace.org/planet4/tech/blocks).
 
-1. Create a new sccs file inside _react-blocks/src/blocks/styles_ named after your block **Blockname.scss** to use for block's frontend styling.
+1. Create a new scss file inside [src/styles/blocks](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/tree/master/assets/src/styles/blocks) named after your block **Blockname.scss** to use for block's frontend styling. You'll need to import this new file in [blocks.scss](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/assets/src/styles/blocks.scss).
 
-    Create a new file named **BlocknameEditor.scss** to use for block's editor styling if you need to style the block in the editor.
+    Create a new file named **BlocknameEditor.scss** to use for block's editor styling if you need to style the block in the editor. You'll need to import this file in [editorStyle.scss](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/assets/src/styles/editorStyle.scss).
 
 1. Finally, before committing do **npm run build** to build the plugin's assets and **vendor/bin/phpcs** to check for any php styling errors in your code.


### PR DESCRIPTION
See https://jira.greenpeace.org/browse/PLANET-5867

This is a draft to update the README file with the new process for building blocks (WYSIWYG). It's partly inspired by what is written in [Gitbook](https://support.greenpeace.org/planet4/tech/blocks), since the two reference each other. Speaking of which, maybe actually this whole section of the README should be moved there? Then we could just link it 🤔 