### PR TITLE
PLANET-5970 Restore previous youtube embed width

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -65,7 +65,7 @@
     "selector-pseudo-element-case": "lower",
     "selector-type-case": "lower",
     "selector-type-no-unknown": [true, {
-	  "ignoreTypes": ["/^--[a-z]\\w*(--?[a-z0-9]+)*--$/"]
+	  "ignoreTypes": ["/^--[a-z]\\w*(--?[a-z0-9]+)*--$/", "lite-youtube"]
 	}],
     "selector-max-empty-lines": 0,
 

--- a/assets/src/styles/blocks/Media.scss
+++ b/assets/src/styles/blocks/Media.scss
@@ -87,6 +87,11 @@
   width: 100% !important;
 }
 
+lite-youtube {
+  width: 100% !important;
+  max-width: 100%;
+}
+
 .wp-block-embed-twitter {
   .wp-block-embed__wrapper {
     padding-bottom: unset;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5970
---

The CSS packaged with the player sets a max-width on the element, whereas previously our iframe had a 100% width and no max-width. I added a new rule for this element specifically.