### PR TITLE
PLANET-5960: Timeline block breaks the editing of media blocks

### DIFF
--- a/assets/src/blocks/Timeline/Timeline.js
+++ b/assets/src/blocks/Timeline/Timeline.js
@@ -49,5 +49,17 @@ export const Timeline = (props) => {
 		],
 	);
 
+	// Revert TimelineJS global usage of lodash,
+	// as it conflicts with Wordpress underscore lib
+	// see https://jira.greenpeace.org/browse/PLANET-5960
+	useEffect(
+		() => {
+			if (scriptLoaded) {
+				_.noConflict();
+			}
+		},
+		[scriptLoaded],
+	);
+
 	return <div ref={ timelineNode }></div>
 }

--- a/assets/src/blocks/Timeline/Timeline.js
+++ b/assets/src/blocks/Timeline/Timeline.js
@@ -29,8 +29,16 @@ export const Timeline = (props) => {
 		});
 	}
 
+	// Revert TimelineJS global usage of lodash,
+	// as it conflicts with Wordpress underscore lib
+	// see https://jira.greenpeace.org/browse/PLANET-5960
+	const revertLodash = function () {
+		_.noConflict();
+	}
+
 	const [scriptLoaded, scriptError] = useScript(
-    `https://cdn.knightlab.com/libs/timeline3/${TIMELINE_JS_VERSION}/js/timeline-min.js`
+    `https://cdn.knightlab.com/libs/timeline3/${TIMELINE_JS_VERSION}/js/timeline-min.js`,
+    revertLodash
 	);
 
 	useEffect(
@@ -47,18 +55,6 @@ export const Timeline = (props) => {
 			timenav_position,
 			language,
 		],
-	);
-
-	// Revert TimelineJS global usage of lodash,
-	// as it conflicts with Wordpress underscore lib
-	// see https://jira.greenpeace.org/browse/PLANET-5960
-	useEffect(
-		() => {
-			if (scriptLoaded) {
-				_.noConflict();
-			}
-		},
-		[scriptLoaded],
 	);
 
 	return <div ref={ timelineNode }></div>

--- a/assets/src/components/useScript/useScript.js
+++ b/assets/src/components/useScript/useScript.js
@@ -2,7 +2,7 @@
 import { useEffect, useState } from 'react';
 import { addScriptTag } from './addScriptTag';
 
-export const useScript = (src) => {
+export const useScript = (src, onScriptLoaded) => {
   // Keeping track of script loaded and error state
   const [state, setState] = useState({
     loaded: false,
@@ -27,6 +27,10 @@ export const useScript = (src) => {
           loaded: true,
           error: false
         });
+
+        if (typeof onScriptLoaded === 'function') {
+          onScriptLoaded();
+        }
       };
 
       const onScriptError = () => {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5960

TimelineJS seems to include lodash in the global `_` variable.
It replaces the Underscore `_` used by Wordpress for media interactions in the editor.
Any block that calls a Wordpress media function (here in `wp-includes/js/media-views.js`) might try to use the `_` object, and if the function has a different API in Underscore and Lodash, it will fail, and put the block (or even the editor in some situations) in a broken state (block/editor has encoutered an error).
```
Uncaught TypeError: this.activateMode is not a function
    _createModes media-views.js:2815
```

## Fix 

Running a [`_.noConflict()`](https://docs-lodash.com/v4/no-conflict/) function (also available in [Underscore](https://underscorejs.org/#noConflict)) after including TimelineJS reverts the `_` variable to its previous value.  

Although this works, I don't know if it's the right place, maybe there's a better time to run this function than the useEffect here.

## Test

With a Timeline and Carousel block:
- Add a page with 2 blocks
  - A Timeline (with url https://docs.google.com/spreadsheets/d/1wIVkeDhC5E0b_NsVVPyVEHKS2aozSaWdkdn5zl-dzFg/edit#gid=0 )
  - A carousel
- On `master` branch it will just crash the Carousel block when you add it.
- On this branch, editing the Carousel is possible
  

With only a Timeline block:

- Add a page with a Timeline (with url https://docs.google.com/spreadsheets/d/1wIVkeDhC5E0b_NsVVPyVEHKS2aozSaWdkdn5zl-dzFg/edit#gid=0 )
  - Try to edit the Featured Image
- On `master` branch the editor will crash
- On this branch, the Featured Image section opens properly

You can also try to edit blocks in an imported campaign (see attachments in https://jira.greenpeace.org/browse/PLANET-5960 )