### PR TITLE
[No issue yet]: PoC - use `useGesture` for swipe detection

### DIFF
--- a/assets/src/blocks/Gallery/GalleryCarousel.js
+++ b/assets/src/blocks/Gallery/GalleryCarousel.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from '@wordpress/element';
+import { useDrag } from 'react-use-gesture';
 
 const { __ } = wp.i18n;
 
@@ -65,8 +66,20 @@ export const GalleryCarousel = ({ images }) => {
     }
   }, [currentSlide, images]);
 
+  const swipeListeners = useDrag(({ swipe: [swipeX], last }) => {
+    if(last && swipeX === -1) {
+      goToPrevSlide();
+    } else if (last && swipeX === 1) {
+      goToNextSlide();
+    }
+  },
+  {
+    swipeDistance: [10, 0],
+    swipeVelocity: 1,
+  });
+
   return (
-    <div className="carousel slide">
+    <div className="carousel slide" {...swipeListeners()}>
       {images.length > 1 &&
         <ol className="carousel-indicators">
           {images.map((image, index) =>
@@ -96,7 +109,7 @@ export const GalleryCarousel = ({ images }) => {
               src={image.image_src}
               srcSet={image.image_srcset}
               sizes={image.image_sizes || 'false'}
-              style={{ objectPosition: image.focus_image }}
+              style={{ objectPosition: image.focus_image, pointerEvents: 'none' }}
               alt={image.alt_text}
             />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14108,6 +14108,11 @@
         "scheduler": "^0.19.1"
       }
     },
+    "react-use-gesture": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/react-use-gesture/-/react-use-gesture-9.0.0.tgz",
+      "integrity": "sha512-inTAcmX0Y8LWr7XViim5+6XlTsJ7kCgwYRrwxSu1Vkjv+8GyClHITFkGGKYXAv5QywZ8YqiJXpzFx8RZpEVF+w=="
+    },
     "react-with-direction": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.6",
-    "jest-environment-node": "^26.0.1"
+    "jest-environment-node": "^26.0.1",
+    "react-use-gesture": "^9.0.0"
   }
 }


### PR DESCRIPTION
Ref: ---

No issue yet, but we talked about this to avoid mixing DOM based libraries like Hammer with React. This is just a test of  useGesture with the Gallery Carousel, as a PoC.


---

<!--
Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
