### PR TITLE
PLANET-5939: Header is too low on campaign templates with no title

### DIFF
--- a/assets/src/styles/campaigns/base/_mixins.scss
+++ b/assets/src/styles/campaigns/base/_mixins.scss
@@ -83,6 +83,11 @@
   position: relative;
   padding-top: 78px;
 
+  &.page-header-hidden {
+    margin: 0;
+    padding: 0;
+  }
+
   .page-header-background {
     overflow: hidden;
 

--- a/assets/src/styles/campaigns/themes/_theme_climate.scss
+++ b/assets/src/styles/campaigns/themes/_theme_climate.scss
@@ -99,6 +99,11 @@ body.theme-climate {
     min-height: 0;
     margin-bottom: 2rem;
 
+    &.page-header-hidden {
+      margin: 0;
+      padding: 0;
+    }
+
     .page-header-title,
     .page-header-subtitle {
       font-family: $jost;

--- a/assets/src/styles/campaigns/themes/_theme_oil.scss
+++ b/assets/src/styles/campaigns/themes/_theme_oil.scss
@@ -79,6 +79,11 @@ body.theme-oil {
     min-height: 0;
     margin-bottom: 2rem;
 
+    &.page-header-hidden {
+      margin: 0;
+      padding: 0;
+    }
+
     .page-header-title,
     .page-header-subtitle {
       font-family: $anton;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5939
Goes with: https://github.com/greenpeace/planet4-master-theme/pull/1301

Since https://github.com/greenpeace/planet4-master-theme/pull/1293 , Campaign templates implementing an override to margin of page-header are pushing content too low.

_Expected layout:_
![Screenshot from 2021-02-16 09-01-06](https://user-images.githubusercontent.com/617346/108034301-9b89a980-7035-11eb-9acc-c69029d366be.png)

_Layout after https://github.com/greenpeace/planet4-master-theme/pull/1293_
![Screenshot from 2021-02-16 09-01-32](https://user-images.githubusercontent.com/617346/108034336-a7756b80-7035-11eb-805b-6dbdc5d66544.png)

This comes from fixed margins applied to `.page-header`, even when this div is `.page-header-hidden`.


## Fix

Reapplying regular margin and padding of `.page-header-hidden` to campaigns.
