### PR TITLE
PLANET-5950: Remove yellow separator between gallery 3 cols images

### DIFF
--- a/assets/src/styles/blocks/Gallery_content_three_column.scss
+++ b/assets/src/styles/blocks/Gallery_content_three_column.scss
@@ -74,8 +74,8 @@
 
     .second-column {
       transform: skew(-25deg);
-      border-left: 10px solid $brown-bg;
-      border-right: 10px solid $brown-bg;
+      border-left: 10px solid var(--body-background-color, $white);
+      border-right: 10px solid var(--body-background-color, $white);
       z-index: 2;
       width: 110%;
       right: 0;
@@ -102,8 +102,8 @@
 
   .second-column {
     transform: skew(25deg);
-    border-left: 10px solid $brown-bg;
-    border-right: 10px solid $brown-bg;
+    border-left: 10px solid var(--body-background-color, $white);
+    border-right: 10px solid var(--body-background-color, $white);
     z-index: 2;
     width: 110%;
     left: 0;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5950

> Remove the yellow color between the images (diagonal stripes), from the 3 columns gallery block by either:
>   - ideally, replacing it by a transparent background color
>   - or, replacing it by a white color, so it fits the white background color

Color is applied to middle image borders; making it transparent just makes the images look stuck to each other.

## Fix 

Changing background color to an existing (used by body in styleguide) variable --body-background-color (fallback to white) to look transparent.

## Test

- Add an image Gallery to a page
- Check the middle image border colors, it should be #fff 
