### PR TITLE
PLANET-5666: Add image sizes

### DIFF
--- a/assets/src/blocks/Articles/ArticlePreview.js
+++ b/assets/src/blocks/Articles/ArticlePreview.js
@@ -1,6 +1,6 @@
 import { Component } from '@wordpress/element';
 import { unescape } from '../../functions/unescape';
-import IMAGE_SIZES from './imageSizes';
+import { IMAGE_SIZES } from './imageSizes';
 
 export class ArticlePreview extends Component {
   constructor(props) {

--- a/assets/src/blocks/Articles/ArticlePreview.js
+++ b/assets/src/blocks/Articles/ArticlePreview.js
@@ -56,6 +56,7 @@ export class ArticlePreview extends Component {
       post: {
         thumbnail_ratio,
         thumbnail_url,
+        thumbnail_srcset,
         link,
         alt_text
       }
@@ -70,6 +71,7 @@ export class ArticlePreview extends Component {
           <img
             className="d-flex topicwise-article-image"
             src={thumbnail_url}
+            srcSet={thumbnail_srcset}
             alt={alt_text}
             loading="lazy"
           />

--- a/assets/src/blocks/Articles/ArticlePreview.js
+++ b/assets/src/blocks/Articles/ArticlePreview.js
@@ -1,5 +1,6 @@
 import { Component } from '@wordpress/element';
 import { unescape } from '../../functions/unescape';
+import IMAGE_SIZES from './imageSizes';
 
 export class ArticlePreview extends Component {
   constructor(props) {
@@ -74,6 +75,7 @@ export class ArticlePreview extends Component {
             srcSet={thumbnail_srcset}
             alt={alt_text}
             loading="lazy"
+            sizes={IMAGE_SIZES.preview}
           />
       </a>
     );

--- a/assets/src/blocks/Articles/imageSizes.js
+++ b/assets/src/blocks/Articles/imageSizes.js
@@ -1,4 +1,4 @@
-export default {
+export const IMAGE_SIZES = {
   preview: `
   (min-width: 1200px) 333px,
   (min-width: 1000px) 279px,

--- a/assets/src/blocks/Articles/imageSizes.js
+++ b/assets/src/blocks/Articles/imageSizes.js
@@ -1,0 +1,8 @@
+export default {
+  preview: `
+  (min-width: 1200px) 333px,
+  (min-width: 1000px) 279px,
+  (min-width: 780px) 207px,
+  (min-width: 580px) 510px,
+  92.31vw`,
+};

--- a/assets/src/blocks/Gallery/GalleryCarousel.js
+++ b/assets/src/blocks/Gallery/GalleryCarousel.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from '@wordpress/element';
+import { IMAGE_SIZES } from './imageSizes';
 
 const { __ } = wp.i18n;
 
@@ -94,7 +95,7 @@ export const GalleryCarousel = ({ images, onImageClick }) => {
               loading='lazy'
               src={image.image_src}
               srcSet={image.image_srcset}
-              sizes={image.image_sizes || 'false'}
+              sizes={IMAGE_SIZES.carousel}
               style={{ objectPosition: image.focus_image }}
               alt={image.alt_text}
               onClick={() => {

--- a/assets/src/blocks/Gallery/GalleryGrid.js
+++ b/assets/src/blocks/Gallery/GalleryGrid.js
@@ -1,3 +1,5 @@
+import { IMAGE_SIZES } from './imageSizes';
+
 export const GalleryGrid = ({ images, onImageClick }) => (
   <div className="container">
     <div className="grid-row">
@@ -7,6 +9,7 @@ export const GalleryGrid = ({ images, onImageClick }) => (
             loading='lazy'
             src={image.image_src}
             srcSet={image.image_srcset}
+            sizes={IMAGE_SIZES.grid}
             style={{ objectPosition: image.focus_image }}
             alt={image.alt_text}
             onClick={() => {

--- a/assets/src/blocks/Gallery/GalleryThreeColumns.js
+++ b/assets/src/blocks/Gallery/GalleryThreeColumns.js
@@ -1,4 +1,4 @@
-import IMAGE_SIZES from './imageSizes';
+import { IMAGE_SIZES } from './imageSizes';
 
 const ordinals = ['first', 'second', 'third'];
 

--- a/assets/src/blocks/Gallery/GalleryThreeColumns.js
+++ b/assets/src/blocks/Gallery/GalleryThreeColumns.js
@@ -1,3 +1,5 @@
+import IMAGE_SIZES from './imageSizes';
+
 const ordinals = ['first', 'second', 'third'];
 
 export const GalleryThreeColumns = ({ images, postType, onImageClick }) => (
@@ -10,7 +12,7 @@ export const GalleryThreeColumns = ({ images, postType, onImageClick }) => (
               loading='lazy'
               src={image.image_src}
               srcSet={image.image_srcset}
-              sizes={image.image_sizes || 'false'}
+              sizes={IMAGE_SIZES[`threeColumns${index}`]}
               style={{ objectPosition: image.focus_image }}
               alt={image.alt_text}
               className={`img_${postType}`}

--- a/assets/src/blocks/Gallery/imageSizes.js
+++ b/assets/src/blocks/Gallery/imageSizes.js
@@ -1,4 +1,4 @@
-export default {
+export const IMAGE_SIZES = {
   threeColumns0: `
   (min-width: 1200px) 500px,
   (min-width: 780px) 400px,
@@ -12,4 +12,15 @@ export default {
   (min-width: 780px) 400px,
   (min-width: 580px) 276px,
   200px`,
+  carousel: `
+  (min-width: 1200px) 1110px,
+  (min-width: 1000px) 930px,
+  (min-width: 780px) 690px,
+  (min-width: 580px) 510px,
+  92.31vw`,
+  grid: `
+  (min-width: 1200px) 269px,
+  (min-width: 780px) 218px,
+  (min-width: 580px) 249px,
+  calc(46.15vw - 9px)`,
 }

--- a/assets/src/blocks/Gallery/imageSizes.js
+++ b/assets/src/blocks/Gallery/imageSizes.js
@@ -1,0 +1,15 @@
+export default {
+  threeColumns0: `
+  (min-width: 1200px) 500px,
+  (min-width: 780px) 400px,
+  (min-width: 580px) 246px,
+  200px`,
+  threeColumns1: `
+  (min-width: 580px) 600px,
+  200px`,
+  threeColumns2: `
+  (min-width: 1200px) 500px,
+  (min-width: 780px) 400px,
+  (min-width: 580px) 276px,
+  200px`,
+}

--- a/assets/src/blocks/Splittwocolumns/SplittwocolumnsFrontend.js
+++ b/assets/src/blocks/Splittwocolumns/SplittwocolumnsFrontend.js
@@ -1,4 +1,4 @@
-import IMAGE_SIZES from './imageSizes';
+import { IMAGE_SIZES } from './imageSizes';
 
 export const SplittwocolumnsFrontend = ({
   title,

--- a/assets/src/blocks/Splittwocolumns/imageSizes.js
+++ b/assets/src/blocks/Splittwocolumns/imageSizes.js
@@ -1,4 +1,4 @@
-export default {
+export const IMAGE_SIZES = {
   columnLeft: `
   (min-width: 580px) 80vw,
   100vw`,

--- a/assets/src/blocks/Splittwocolumns/imageSizes.js
+++ b/assets/src/blocks/Splittwocolumns/imageSizes.js
@@ -1,10 +1,8 @@
 export default {
   columnLeft: `
   (min-width: 580px) 80vw,
-  100vw
-  `,
+  100vw`,
   columnRight: `
   (min-width: 580px) 75vw,
-  1vw
-  `,
+  1vw`,
 };

--- a/classes/blocks/class-articles.php
+++ b/classes/blocks/class-articles.php
@@ -202,6 +202,8 @@ class Articles extends Base_Block {
 					$recent['thumbnail_ratio'] = ( isset( $dimensions['height'] ) && $dimensions['height'] > 0 ) ? $dimensions['width'] / $dimensions['height'] : 1;
 					$recent['alt_text']        = get_post_meta( $img_id, '_wp_attachment_image_alt', true );
 					$recent['thumbnail_url']   = get_the_post_thumbnail_url( $recent['ID'], 'articles-medium-large' );
+
+					$recent['thumbnail_srcset'] = wp_get_attachment_image_srcset( $img_id, 'articles-medium-large' );
 				}
 
 				// TODO - Update this method to use P4_Post functionality to get Tags/Terms.


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5666

Misnamed the branch, has nothing to do with lazy loading :facepalm: 

Add image sizes to some of our blocks. There's more to do but let's evaluate the impact of these already.

The attributes were generated using this bookmarklet https://github.com/ausi/respimagelint

Also adds missing `srcset` to Articles, that could help a lot too :grin: 