### PR TITLE
A11y: Convert carousel anchors to buttons

### DIFF
--- a/assets/src/blocks/Gallery/GalleryCarousel.js
+++ b/assets/src/blocks/Gallery/GalleryCarousel.js
@@ -80,10 +80,10 @@ export const GalleryCarousel = ({ images, onImageClick }) => {
       }
       <div className="carousel-inner" role="listbox">
         {images.length > 1 &&
-          <a className="carousel-control-prev" role="button" onClick={goToPrevSlide}>
+          <button className="carousel-control-prev" role="button" onClick={goToPrevSlide}>
             <span className="carousel-control-prev-icon" aria-hidden="true"><i></i></span>
             <span className="sr-only">{__('Previous', 'planet4-blocks')}</span>
-          </a>
+          </button>
         }
         {images.map((image, index) => (
           <div
@@ -113,10 +113,10 @@ export const GalleryCarousel = ({ images, onImageClick }) => {
           </div>
         ))}
         {images.length > 1 && (
-          <a className="carousel-control-next" role="button" onClick={goToNextSlide}>
+          <button className="carousel-control-next" role="button" onClick={goToNextSlide}>
             <span className="carousel-control-next-icon" aria-hidden="true"><i></i></span>
             <span className="sr-only">{__('Next', 'planet4-blocks')}</span>
-          </a>
+          </button>
         )}
       </div>
     </div>

--- a/assets/src/styles/blocks/Gallery_carousel.scss
+++ b/assets/src/styles/blocks/Gallery_carousel.scss
@@ -186,6 +186,8 @@
     width: 30%;
     z-index: 3;
     cursor: pointer;
+    background: transparent;
+    border: 0;
 
     @include mobile-only {
       .carousel-control-prev-icon,


### PR DESCRIPTION
Partial fix for:
Ref: https://github.com/greenpeace/planet4/issues/125

Accessibility fix: convert anchors into buttons on the carousels.