### PR TITLE
PLANET-5980 Fix inconsistencies between editor and frontend

### DIFF
--- a/assets/src/styles/blocks/File.scss
+++ b/assets/src/styles/blocks/File.scss
@@ -1,9 +1,6 @@
-.wp-block-file {
-  .wp-block-file__button {
-    overflow: unset;
-    padding: 0 1em;
-    width: min-content;
-    margin-left: 1em;
-    font-size: .8em;
-  }
+.wp-block-file .wp-block-file__button {
+  overflow: unset;
+  padding: 0 1em;
+  margin-inline-start: 1em;
+  font-size: .8em;
 }

--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -40,8 +40,6 @@
   }
 
   img {
-    width: 100%;
-    max-width: 100%;
     height: auto;
   }
 

--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -48,25 +48,15 @@
     font-family: $roboto;
     line-height: 1.4;
     margin-bottom: 0;
-  }
-
-  &.caption-style-medium, &.caption-style-blue-overlay {
-    figcaption {
-      color: $grey-60;
-    }
-  }
-}
-
-figcaption {
-  .caption-alignment-left & {
-    text-align: left;
-  }
-
-  .caption-alignment-center & {
+    color: $grey-60;
     text-align: center;
   }
 
-  .caption-alignment-right & {
+  &.caption-alignment-left figcaption {
+    text-align: left;
+  }
+
+  &.caption-alignment-right figcaption {
     text-align: right;
   }
 }


### PR DESCRIPTION
### Description

See [PLANET-5980](https://jira.greenpeace.org/browse/PLANET-5980)
- Header alignment choice (left/right/center) not reflected in the frontend
- Image alignment breaks text and creates gaps
- Button manually chosen text color not applied properly in the frontend

Should also solve [PLANET-5857](https://jira.greenpeace.org/browse/PLANET-5857)
- Weird breaks in paragraphs and lists with HTML tags (bold, anchor links, etc)

### Related PRs
- [styleguide](https://github.com/greenpeace/planet4-styleguide/pull/100)