### PR TITLE
PLANET-5901: Lazy load gallery images

### DIFF
--- a/assets/src/blocks/Gallery/GalleryCarousel.js
+++ b/assets/src/blocks/Gallery/GalleryCarousel.js
@@ -92,6 +92,7 @@ export const GalleryCarousel = ({ images }) => {
             ref={element => slidesRef.current[index] = element}
           >
             <img
+              loading='lazy'
               src={image.image_src}
               srcSet={image.image_srcset}
               sizes={image.image_sizes || 'false'}

--- a/assets/src/blocks/Gallery/GalleryGrid.js
+++ b/assets/src/blocks/Gallery/GalleryGrid.js
@@ -4,6 +4,7 @@ export const GalleryGrid = ({ images }) => (
       {images.map(image => (
         <div key={image.image_src} className="grid-item">
           <img
+            loading='lazy'
             src={image.image_src}
             srcSet={image.image_srcset}
             style={{ objectPosition: image.focus_image }}

--- a/assets/src/blocks/Gallery/GalleryThreeColumns.js
+++ b/assets/src/blocks/Gallery/GalleryThreeColumns.js
@@ -7,6 +7,7 @@ export const GalleryThreeColumns = ({ images, postType }) => (
         <div className={`${ordinals[index]}-column split-image`}>
           {image.image_src &&
             <img
+              loading='lazy'
               src={image.image_src}
               srcSet={image.image_srcset}
               sizes={image.image_sizes || 'false'}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5901

This ensures a lot less images are loaded if this block is present below the fold.