### PR TITLE
Comment a11y test out until we make them run on test instances

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
       - php73-tests
       - frontend-tests
       - acceptance-tests
-      - a11y-tests
+      #- a11y-tests
       - create-zip:
           filters:
             tags:


### PR DESCRIPTION
a11y tests are currently failing because of some changes in our docker-compose configuration.
We are planning to run those tests on live test instances, and this job is consuming resources while failing systematically. It's better to comment this out for now and work next on moving it to run on the test instance.

Related: https://github.com/greenpeace/planet4-master-theme/pull/1318