### PR TITLE
[no-instance] PLANET-5523 Add type specific class

### DIFF
--- a/templates/blocks/old_covers.twig
+++ b/templates/blocks/old_covers.twig
@@ -10,7 +10,7 @@
 			{% set covers_view_class = 'show-all-covers' %}
 		{% endif %}
 
-		<section class="block covers-block {{ covers_view_class }}">
+		<section class="block covers-block take-action-covers-block {{ covers_view_class }}">
 			<div class="container">
 
 				{% if ( fields.title ) %}


### PR DESCRIPTION
* Only the "Take Action Covers" type of the block had the "block-covers"
class, and it's being used to only target that type. By adding this
extra class we can make all downstream CSS use that one instead to
target this type, and we can simplify the block code to always include
the type class for all types.

Ref: https://jira.greenpeace.org/browse/PLANET-5523

Prefixed the title with "[no-instance]" so that CI doesn't steal Maud's branch's test instance.