### PR TITLE
PLANET-5871 Update button block files with custom colors, remove BorderPanel & WidthPanel

### DIFF
--- a/admin/js/editor.js
+++ b/admin/js/editor.js
@@ -1,23 +1,6 @@
 /* global wp */
 
 wp.domReady(() => {
-  // Button block styles
-  wp.blocks.registerBlockStyle( 'core/button', {
-    name: 'secondary',
-    label: 'Secondary',
-    isDefault: true
-  });
-  wp.blocks.registerBlockStyle( 'core/button', {
-    name: 'cta',
-    label: 'CTA'
-  });
-  wp.blocks.registerBlockStyle( 'core/button', {
-    name: 'donate',
-    label: 'Donate'
-  });
-  wp.blocks.unregisterBlockStyle('core/button', 'outline');
-  wp.blocks.unregisterBlockStyle('core/button', 'fill');
-
   // Image block styles
   wp.blocks.unregisterBlockStyle('core/image', 'rounded');
   wp.blocks.unregisterBlockStyle('core/image', 'default');

--- a/assets/src/BlockFilters.js
+++ b/assets/src/BlockFilters.js
@@ -35,8 +35,31 @@ const addButtonBlockFilter = () => {
     }
 
     if ( settings.name === 'core/button' ) {
+      // Override the Native button block styles and use p4 button styles.
+      const p4ButtonStyle = [
+        {
+          name: 'secondary',
+          label: 'Secondary',
+          isDefault: true
+        },
+        {
+          name: 'cta',
+          label: 'CTA'
+        },
+        {
+          name: 'donate',
+          label: 'Donate'
+        }
+      ];
+
+      const newAttributes = settings.attributes;
+      // Set button block default style.
+      newAttributes.className = Object.assign({ default: "is-style-secondary" }, newAttributes.className);
+
       lodash.assign( settings, {
         edit: P4ButtonEdit,
+        attributes: newAttributes,
+        styles: p4ButtonStyle,
       } );
     }
 

--- a/assets/src/components/p4_button/color-edit.js
+++ b/assets/src/components/p4_button/color-edit.js
@@ -3,6 +3,7 @@
  * Customize changes(PLANET-4924) :
  *  - Added `p4_button_text_colors` and `p4_button_bg_colors` custom P4 button colors.
  *  - Remove the BorderPanel control(button borderRadius).
+ *  - Remove the WidthPanel control(button width).
  */
 
 /**
@@ -39,6 +40,17 @@ import {
 const EMPTY_ARRAY = [];
 
 const isWebPlatform = Platform.OS === 'web';
+
+const P4_BUTTON_TEXT_COLORS = [
+  { name: 'Grey 80%', slug: 'grey-80', color: '#020202' },
+  { name: 'White', slug: 'white', color: '#ffffff' },
+];
+
+const P4_BUTTON_BG_COLORS = [
+  { name: 'Orange', slug: 'orange', color: '#f36d3a' },
+  { name: 'Aquamarine', slug: 'aquamarine', color: '#68dfde' },
+  { name: 'White', slug: 'white', color: '#ffffff' },
+];
 
 function getComputedStyle( node ) {
 	return node.ownerDocument.defaultView.getComputedStyle( node );
@@ -135,6 +147,7 @@ function ColorPanel( { settings, clientId, enableContrastChecking = true } ) {
 function ColorEdit( props ) {
 	const { attributes } = props;
 	const colors = useEditorFeature( 'color.palette' ) || EMPTY_ARRAY;
+
 	const gradients = useEditorFeature( 'color.gradients' ) || EMPTY_ARRAY;
 
 	// Shouldn't be needed but right now the ColorGradientsPanel
@@ -219,21 +232,23 @@ function ColorEdit( props ) {
 				label: __( 'Text Color' ),
 				onColorChange: onChangeColor( 'text' ),
 				colorValue: getColorObjectByAttributeValues(
-					colors,
+					P4_BUTTON_TEXT_COLORS,
 					textColor,
 					style?.color?.text
 				).color,
+				colors: P4_BUTTON_TEXT_COLORS,
 			},
 			{
 				label: __( 'Background Color' ),
 				onColorChange: onChangeColor( 'background' ),
 				colorValue: getColorObjectByAttributeValues(
-					colors,
+					P4_BUTTON_BG_COLORS,
 					backgroundColor,
 					style?.color?.background
 				).color,
 				gradientValue,
 				onGradientChange: onChangeGradient,
+				colors: P4_BUTTON_BG_COLORS,
 			},
 		];
 	}, [

--- a/assets/src/components/p4_button/color-edit.js
+++ b/assets/src/components/p4_button/color-edit.js
@@ -1,0 +1,257 @@
+/**
+ * This file is copy of core button block color-edit.js (https://github.com/WordPress/gutenberg/blob/db6d666f3165e78a4dcf350c7ff7f6638e8439e0/packages/block-library/src/button/color-edit.js), with customize changes.
+ * Customize changes(PLANET-4924) :
+ *  - Added `p4_button_text_colors` and `p4_button_bg_colors` custom P4 button colors.
+ *  - Remove the BorderPanel control(button borderRadius).
+ */
+
+/**
+ * External dependencies
+ */
+import { pickBy, isEqual, isObject, identity, mapValues } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	useState,
+	useEffect,
+	useRef,
+	useMemo,
+	Platform,
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getColorObjectByColorValue,
+	getColorObjectByAttributeValues,
+	getGradientValueBySlug,
+	getGradientSlugByValue,
+	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
+	ContrastChecker,
+	InspectorControls,
+	__experimentalUseEditorFeature as useEditorFeature,
+} from '@wordpress/block-editor';
+
+const EMPTY_ARRAY = [];
+
+const isWebPlatform = Platform.OS === 'web';
+
+function getComputedStyle( node ) {
+	return node.ownerDocument.defaultView.getComputedStyle( node );
+}
+
+// The code in this file is copied entirely from the "color" and "style" support flags
+// The flag can't be used at the moment because of the extra wrapper around
+// the button block markup.
+
+function getBlockDOMNode( clientId ) {
+	return document.getElementById( 'block-' + clientId );
+}
+
+/**
+ * Removed undefined values from nested object.
+ *
+ * @param {*} object
+ * @return {*} Object cleaned from undefined values
+ */
+const cleanEmptyObject = ( object ) => {
+	if ( ! isObject( object ) ) {
+		return object;
+	}
+	const cleanedNestedObjects = pickBy(
+		mapValues( object, cleanEmptyObject ),
+		identity
+	);
+	return isEqual( cleanedNestedObjects, {} )
+		? undefined
+		: cleanedNestedObjects;
+};
+
+function ColorPanel( { settings, clientId, enableContrastChecking = true } ) {
+	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
+	const [ detectedColor, setDetectedColor ] = useState();
+
+	const title = isWebPlatform
+		? __( 'Color settings' )
+		: __( 'Color Settings' );
+
+	useEffect( () => {
+		if ( isWebPlatform && ! enableContrastChecking ) {
+			return;
+		}
+
+		const colorsDetectionElement = getBlockDOMNode( clientId );
+		if ( ! colorsDetectionElement ) {
+			return;
+		}
+		setDetectedColor( getComputedStyle( colorsDetectionElement ).color );
+
+		let backgroundColorNode = colorsDetectionElement;
+		let backgroundColor = getComputedStyle( backgroundColorNode )
+			.backgroundColor;
+		while (
+			backgroundColor === 'rgba(0, 0, 0, 0)' &&
+			backgroundColorNode.parentNode &&
+			backgroundColorNode.parentNode.nodeType ===
+				backgroundColorNode.parentNode.ELEMENT_NODE
+		) {
+			backgroundColorNode = backgroundColorNode.parentNode;
+			backgroundColor = getComputedStyle( backgroundColorNode )
+				.backgroundColor;
+		}
+
+		setDetectedBackgroundColor( backgroundColor );
+	} );
+
+	return (
+		<InspectorControls>
+			<PanelColorGradientSettings
+				title={ title }
+				initialOpen={ false }
+				settings={ settings }
+			>
+				{ isWebPlatform && enableContrastChecking && (
+					<ContrastChecker
+						backgroundColor={ detectedBackgroundColor }
+						textColor={ detectedColor }
+					/>
+				) }
+			</PanelColorGradientSettings>
+		</InspectorControls>
+	);
+}
+
+/**
+ * Inspector control panel containing the color related configuration
+ *
+ * @param {Object} props
+ *
+ * @return {WPElement} Color edit element.
+ */
+function ColorEdit( props ) {
+	const { attributes } = props;
+	const colors = useEditorFeature( 'color.palette' ) || EMPTY_ARRAY;
+	const gradients = useEditorFeature( 'color.gradients' ) || EMPTY_ARRAY;
+
+	// Shouldn't be needed but right now the ColorGradientsPanel
+	// can trigger both onChangeColor and onChangeBackground
+	// synchronously causing our two callbacks to override changes
+	// from each other.
+	const localAttributes = useRef( attributes );
+	useEffect( () => {
+		localAttributes.current = attributes;
+	}, [ attributes ] );
+
+	const { style, textColor, backgroundColor, gradient } = attributes;
+	let gradientValue;
+	if ( gradient ) {
+		gradientValue = getGradientValueBySlug( gradients, gradient );
+	} else {
+		gradientValue = style?.color?.gradient;
+	}
+
+	const onChangeColor = ( name ) => ( value ) => {
+		const colorObject = getColorObjectByColorValue( colors, value );
+		const attributeName = name + 'Color';
+		const newStyle = {
+			...localAttributes.current.style,
+			color: {
+				...localAttributes.current?.style?.color,
+				[ name ]: colorObject?.slug ? undefined : value,
+			},
+		};
+
+		const newNamedColor = colorObject?.slug ? colorObject.slug : undefined;
+		const newAttributes = {
+			style: cleanEmptyObject( newStyle ),
+			[ attributeName ]: newNamedColor,
+		};
+
+		props.setAttributes( newAttributes );
+		localAttributes.current = {
+			...localAttributes.current,
+			...newAttributes,
+		};
+	};
+
+	const onChangeGradient = ( value ) => {
+		const slug = getGradientSlugByValue( gradients, value );
+		let newAttributes;
+		if ( slug ) {
+			const newStyle = {
+				...localAttributes.current?.style,
+				color: {
+					...localAttributes.current?.style?.color,
+					gradient: undefined,
+				},
+			};
+			newAttributes = {
+				style: cleanEmptyObject( newStyle ),
+				gradient: slug,
+			};
+		} else {
+			const newStyle = {
+				...localAttributes.current?.style,
+				color: {
+					...localAttributes.current?.style?.color,
+					gradient: value,
+				},
+			};
+			newAttributes = {
+				style: cleanEmptyObject( newStyle ),
+				gradient: undefined,
+			};
+		}
+		props.setAttributes( newAttributes );
+		localAttributes.current = {
+			...localAttributes.current,
+			...newAttributes,
+		};
+	};
+
+	const settings = useMemo( () => {
+		return [
+			{
+				label: __( 'Text Color' ),
+				onColorChange: onChangeColor( 'text' ),
+				colorValue: getColorObjectByAttributeValues(
+					colors,
+					textColor,
+					style?.color?.text
+				).color,
+			},
+			{
+				label: __( 'Background Color' ),
+				onColorChange: onChangeColor( 'background' ),
+				colorValue: getColorObjectByAttributeValues(
+					colors,
+					backgroundColor,
+					style?.color?.background
+				).color,
+				gradientValue,
+				onGradientChange: onChangeGradient,
+			},
+		];
+	}, [
+		colors,
+		textColor,
+		backgroundColor,
+		gradientValue,
+		style?.color?.text,
+		style?.color?.background,
+	] );
+
+	return (
+		<ColorPanel
+			enableContrastChecking={ ! gradient && ! style?.color?.gradient }
+			clientId={ props.clientId }
+			settings={ settings }
+		/>
+	);
+}
+
+export default ColorEdit;

--- a/assets/src/components/p4_button/color-props.js
+++ b/assets/src/components/p4_button/color-props.js
@@ -1,0 +1,89 @@
+/**
+ * This file is copy of core button block color-props.js (https://github.com/WordPress/gutenberg/blob/cb2c25aafec3d6a4825300e30210c7a2771133a7/packages/block-library/src/button/color-props.js), with customize changes.
+ * Customize changes(PLANET-4924) :
+ *  - Added `p4_button_text_colors` and `p4_button_bg_colors` custom P4 button colors.
+ *  - Remove the BorderPanel control(button borderRadius).
+ */
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	getColorClassName,
+	getColorObjectByAttributeValues,
+	__experimentalGetGradientClass,
+} from '@wordpress/block-editor';
+
+// The code in this file is copied entirely from the "color" and "style" support flags
+// The flag can't be used at the moment because of the extra wrapper around
+// the button block markup.
+
+export default function getColorAndStyleProps(
+	attributes,
+	colors,
+	isEdit = false
+) {
+	// I'd have prefered to avoid the "style" attribute usage here
+	const { backgroundColor, textColor, gradient, style } = attributes;
+
+	const backgroundClass = getColorClassName(
+		'background-color',
+		backgroundColor
+	);
+	const gradientClass = __experimentalGetGradientClass( gradient );
+	const textClass = getColorClassName( 'color', textColor );
+	const className = classnames( textClass, gradientClass, {
+		// Don't apply the background class if there's a custom gradient
+		[ backgroundClass ]: ! style?.color?.gradient && !! backgroundClass,
+		'has-text-color': textColor || style?.color?.text,
+		'has-background':
+			backgroundColor ||
+			style?.color?.background ||
+			gradient ||
+			style?.color?.gradient,
+	} );
+	const styleProp =
+		style?.color?.background || style?.color?.text || style?.color?.gradient
+			? {
+					background: style?.color?.gradient
+						? style.color.gradient
+						: undefined,
+					backgroundColor: style?.color?.background
+						? style.color.background
+						: undefined,
+					color: style?.color?.text ? style.color.text : undefined,
+			  }
+			: {};
+
+	// This is needed only for themes that don't load their color stylesheets in the editor
+	// We force an inline style to apply the color.
+	if ( isEdit ) {
+		if ( backgroundColor ) {
+			const backgroundColorObject = getColorObjectByAttributeValues(
+				colors,
+				backgroundColor
+			);
+
+			styleProp.backgroundColor = backgroundColorObject.color;
+		}
+
+		if ( textColor ) {
+			const textColorObject = getColorObjectByAttributeValues(
+				colors,
+				textColor
+			);
+
+			styleProp.color = textColorObject.color;
+		}
+	}
+
+	return {
+		className: !! className ? className : undefined,
+		style: styleProp,
+	};
+}

--- a/assets/src/components/p4_button/color-props.js
+++ b/assets/src/components/p4_button/color-props.js
@@ -3,6 +3,7 @@
  * Customize changes(PLANET-4924) :
  *  - Added `p4_button_text_colors` and `p4_button_bg_colors` custom P4 button colors.
  *  - Remove the BorderPanel control(button borderRadius).
+ *  - Remove the WidthPanel control(button width).
  */
 
 /**

--- a/assets/src/components/p4_button/edit.js
+++ b/assets/src/components/p4_button/edit.js
@@ -17,11 +17,8 @@ import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useState } from '@wordpress/element';
 import {
-	Button,
-	ButtonGroup,
 	KeyboardShortcuts,
 	PanelBody,
-	RangeControl,
 	TextControl,
 	ToggleControl,
 	ToolbarButton,
@@ -37,7 +34,6 @@ import {
 	__experimentalUseEditorFeature as useEditorFeature,
 } from '@wordpress/block-editor';
 import { rawShortcut, displayShortcut } from '@wordpress/keycodes';
-import { link, linkOff } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
 
 /**
@@ -47,9 +43,6 @@ import ColorEdit from './color-edit';
 import getColorAndStyleProps from './color-props';
 
 const NEW_TAB_REL = 'noreferrer noopener';
-const MIN_BORDER_RADIUS_VALUE = 0;
-const MAX_BORDER_RADIUS_VALUE = 50;
-const INITIAL_BORDER_RADIUS_POSITION = 5;
 
 const EMPTY_ARRAY = [];
 


### PR DESCRIPTION
Ref: [JIRA 5871](https://jira.greenpeace.org/browse/PLANET-5871)

---

- Updated the native button block files with the new version for WP5.6.
- Make the default button style selected by default
- Move P4 button styles override from [editor.js](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/edf475f0c227657b91a32a31b7b43e4b880c9d9d/admin/js/editor.js#L4) to [BlockFilter.js](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/assets/src/BlockFilters.js)
