### PR TITLE
PLANET-5865: Submenu block breaks when it has no heading level

### DIFF
--- a/assets/src/blocks/Submenu/getHeadingsFromDom.js
+++ b/assets/src/blocks/Submenu/getHeadingsFromDom.js
@@ -4,6 +4,10 @@ const getHeadingLevel = heading => Number(heading.tagName.replace('H', ''));
 
 export const getHeadingsFromDom = (selectedLevels) => {
   const container = document.querySelector('div.page-template');
+  if (!container || !selectedLevels) {
+    return [];
+  }
+
   // Get all heading tags that we need to query
   const headingsSelector = selectedLevels.map(level => `:not(.submenu-block) h${level.heading}`);
 

--- a/classes/blocks/class-submenu.php
+++ b/classes/blocks/class-submenu.php
@@ -54,8 +54,8 @@ class Submenu extends Base_Block {
 					 * }
 					 */
 					'levels'        => [
-						'type'  => 'array',
-						'items' => [
+						'type'    => 'array',
+						'items'   => [
 							'type'       => 'object',
 							// In JSON Schema you can specify object properties in the properties attribute.
 							'properties' => [
@@ -68,6 +68,13 @@ class Submenu extends Base_Block {
 								'style'   => [
 									'type' => 'string',
 								],
+							],
+						],
+						'default' => [
+							[
+								'heading' => 2,
+								'link'    => false,
+								'style'   => 'none',
 							],
 						],
 					],


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5865

Submenu block crashes when it doesn't get any heading level.

A new submenu saved without adding any level doesn't have a `levels` attribute on the frontend, which leads to `getHeadingsFromDom()` throwing errors.  

## Fix

- add default `levels` value to attributes, matching the editor behavior on this
- value check in `getHeadingsFromDom()` so that this error can't happen

## Test

- Add a `Submenu` block on an empty page, adding no option to the block
  - on `master` branch, viewing/previewing this page on frontend will throw an error
  - on this branch, no error is thrown and the submenu is displayed if it has a title