### PR TITLE
PLANET-5964: make load earlier by removing main dep

### DIFF
--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -406,7 +406,6 @@ final class Loader {
 				'wp-element',
 				// Exports the __() function.
 				'wp-i18n',
-				'main',
 			],
 			true
 		);


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5964

We can merge this already since the dependency is not needed. Needs further changes in master-theme to actually load before jQuery: https://github.com/greenpeace/planet4-master-theme/pull/1300