### PR TITLE
PLANET-5945: Add credits to gallery caption

### DIFF
--- a/assets/src/blocks/Gallery/GalleryFrontend.js
+++ b/assets/src/blocks/Gallery/GalleryFrontend.js
@@ -5,12 +5,19 @@ import { getGalleryLayout, GALLERY_BLOCK_CLASSES } from './getGalleryLayout';
 import { Lightbox } from '../../components/Lightbox/Lightbox';
 import { useLightbox } from '../../components/Lightbox/useLightbox';
 
+const getTitle = (image) => {
+  const caption = image.caption || '';
+  const credits = image.credits && !caption.includes(image.credits)
+    ? (image.credits.includes('©') ? image.credits : `© ${image.credits}`) : '';
+  return `${caption}  ${credits}`.trim();
+}
+
 const imagesToItems = images => images.map(
   image => ({
     src: image.image_src,
     w: 0,
     h: 0,
-    title: image.caption || image.credits || ''
+    title: getTitle(image)
   })
 );
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5945

> Image credits are not visible in the Gallery block.

The current code displays credits only if there's no caption.

## Fix

- Compile image title with credits if it exists

## Test

- Insert a Gallery block in a page
- Add images that have the `Credit` field filled, or fill it
- Credits should appear on the frontend, after the caption 

![Screenshot from 2021-02-09 10-14-11](https://user-images.githubusercontent.com/617346/107341698-98d00700-6abf-11eb-988e-144fbe31d1f3.png)