### PR TITLE
PLANET-5842 Remove unused colors

### DIFF
--- a/assets/src/styles/blocks/CarouselHeader.scss
+++ b/assets/src/styles/blocks/CarouselHeader.scss
@@ -167,7 +167,6 @@ $slide-transition-speed: 1s;
   }
 
   .main-header {
-    color: $article-heading-color;
     padding-top: 70px;
     padding-bottom: 0;
     height: 100%;

--- a/assets/src/styles/blocks/CarouselHeader_full_width_classic.scss
+++ b/assets/src/styles/blocks/CarouselHeader_full_width_classic.scss
@@ -375,7 +375,6 @@ $medium-image-height: 600px;
       }
 
       .main-header {
-        color: $article-heading-color;
         padding-top: 0;
         padding-bottom: 0;
         height: 100%;

--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -217,24 +217,6 @@
           opacity: 1;
         }
 
-        &.active {
-          background: $grey;
-          opacity: 0.8;
-          color: $white;
-
-          @include large-and-up {
-            background-color: $allports;
-            opacity: 1;
-          }
-
-          .step-number-inner {
-            @include large-and-up {
-              background-color: $allports;
-              border-color: $spray;
-            }
-          }
-        }
-
         .step-number-inner {
           font-family: $roboto;
 
@@ -312,7 +294,6 @@
           .mobile-accordion-info {
             width: 100%;
             margin: 0;
-            color: $percentage-text;
             font-size: $font-size-xxs;
           }
 

--- a/assets/src/styles/blocks/Covers/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionCovers.scss
@@ -171,8 +171,6 @@
     @include background-before-opacity($black, .25);
 
     &:hover {
-      @include background-before-opacity($green-80, .7);
-
       h2,
       p {
         color: $white;

--- a/assets/src/styles/blocks/Happypoint.scss
+++ b/assets/src/styles/blocks/Happypoint.scss
@@ -116,7 +116,7 @@
     font-family: $roboto;
     font-size: 0.8125rem;
     line-height: 18px;
-    color: $shadow-color;
+    color: $grey-60;
     text-align: left;
 
     @include medium-and-up {

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -565,16 +565,6 @@ DEFERREDCSS;
 					'color' => '#333333',
 				],
 				[
-					'name'  => __( 'Green', 'planet4-blocks-backend' ),
-					'slug'  => 'green',
-					'color' => '#003300',
-				],
-				[
-					'name'  => __( 'Green 80%', 'planet4-blocks-backend' ),
-					'slug'  => 'green-80',
-					'color' => '#1b4a1b',
-				],
-				[
 					'name'  => __( 'GP Green', 'planet4-blocks-backend' ),
 					'slug'  => 'gp-green',
 					'color' => '#66cc00',
@@ -585,24 +575,9 @@ DEFERREDCSS;
 					'color' => '#052a30',
 				],
 				[
-					'name'  => __( 'Genoa', 'planet4-blocks-backend' ),
-					'slug'  => 'genoa',
-					'color' => '#186a70',
-				],
-				[
-					'name'  => __( 'Inch Worm', 'planet4-blocks-backend' ),
-					'slug'  => 'inch-worm',
-					'color' => '#a7e021',
-				],
-				[
 					'name'  => __( 'X Dark Blue', 'planet4-blocks-backend' ),
 					'slug'  => 'x-dark-blue',
 					'color' => '#042233',
-				],
-				[
-					'name'  => __( 'All Ports', 'planet4-blocks-backend' ),
-					'slug'  => 'allports',
-					'color' => '#007799',
 				],
 				[
 					'name'  => __( 'Spray', 'planet4-blocks-backend' ),
@@ -618,16 +593,6 @@ DEFERREDCSS;
 					'name'  => __( 'Blue', 'planet4-blocks-backend' ),
 					'slug'  => 'blue',
 					'color' => '#2077bf',
-				],
-				[
-					'name'  => __( 'Blue 60%', 'planet4-blocks-backend' ),
-					'slug'  => 'blue-60',
-					'color' => '#63bbfd',
-				],
-				[
-					'name'  => __( 'Crimson', 'planet4-blocks-backend' ),
-					'slug'  => 'crimson',
-					'color' => '#e51538',
 				],
 				[
 					'name'  => __( 'Orange Hover', 'planet4-blocks-backend' ),


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-5842

- ~~#63bbfd = $blue-60~~
- ~~($grey-60) = $shadow-color~~
- ~~#f6f4e7 = $single-bg~~
- ~~#aed4c7 = $active~~
- ~~#b0d4c8 = $body-bg~~
- ~~#a7e021 = $inch-worm~~
- ~~#e51538 = $crimson~~
- ~~#5c1f10 = $brown-header~~
- ~~#003300 = $green~~
- ~~#264042 = $darkb-blue-text~~
- ~~#004d53 = $heading~~
- ~~#115247 = $search-text-color~~
- ~~#186a70 = $genoa~~
- ~~#017e7a = $percentage-text~~
- #418482 = $faded-jade => actually used in search page for search bar border, will be replaced in https://jira.greenpeace.org/browse/PLANET-5843
- ~~#22938d = $blue-elm~~
- ~~#67b2af = $light-blue~~
- ~~#1bb6d6 = $java~~
- ~~#007799 = $allports~~
- ~~#152340 = (none)~~
- ~~#152431 = $article-heading-color~~
- ~~#1b4a1b = $green-80~~
- ~~#a7a7a7 = $step-number~~
- ~~$blue-top-nav = $dark-blue~~

### Related PRs:
- [styleguide](https://github.com/greenpeace/planet4-styleguide/pull/95)
- [master-theme](https://github.com/greenpeace/planet4-master-theme/pull/1291)