### PR TITLE
PLANET-5875 Update Table  block edit file for WP5.6

### DIFF
--- a/assets/src/components/p4_table/edit.js
+++ b/assets/src/components/p4_table/edit.js
@@ -35,19 +35,6 @@ import {
 	ToolbarGroup,
 	ToolbarItem,
 } from '@wordpress/components';
-import {
-	alignLeft,
-	alignRight,
-	alignCenter,
-	blockTable as icon,
-	tableColumnAfter,
-	tableColumnBefore,
-	tableColumnDelete,
-	tableRowAfter,
-	tableRowBefore,
-	tableRowDelete,
-	table,
-} from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
 
 /**
@@ -67,40 +54,35 @@ import {
 
 const BACKGROUND_COLORS = [
 	{
-		color: '#f3f4f5',
-		name: 'Subtle light gray',
-		slug: 'subtle-light-gray',
+		color: '#f5f7f8',
+    name: __('Grey'),
+    slug: 'grey'
 	},
 	{
-		color: '#e9fbe5',
-		name: 'Subtle pale green',
-		slug: 'subtle-pale-green',
+		color: '#eafee7',
+    name: __('Green'),
+    slug: 'green'
 	},
 	{
 		color: '#e7f5fe',
-		name: 'Subtle pale blue',
-		slug: 'subtle-pale-blue',
-	},
-	{
-		color: '#fcf0ef',
-		name: 'Subtle pale pink',
-		slug: 'subtle-pale-pink',
-	},
+    name: __('Blue'),
+    slug: 'blue'
+	}
 ];
 
 const ALIGNMENT_CONTROLS = [
 	{
-		icon: alignLeft,
+		icon: "editor-alignleft",
 		title: __( 'Align column left' ),
 		align: 'left',
 	},
 	{
-		icon: alignCenter,
+		icon: "editor-aligncenter",
 		title: __( 'Align column center' ),
 		align: 'center',
 	},
 	{
-		icon: alignRight,
+		icon: "editor-alignright",
 		title: __( 'Align column right' ),
 		align: 'right',
 	},
@@ -379,37 +361,37 @@ function TableEdit( {
 
 	const tableControls = [
 		{
-			icon: tableRowBefore,
+			icon: "table-row-before",
 			title: __( 'Insert row before' ),
 			isDisabled: ! selectedCell,
 			onClick: onInsertRowBefore,
 		},
 		{
-			icon: tableRowAfter,
+			icon: "table-row-after",
 			title: __( 'Insert row after' ),
 			isDisabled: ! selectedCell,
 			onClick: onInsertRowAfter,
 		},
 		{
-			icon: tableRowDelete,
+			icon: "table-row-delete",
 			title: __( 'Delete row' ),
 			isDisabled: ! selectedCell,
 			onClick: onDeleteRow,
 		},
 		{
-			icon: tableColumnBefore,
+			icon: "table-col-before",
 			title: __( 'Insert column before' ),
 			isDisabled: ! selectedCell,
 			onClick: onInsertColumnBefore,
 		},
 		{
-			icon: tableColumnAfter,
+			icon: "table-col-after",
 			title: __( 'Insert column after' ),
 			isDisabled: ! selectedCell,
 			onClick: onInsertColumnAfter,
 		},
 		{
-			icon: tableColumnDelete,
+			icon: "table-col-delete",
 			title: __( 'Delete column' ),
 			isDisabled: ! selectedCell,
 			onClick: onDeleteColumn,
@@ -466,7 +448,7 @@ function TableEdit( {
 							{ ( toggleProps ) => (
 								<DropdownMenu
 									hasArrowIndicator
-									icon={ table }
+									icon="editor-table"
 									toggleProps={ toggleProps }
 									label={ __( 'Edit table' ) }
 									controls={ tableControls }
@@ -550,7 +532,7 @@ function TableEdit( {
 			{ isEmpty && (
 				<Placeholder
 					label={ __( 'Table' ) }
-					icon={ <BlockIcon icon={ icon } showColors /> }
+					icon={ <BlockIcon icon="editor-table" showColors /> }
 					instructions={ __( 'Insert a table for sharing data.' ) }
 				>
 					<form

--- a/assets/src/components/p4_table/edit.js
+++ b/assets/src/components/p4_table/edit.js
@@ -1,7 +1,8 @@
 /**
- * This file is copy of the table block edit.js (https://github.com/WordPress/gutenberg/blob/7dd6c58c3c6e17c85423fff7a666eab29d749689/packages/block-library/src/table/edit.js), with customize changes.
+ * This file is a copy of the table block edit.js (https://github.com/WordPress/gutenberg/blob/f3c538578aa818e76dbe09445d0fb1678166086d/packages/block-library/src/table/edit.js), with customize changes.
  * Customize changes(PLANET-5058) :
  *  - Added custom background colors for header, odd/even rows and footer.
+ *  - Added translation domain (planet4-blocks-backend) for strings.
  */
 
 /**
@@ -12,7 +13,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import {
 	InspectorControls,
 	BlockControls,
@@ -21,6 +22,7 @@ import {
 	createCustomColorsHOC,
 	BlockIcon,
 	AlignmentToolbar,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import {
@@ -31,7 +33,22 @@ import {
 	TextControl,
 	ToggleControl,
 	ToolbarGroup,
+	ToolbarItem,
 } from '@wordpress/components';
+import {
+	alignLeft,
+	alignRight,
+	alignCenter,
+	blockTable as icon,
+	tableColumnAfter,
+	tableColumnBefore,
+	tableColumnDelete,
+	tableRowAfter,
+	tableRowBefore,
+	tableRowDelete,
+	table,
+} from '@wordpress/icons';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -50,95 +67,92 @@ import {
 
 const BACKGROUND_COLORS = [
 	{
-		color: '#f5f7f8',
-    name: 'Grey',
-    slug: 'grey'
+		color: '#f3f4f5',
+		name: 'Subtle light gray',
+		slug: 'subtle-light-gray',
 	},
 	{
-		color: '#eafee7',
-    name: 'Green',
-    slug: 'green'
+		color: '#e9fbe5',
+		name: 'Subtle pale green',
+		slug: 'subtle-pale-green',
 	},
 	{
 		color: '#e7f5fe',
-    name: 'Blue',
-    slug: 'blue'
-	}
+		name: 'Subtle pale blue',
+		slug: 'subtle-pale-blue',
+	},
+	{
+		color: '#fcf0ef',
+		name: 'Subtle pale pink',
+		slug: 'subtle-pale-pink',
+	},
 ];
 
 const ALIGNMENT_CONTROLS = [
 	{
-		icon: "editor-alignleft",
-		title: __( 'Align Column Left' ),
+		icon: alignLeft,
+		title: __( 'Align column left' ),
 		align: 'left',
 	},
 	{
-		icon: "editor-aligncenter",
-		title: __( 'Align Column Center' ),
+		icon: alignCenter,
+		title: __( 'Align column center' ),
 		align: 'center',
 	},
 	{
-		icon: "editor-alignright",
-		title: __( 'Align Column Right' ),
+		icon: alignRight,
+		title: __( 'Align column right' ),
 		align: 'right',
 	},
 ];
 
 const withCustomBackgroundColors = createCustomColorsHOC( BACKGROUND_COLORS );
 
-export class TableEdit extends Component {
-	constructor() {
-		super( ...arguments );
+const cellAriaLabel = {
+	head: __( 'Header cell text' ),
+	body: __( 'Body cell text' ),
+	foot: __( 'Footer cell text' ),
+};
 
-		this.onCreateTable = this.onCreateTable.bind( this );
-		this.onChangeFixedLayout = this.onChangeFixedLayout.bind( this );
-		this.onChange = this.onChange.bind( this );
-		this.onChangeInitialColumnCount = this.onChangeInitialColumnCount.bind(
-			this
-		);
-		this.onChangeInitialRowCount = this.onChangeInitialRowCount.bind(
-			this
-		);
-		this.renderSection = this.renderSection.bind( this );
-		this.getTableControls = this.getTableControls.bind( this );
-		this.onInsertRow = this.onInsertRow.bind( this );
-		this.onInsertRowBefore = this.onInsertRowBefore.bind( this );
-		this.onInsertRowAfter = this.onInsertRowAfter.bind( this );
-		this.onDeleteRow = this.onDeleteRow.bind( this );
-		this.onInsertColumn = this.onInsertColumn.bind( this );
-		this.onInsertColumnBefore = this.onInsertColumnBefore.bind( this );
-		this.onInsertColumnAfter = this.onInsertColumnAfter.bind( this );
-		this.onDeleteColumn = this.onDeleteColumn.bind( this );
-		this.onToggleHeaderSection = this.onToggleHeaderSection.bind( this );
-		this.onToggleFooterSection = this.onToggleFooterSection.bind( this );
-		this.onChangeColumnAlignment = this.onChangeColumnAlignment.bind(
-			this
-		);
-		this.getCellAlignment = this.getCellAlignment.bind( this );
+const placeholder = {
+	head: __( 'Header label' ),
+	foot: __( 'Footer label' ),
+};
 
-		this.state = {
-			initialRowCount: 2,
-			initialColumnCount: 2,
-			selectedCell: null,
-		};
-	}
+function TSection( { name, ...props } ) {
+	const TagName = `t${ name }`;
+	return <TagName { ...props } />;
+}
+
+function TableEdit( {
+	attributes,
+	backgroundColor,
+	setBackgroundColor,
+	setAttributes,
+	insertBlocksAfter,
+	isSelected,
+} ) {
+	const { hasFixedLayout, caption, head, foot } = attributes;
+	const [ initialRowCount, setInitialRowCount ] = useState( 2 );
+	const [ initialColumnCount, setInitialColumnCount ] = useState( 2 );
+	const [ selectedCell, setSelectedCell ] = useState();
 
 	/**
 	 * Updates the initial column count used for table creation.
 	 *
-	 * @param {number} initialColumnCount New initial column count.
+	 * @param {number} count New initial column count.
 	 */
-	onChangeInitialColumnCount( initialColumnCount ) {
-		this.setState( { initialColumnCount } );
+	function onChangeInitialColumnCount( count ) {
+		setInitialColumnCount( count );
 	}
 
 	/**
 	 * Updates the initial row count used for table creation.
 	 *
-	 * @param {number} initialRowCount New initial row count.
+	 * @param {number} count New initial row count.
 	 */
-	onChangeInitialRowCount( initialRowCount ) {
-		this.setState( { initialRowCount } );
+	function onChangeInitialRowCount( count ) {
+		setInitialRowCount( count );
 	}
 
 	/**
@@ -146,19 +160,13 @@ export class TableEdit extends Component {
 	 *
 	 * @param {Object} event Form submit event.
 	 */
-	onCreateTable( event ) {
+	function onCreateTable( event ) {
 		event.preventDefault();
-
-		const { setAttributes } = this.props;
-		let { initialRowCount, initialColumnCount } = this.state;
-
-		initialRowCount = parseInt( initialRowCount, 10 ) || 2;
-		initialColumnCount = parseInt( initialColumnCount, 10 ) || 2;
 
 		setAttributes(
 			createTable( {
-				rowCount: initialRowCount,
-				columnCount: initialColumnCount,
+				rowCount: parseInt( initialRowCount, 10 ) || 2,
+				columnCount: parseInt( initialColumnCount, 10 ) || 2,
 			} )
 		);
 	}
@@ -166,10 +174,7 @@ export class TableEdit extends Component {
 	/**
 	 * Toggles whether the table has a fixed layout or not.
 	 */
-	onChangeFixedLayout() {
-		const { attributes, setAttributes } = this.props;
-		const { hasFixedLayout } = attributes;
-
+	function onChangeFixedLayout() {
 		setAttributes( { hasFixedLayout: ! hasFixedLayout } );
 	}
 
@@ -178,14 +183,10 @@ export class TableEdit extends Component {
 	 *
 	 * @param {Array} content A RichText content value.
 	 */
-	onChange( content ) {
-		const { selectedCell } = this.state;
-
+	function onChange( content ) {
 		if ( ! selectedCell ) {
 			return;
 		}
-
-		const { attributes, setAttributes } = this.props;
 
 		setAttributes(
 			updateSelectedCell(
@@ -204,9 +205,7 @@ export class TableEdit extends Component {
 	 *
 	 * @param {string} align The new alignment to apply to the column.
 	 */
-	onChangeColumnAlignment( align ) {
-		const { selectedCell } = this.state;
-
+	function onChangeColumnAlignment( align ) {
 		if ( ! selectedCell ) {
 			return;
 		}
@@ -218,7 +217,6 @@ export class TableEdit extends Component {
 			columnIndex: selectedCell.columnIndex,
 		};
 
-		const { attributes, setAttributes } = this.props;
 		const newAttributes = updateSelectedCell(
 			attributes,
 			columnSelection,
@@ -235,14 +233,10 @@ export class TableEdit extends Component {
 	 *
 	 * @return {string} The new alignment to apply to the column.
 	 */
-	getCellAlignment() {
-		const { selectedCell } = this.state;
-
+	function getCellAlignment() {
 		if ( ! selectedCell ) {
 			return;
 		}
-
-		const { attributes } = this.props;
 
 		return getCellAttribute( attributes, selectedCell, 'align' );
 	}
@@ -250,16 +244,14 @@ export class TableEdit extends Component {
 	/**
 	 * Add or remove a `head` table section.
 	 */
-	onToggleHeaderSection() {
-		const { attributes, setAttributes } = this.props;
+	function onToggleHeaderSection() {
 		setAttributes( toggleSection( attributes, 'head' ) );
 	}
 
 	/**
 	 * Add or remove a `foot` table section.
 	 */
-	onToggleFooterSection() {
-		const { attributes, setAttributes } = this.props;
+	function onToggleFooterSection() {
 		setAttributes( toggleSection( attributes, 'foot' ) );
 	}
 
@@ -268,53 +260,54 @@ export class TableEdit extends Component {
 	 *
 	 * @param {number} delta Offset for selected row index at which to insert.
 	 */
-	onInsertRow( delta ) {
-		const { selectedCell } = this.state;
-
+	function onInsertRow( delta ) {
 		if ( ! selectedCell ) {
 			return;
 		}
 
-		const { attributes, setAttributes } = this.props;
 		const { sectionName, rowIndex } = selectedCell;
+		const newRowIndex = rowIndex + delta;
 
-		this.setState( { selectedCell: null } );
 		setAttributes(
 			insertRow( attributes, {
 				sectionName,
-				rowIndex: rowIndex + delta,
+				rowIndex: newRowIndex,
 			} )
 		);
+		// Select the first cell of the new row
+		setSelectedCell( {
+			sectionName,
+			rowIndex: newRowIndex,
+			columnIndex: 0,
+			type: 'cell',
+		} );
 	}
 
 	/**
 	 * Inserts a row before the currently selected row.
 	 */
-	onInsertRowBefore() {
-		this.onInsertRow( 0 );
+	function onInsertRowBefore() {
+		onInsertRow( 0 );
 	}
 
 	/**
 	 * Inserts a row after the currently selected row.
 	 */
-	onInsertRowAfter() {
-		this.onInsertRow( 1 );
+	function onInsertRowAfter() {
+		onInsertRow( 1 );
 	}
 
 	/**
 	 * Deletes the currently selected row.
 	 */
-	onDeleteRow() {
-		const { selectedCell } = this.state;
-
+	function onDeleteRow() {
 		if ( ! selectedCell ) {
 			return;
 		}
 
-		const { attributes, setAttributes } = this.props;
 		const { sectionName, rowIndex } = selectedCell;
 
-		this.setState( { selectedCell: null } );
+		setSelectedCell();
 		setAttributes( deleteRow( attributes, { sectionName, rowIndex } ) );
 	}
 
@@ -323,282 +316,175 @@ export class TableEdit extends Component {
 	 *
 	 * @param {number} delta Offset for selected column index at which to insert.
 	 */
-	onInsertColumn( delta = 0 ) {
-		const { selectedCell } = this.state;
-
+	function onInsertColumn( delta = 0 ) {
 		if ( ! selectedCell ) {
 			return;
 		}
 
-		const { attributes, setAttributes } = this.props;
 		const { columnIndex } = selectedCell;
+		const newColumnIndex = columnIndex + delta;
 
-		this.setState( { selectedCell: null } );
 		setAttributes(
 			insertColumn( attributes, {
-				columnIndex: columnIndex + delta,
+				columnIndex: newColumnIndex,
 			} )
 		);
+		// Select the first cell of the new column
+		setSelectedCell( {
+			rowIndex: 0,
+			columnIndex: newColumnIndex,
+			type: 'cell',
+		} );
 	}
 
 	/**
 	 * Inserts a column before the currently selected column.
 	 */
-	onInsertColumnBefore() {
-		this.onInsertColumn( 0 );
+	function onInsertColumnBefore() {
+		onInsertColumn( 0 );
 	}
 
 	/**
 	 * Inserts a column after the currently selected column.
 	 */
-	onInsertColumnAfter() {
-		this.onInsertColumn( 1 );
+	function onInsertColumnAfter() {
+		onInsertColumn( 1 );
 	}
 
 	/**
 	 * Deletes the currently selected column.
 	 */
-	onDeleteColumn() {
-		const { selectedCell } = this.state;
-
+	function onDeleteColumn() {
 		if ( ! selectedCell ) {
 			return;
 		}
 
-		const { attributes, setAttributes } = this.props;
 		const { sectionName, columnIndex } = selectedCell;
 
-		this.setState( { selectedCell: null } );
+		setSelectedCell();
 		setAttributes(
 			deleteColumn( attributes, { sectionName, columnIndex } )
 		);
 	}
 
-	/**
-	 * Creates an onFocus handler for a specified cell.
-	 *
-	 * @param {Object} cellLocation Object with `section`, `rowIndex`, and
-	 *                              `columnIndex` properties.
-	 *
-	 * @return {Function} Function to call on focus.
-	 */
-	createOnFocus( cellLocation ) {
-		return () => {
-			this.setState( {
-				selectedCell: {
-					...cellLocation,
-					type: 'cell',
-				},
-			} );
-		};
-	}
-
-	/**
-	 * Gets the table controls to display in the block toolbar.
-	 *
-	 * @return {Array} Table controls.
-	 */
-	getTableControls() {
-		const { selectedCell } = this.state;
-
-		return [
-			{
-				icon: "table-row-before",
-				title: __( 'Add Row Before' ),
-				isDisabled: ! selectedCell,
-				onClick: this.onInsertRowBefore,
-			},
-			{
-				icon: "table-row-after",
-				title: __( 'Add Row After' ),
-				isDisabled: ! selectedCell,
-				onClick: this.onInsertRowAfter,
-			},
-			{
-				icon: "table-row-delete",
-				title: __( 'Delete Row' ),
-				isDisabled: ! selectedCell,
-				onClick: this.onDeleteRow,
-			},
-			{
-				icon: "table-col-before",
-				title: __( 'Add Column Before' ),
-				isDisabled: ! selectedCell,
-				onClick: this.onInsertColumnBefore,
-			},
-			{
-				icon: "table-col-after",
-				title: __( 'Add Column After' ),
-				isDisabled: ! selectedCell,
-				onClick: this.onInsertColumnAfter,
-			},
-			{
-				icon: "table-col-delete",
-				title: __( 'Delete Column' ),
-				isDisabled: ! selectedCell,
-				onClick: this.onDeleteColumn,
-			},
-		];
-	}
-
-	/**
-	 * Renders a table section.
-	 *
-	 * @param {Object} options
-	 * @param {string} options.type Section type: head, body, or foot.
-	 * @param {Array}  options.rows The rows to render.
-	 *
-	 * @return {Object} React element for the section.
-	 */
-	renderSection( { name, rows } ) {
-		if ( isEmptyTableSection( rows ) ) {
-			return null;
+	useEffect( () => {
+		if ( ! isSelected ) {
+			setSelectedCell();
 		}
+	}, [ isSelected ] );
 
-		const Tag = `t${ name }`;
+	const sections = [ 'head', 'body', 'foot' ].filter(
+		( name ) => ! isEmptyTableSection( attributes[ name ] )
+	);
 
-		return (
-			<Tag>
-				{ rows.map( ( { cells }, rowIndex ) => (
-					<tr key={ rowIndex }>
-						{ cells.map(
-							(
-								{ content, tag: CellTag, scope, align },
-								columnIndex
-							) => {
-								const cellLocation = {
-									sectionName: name,
-									rowIndex,
-									columnIndex,
-								};
+	const tableControls = [
+		{
+			icon: tableRowBefore,
+			title: __( 'Insert row before' ),
+			isDisabled: ! selectedCell,
+			onClick: onInsertRowBefore,
+		},
+		{
+			icon: tableRowAfter,
+			title: __( 'Insert row after' ),
+			isDisabled: ! selectedCell,
+			onClick: onInsertRowAfter,
+		},
+		{
+			icon: tableRowDelete,
+			title: __( 'Delete row' ),
+			isDisabled: ! selectedCell,
+			onClick: onDeleteRow,
+		},
+		{
+			icon: tableColumnBefore,
+			title: __( 'Insert column before' ),
+			isDisabled: ! selectedCell,
+			onClick: onInsertColumnBefore,
+		},
+		{
+			icon: tableColumnAfter,
+			title: __( 'Insert column after' ),
+			isDisabled: ! selectedCell,
+			onClick: onInsertColumnAfter,
+		},
+		{
+			icon: tableColumnDelete,
+			title: __( 'Delete column' ),
+			isDisabled: ! selectedCell,
+			onClick: onDeleteColumn,
+		},
+	];
 
-								const cellClasses = classnames(
+	const renderedSections = [ 'head', 'body', 'foot' ].map( ( name ) => (
+		<TSection name={ name } key={ name }>
+			{ attributes[ name ].map( ( { cells }, rowIndex ) => (
+				<tr key={ rowIndex }>
+					{ cells.map(
+						(
+							{ content, tag: CellTag, scope, align },
+							columnIndex
+						) => (
+							<RichText
+								tagName={ CellTag }
+								key={ columnIndex }
+								className={ classnames(
 									{
 										[ `has-text-align-${ align }` ]: align,
 									},
 									'wp-block-table__cell-content'
-								);
+								) }
+								scope={ CellTag === 'th' ? scope : undefined }
+								value={ content }
+								onChange={ onChange }
+								unstableOnFocus={ () => {
+									setSelectedCell( {
+										sectionName: name,
+										rowIndex,
+										columnIndex,
+										type: 'cell',
+									} );
+								} }
+								aria-label={ cellAriaLabel[ name ] }
+								placeholder={ placeholder[ name ] }
+							/>
+						)
+					) }
+				</tr>
+			) ) }
+		</TSection>
+	) );
 
-								let placeholder = '';
-								if ( name === 'head' ) {
-									placeholder = __( 'Header label' );
-								} else if ( name === 'foot' ) {
-									placeholder = __( 'Footer label' );
-								}
+	const isEmpty = ! sections.length;
 
-								return (
-									<RichText
-										tagName={ CellTag }
-										key={ columnIndex }
-										className={ cellClasses }
-										scope={
-											CellTag === 'th' ? scope : undefined
-										}
-										value={ content }
-										onChange={ this.onChange }
-										unstableOnFocus={ this.createOnFocus(
-											cellLocation
-										) }
-										placeholder={ placeholder }
-									/>
-								);
-							}
-						) }
-					</tr>
-				) ) }
-			</Tag>
-		);
-	}
-
-	componentDidUpdate() {
-		const { isSelected } = this.props;
-		const { selectedCell } = this.state;
-
-		if ( ! isSelected && selectedCell ) {
-			this.setState( { selectedCell: null } );
-		}
-	}
-
-	render() {
-		const {
-			attributes,
-			backgroundColor,
-			setBackgroundColor,
-      setAttributes,
-        } = this.props;
-
-		const { initialRowCount, initialColumnCount } = this.state;
-		const { hasFixedLayout, caption, head, body, foot } = attributes;
-		const isEmpty =
-			isEmptyTableSection( head ) &&
-			isEmptyTableSection( body ) &&
-			isEmptyTableSection( foot );
-		const Section = this.renderSection;
-
-		if ( isEmpty ) {
-			return (
-				<Placeholder
-					label={ __( 'Table' ) }
-					icon={ <BlockIcon icon="block-table" showColors /> }
-					instructions={ __( 'Insert a table for sharing data.' ) }
-				>
-					<form
-						className="wp-block-table__placeholder-form"
-						onSubmit={ this.onCreateTable }
-					>
-						<TextControl
-							type="number"
-							label={ __( 'Column Count' ) }
-							value={ initialColumnCount }
-							onChange={ this.onChangeInitialColumnCount }
-							min="1"
-							className="wp-block-table__placeholder-input"
-						/>
-						<TextControl
-							type="number"
-							label={ __( 'Row Count' ) }
-							value={ initialRowCount }
-							onChange={ this.onChangeInitialRowCount }
-							min="1"
-							className="wp-block-table__placeholder-input"
-						/>
-						<Button
-							className="wp-block-table__placeholder-button"
-							isSecondary
-							type="submit"
-						>
-							{ __( 'Create Table' ) }
-						</Button>
-					</form>
-				</Placeholder>
-			);
-		}
-
-		const tableClasses = classnames( backgroundColor.class, {
-      'has-fixed-layout': hasFixedLayout
-    } );
-
-		return (
-			<>
+	return (
+		<figure { ...useBlockProps() }>
+			{ ! isEmpty && (
 				<BlockControls>
 					<ToolbarGroup>
-						<DropdownMenu
-							hasArrowIndicator
-							icon="editor-table"
-							label={ __( 'Edit table' ) }
-							controls={ this.getTableControls() }
-						/>
+						<ToolbarItem>
+							{ ( toggleProps ) => (
+								<DropdownMenu
+									hasArrowIndicator
+									icon={ table }
+									toggleProps={ toggleProps }
+									label={ __( 'Edit table' ) }
+									controls={ tableControls }
+								/>
+							) }
+						</ToolbarItem>
 					</ToolbarGroup>
 					<AlignmentToolbar
 						label={ __( 'Change column alignment' ) }
 						alignmentControls={ ALIGNMENT_CONTROLS }
-						value={ this.getCellAlignment() }
+						value={ getCellAlignment() }
 						onChange={ ( nextAlign ) =>
-							this.onChangeColumnAlignment( nextAlign )
+							onChangeColumnAlignment( nextAlign )
 						}
-						onHover={ this.onHoverAlignment }
 					/>
 				</BlockControls>
+			) }
+			{ ! isEmpty && (
 				<InspectorControls>
 					<PanelBody
 						title={ __( 'Table settings' ) }
@@ -607,17 +493,17 @@ export class TableEdit extends Component {
 						<ToggleControl
 							label={ __( 'Fixed width table cells' ) }
 							checked={ !! hasFixedLayout }
-							onChange={ this.onChangeFixedLayout }
+							onChange={ onChangeFixedLayout }
 						/>
 						<ToggleControl
 							label={ __( 'Header section' ) }
 							checked={ !! ( head && head.length ) }
-							onChange={ this.onToggleHeaderSection }
+							onChange={ onToggleHeaderSection }
 						/>
 						<ToggleControl
 							label={ __( 'Footer section' ) }
 							checked={ !! ( foot && foot.length ) }
-							onChange={ this.onToggleFooterSection }
+							onChange={ onToggleFooterSection }
 						/>
 					</PanelBody>
 					<PanelColorSettings
@@ -634,28 +520,71 @@ export class TableEdit extends Component {
 						] }
 					/>
 				</InspectorControls>
-				<figure className={`wp-block-table ${attributes.className}`}>
-					<table className={ tableClasses }>
-						<Section name="head" rows={ head } />
-						<Section name="body" rows={ body } />
-						<Section name="foot" rows={ foot } />
-					</table>
-					<RichText
-						tagName="figcaption"
-						placeholder={ __( 'Write caption…' ) }
-						value={ caption }
-						onChange={ ( value ) =>
-							setAttributes( { caption: value } )
-						}
-						// Deselect the selected table cell when the caption is focused.
-						unstableOnFocus={ () =>
-							this.setState( { selectedCell: null } )
-						}
-					/>
-				</figure>
-			</>
-		);
-	}
+			) }
+			{ ! isEmpty && (
+				<table
+					className={ classnames( backgroundColor.class, {
+						'has-fixed-layout': hasFixedLayout,
+						'has-background': !! backgroundColor.color,
+					} ) }
+				>
+					{ renderedSections }
+				</table>
+			) }
+			{ ! isEmpty && (
+				<RichText
+					tagName="figcaption"
+					aria-label={ __( 'Table caption text' ) }
+					placeholder={ __( 'Write caption…' ) }
+					value={ caption }
+					onChange={ ( value ) =>
+						setAttributes( { caption: value } )
+					}
+					// Deselect the selected table cell when the caption is focused.
+					unstableOnFocus={ () => setSelectedCell() }
+					__unstableOnSplitAtEnd={ () =>
+						insertBlocksAfter( createBlock( 'core/paragraph' ) )
+					}
+				/>
+			) }
+			{ isEmpty && (
+				<Placeholder
+					label={ __( 'Table' ) }
+					icon={ <BlockIcon icon={ icon } showColors /> }
+					instructions={ __( 'Insert a table for sharing data.' ) }
+				>
+					<form
+						className="blocks-table__placeholder-form"
+						onSubmit={ onCreateTable }
+					>
+						<TextControl
+							type="number"
+							label={ __( 'Column count' ) }
+							value={ initialColumnCount }
+							onChange={ onChangeInitialColumnCount }
+							min="1"
+							className="blocks-table__placeholder-input"
+						/>
+						<TextControl
+							type="number"
+							label={ __( 'Row count' ) }
+							value={ initialRowCount }
+							onChange={ onChangeInitialRowCount }
+							min="1"
+							className="blocks-table__placeholder-input"
+						/>
+						<Button
+							className="blocks-table__placeholder-button"
+							isPrimary
+							type="submit"
+						>
+							{ __( 'Create Table' ) }
+						</Button>
+					</form>
+				</Placeholder>
+			) }
+		</figure>
+	);
 }
 
 export default withCustomBackgroundColors( 'backgroundColor' )( TableEdit );


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-5875

I've updated the `edit` file with the new version for WP5.6 and modified it to fit our needs. This PR should also solve the Table block part of [PLANET-5871](https://jira.greenpeace.org/browse/PLANET-5871) (it adds back the top controls for moving/deleting/etc the block).

You can test it on the [test-titan instance](https://www-dev.greenpeace.org/test-titan/).

There is another way to solve these issues, explored in https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/515.