### PR TITLE
Switch to pip3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ jobs:
       - run:
           name: "Python script deps"
           command: |
-            pip install requests requests_oauthlib
+            pip3 install requests requests_oauthlib
       - run:
           name: "Book instance"
           command: |


### PR DESCRIPTION
Next-gen circleci image has python3

---

Same as greenpeace/planet4-master-theme#1302