### PR TITLE
PLANET-5849 Campaign page: fix columns block button width

### DIFF
--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -8,7 +8,7 @@
       color: $white;
     }
 
-    &.btn-primary, &.btn-secondary {
+    &.btn-secondary {
       width: 100%;
     }
   }


### PR DESCRIPTION
Ref: [JIRA 5849](https://jira.greenpeace.org/browse/PLANET-5849)

---
- In columns block twig template, the `btn-primary` button class is only use for campaign, so removing it from Columns.scss will not cause any side effects 

eg.
https://www-dev.greenpeace.org/test-venus/campaign/toolkit-plastic-free-future/
https://www-dev.greenpeace.org/test-venus/campaign/test-default-theme/
https://www-dev.greenpeace.org/test-venus/campaign/test-climate-emergency-theme/
https://www-dev.greenpeace.org/test-venus/campaign/test-oil/
