### PR TITLE
PLANET-5981 Updates for Bootstrap 5

### DIFF
--- a/assets/src/blocks/Articles/ArticlesFrontend.js
+++ b/assets/src/blocks/Articles/ArticlesFrontend.js
@@ -39,7 +39,7 @@ export const ArticlesFrontend = (props) => {
         { hasMorePages &&
         <div className="row">
           { read_more_link ?
-            <div className="col-md-12 col-lg-5 col-xl-5 mr-auto">
+            <div className="col-md-12 col-lg-5 col-xl-5">
               <a
                 className="btn btn-secondary btn-block article-load-more"
                 href={ read_more_link }

--- a/assets/src/blocks/Carouselheader/FullWidthCarouselHeader.js
+++ b/assets/src/blocks/Carouselheader/FullWidthCarouselHeader.js
@@ -56,8 +56,8 @@ export const FullWidthCarouselHeader = {
 
       // Populate carousel indicators list
       $('<li>')
-        .attr('data-target', '#carousel-wrapper-header')
-        .attr('data-slide-to', i)
+        .attr('data-bs-target', '#carousel-wrapper-header')
+        .attr('data-bs-slide-to', i)
         .toggleClass('active', i === 0)
         .appendTo(me.$CarouselIndicators);
 
@@ -70,7 +70,7 @@ export const FullWidthCarouselHeader = {
         .css('background-position', $img.data('background-position'));
 
       // Populate carousel slide index
-      $slide.attr('data-slide', i);
+      $slide.attr('data-bs-slide', i);
     });
 
     // Bind mouse interaction events

--- a/assets/src/blocks/Gallery/GalleryCarousel.js
+++ b/assets/src/blocks/Gallery/GalleryCarousel.js
@@ -28,7 +28,7 @@ export const GalleryCarousel = ({ images, onImageClick }) => {
     if (newSlide !== currentSlide && nextElement && activeElement && !sliding) {
       setSliding(true);
       const order = getOrder(newSlide);
-      const direction = order === 'next' ? 'left' : 'right';
+      const direction = order === 'next' ? 'start' : 'end';
       const orderClassname = `carousel-item-${order}`;
       const directionClassname = `carousel-item-${direction}`;
 

--- a/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
@@ -166,13 +166,12 @@ export class SpreadsheetFrontend extends Component {
     return (
       <Fragment>
         <section className="block block-spreadsheet" style={{ cssText: toDeclarations( this.props.css_variables ) }}>
-          <div className="form-inline">
-            <input className="spreadsheet-search form-control"
-              type="text"
-              value={ this.state.searchText }
-              onChange={ event => this.setState({ searchText: event.target.value }) }
-              placeholder={ __('Search data', 'planet4-blocks') } />
-          </div>
+          <input className="spreadsheet-search form-control"
+            type="text"
+            value={ this.state.searchText }
+            onChange={ event => this.setState({ searchText: event.target.value }) }
+            placeholder={ __('Search data', 'planet4-blocks') }
+          />
           <div className="table-wrapper">
             <table className="spreadsheet-table">
               <thead>

--- a/assets/src/styles/blocks/Covers/ContentCovers.scss
+++ b/assets/src/styles/blocks/Covers/ContentCovers.scss
@@ -17,6 +17,12 @@
       -ms-overflow-style: none;
       scrollbar-width: none;
     }
+
+    @media (max-width: 768px) {
+      .post-column {
+        max-width: 45%;
+      }
+    }
   }
 
   .row::-webkit-scrollbar {

--- a/assets/src/styles/blocks/Covers/ContentCovers.scss
+++ b/assets/src/styles/blocks/Covers/ContentCovers.scss
@@ -5,15 +5,6 @@
     margin-top: -$space-lg;
   }
 
-  .col-md-4 {
-    outline: none;
-    width: 45%;
-
-    @include medium-and-up {
-      width: 157px;
-    }
-  }
-
   .load-more-posts-button-div {
     margin-top: $space-lg;
   }

--- a/assets/src/styles/blocks/ENForm/components/_enform.scss
+++ b/assets/src/styles/blocks/ENForm/components/_enform.scss
@@ -92,7 +92,6 @@
     margin: 0;
 
     input,
-    .custom-select,
     select.form-control.en__field__input--select,
     button {
       min-width: 200px;

--- a/assets/src/styles/blocks/Gallery_content_three_column.scss
+++ b/assets/src/styles/blocks/Gallery_content_three_column.scss
@@ -17,6 +17,10 @@
     }
   }
 
+  .col {
+    position: relative;
+  }
+
   .split-image {
     position: absolute;
 

--- a/assets/src/styles/blocks/Happypoint.scss
+++ b/assets/src/styles/blocks/Happypoint.scss
@@ -148,7 +148,7 @@
   }
 
   form {
-    input, .custom-select {
+    input {
       height: 42px;
       border-radius: 4px;
       border-color: transparent;

--- a/assets/src/styles/blocks/Media.scss
+++ b/assets/src/styles/blocks/Media.scss
@@ -40,30 +40,13 @@
   height: 100%;
 }
 
-.video-embed, .wp-block-embed-youtube, .wp-block-embed-vimeo, .wp-block-embed-dailymotion, .wp-block-embed-kickstarter {
+.wp-block-embed-youtube, .wp-block-embed-vimeo, .wp-block-embed-dailymotion, .wp-block-embed-kickstarter {
   margin-top: $space-xs;
   margin-bottom: $space-md;
-
-  @include  small-and-up {
-    max-width: 360px;
-    max-height: 202px;
-  }
-
-  @include medium-and-up {
-    max-width: 690px;
-    max-height: 388px;
-  }
 
   @include large-and-up {
     margin-top: $space-md;
     margin-bottom: $space-lg;
-    max-width: 930px;
-    max-height: 523px;
-  }
-
-  @include x-large-and-up {
-    max-width: 100%;
-    max-height: 615px;
   }
 }
 

--- a/templates/blocks/carousel_header_full-width-classic.twig
+++ b/templates/blocks/carousel_header_full-width-classic.twig
@@ -21,7 +21,7 @@
 					{% else %}
 						{% set css_class = 'carousel-item' %}
 					{% endif %}
-					<div class="{{ css_class }}" data-slide="{{ i }}">
+					<div class="{{ css_class }}" data-bs-slide="{{ i }}">
 						<div class="carousel-item-mask">
 							<div class="background-holder">
 								{% if slide.image %}
@@ -68,11 +68,11 @@
 
 		</div>
 		{% if fields.total_images > 1 %}
-			<a class="carousel-control-prev" href="#carousel-wrapper-header" role="button" data-slide="prev">
+			<a class="carousel-control-prev" href="#carousel-wrapper-header" role="button" data-bs-slide="prev">
 				<span class="carousel-control-prev-icon" aria-hidden="true"><i></i></span>
 				<span class="visually-hidden">Prev</span>
 			</a>
-			<a class="carousel-control-next" href="#carousel-wrapper-header" role="button" data-slide="next">
+			<a class="carousel-control-next" href="#carousel-wrapper-header" role="button" data-bs-slide="next">
 				<span class="carousel-control-next-icon" aria-hidden="true"><i></i></span>
 				<span class="visually-hidden">Next</span>
 			</a>

--- a/templates/blocks/columns_tasks.twig
+++ b/templates/blocks/columns_tasks.twig
@@ -82,7 +82,7 @@
 
 								<div class="card">
 									<a class="card-header {{ loop.index>1 ? 'collapsed' : '' }}" role="tab" id="heading-{{ number_to_word }}"
-									   data-toggle="collapse" data-target=".card-header:hover + #collapse-{{ number_to_word }}"
+									   data-bs-toggle="collapse" data-bs-target=".card-header:hover + #collapse-{{ number_to_word }}"
 									   href="#collapse-{{ number_to_word }}"
 									   aria-expanded="true"
 									   aria-controls="collapse-{{ number_to_word }}"
@@ -112,7 +112,7 @@
 									{% endif %}
 
 									<div id="collapse-{{ number_to_word }}" class="{{ collapse_class }}"
-										 data-parent="#accordion" role="tabpanel"
+										 data-bs-parent="#accordion" role="tabpanel"
 										 aria-labelledby="heading-{{ number_to_word }}">
 										<div class="card-block info-with-image-wrap clearfix">
 											<div class="mobile-accordion-info">

--- a/templates/blocks/enform/country_select.twig
+++ b/templates/blocks/enform/country_select.twig
@@ -2,7 +2,7 @@
 	<div class="en__field--{{ data.id }} en__field--{{ data.name }}">
 		<select id="en__field_supporter_{{ field.name }}"
 			name="supporter.{{ field.property }}"
-			class="en__field__input en__field__input--select en_select_country form-control"
+			class="en__field__input en__field__input--select en_select_country form-select"
 			data-errormessage="{{ errorMessage }}"
 			{{ 'true' == field.required ? 'required' : '' }}>
 			<option value="" selected="selected" disabled={{ field.required == 'true' }}>{{ __( 'Select Country or Region', 'planet4-engagingnetworks' ) }}{{ 'true' == field.required ? '*' : '' }}</option>

--- a/templates/blocks/enform/position_select.twig
+++ b/templates/blocks/enform/position_select.twig
@@ -2,7 +2,7 @@
 	<div class="en__field--{{ data.id }} en__field--{{ data.name }}">
 		<select id="en__field_supporter_{{ field.name }}"
 			name="supporter.{{ field.property }}"
-			class="en__field__input en__field__input--select en_select_position form-control"
+			class="en__field__input en__field__input--select en_select_position form-select"
 			data-errormessage="{{ errorMessage }}"
 			{{ 'true' == field.required ? 'required' : '' }}>
 			<option value="" selected="selected" disabled={{ field.required == 'true' }}>{{ __( 'Select Affiliation, Position or Profession', 'planet4-engagingnetworks' ) }}{{ 'true' == field.required ? '*' : '' }}</option>


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-5981

Changes made to comply with the [migration doc](https://getbootstrap.com/docs/5.0/migration/):
- Rename all Bootstrap attributes' prefixes from `data-` to `data-bs-`
- Remove `form-inline` and `custom-select` classes (removed from Bootstrap 5)
- Add `form-select` to select components instead of `form-control` (which now has the `appearance: none;` hiding the select's arrow)
- Remove `mr-auto` class (it should have been renamed `me-auto`, but wasn't doing anything except causing issues in RTL sites so better remove it 🤷‍♀️)
- Update ContentCovers width overrides
- Add `position: relative;` to `col` class for GalleryThreeColumns since it was removed from Bootstrap
- Rename `carousel-item-left` and `carousel-item-right` to `carousel-item-start` and `carousel-item-end` respectively
- Remove max-height and max-width from video embeds and update vertical margin

### Testing

You can check the changes on [this test instance](https://www-dev.greenpeace.org/test-janus/), basically everything should look/behave the same as it does in the current sites 🙂 

### Related PRs

- [styleguide](https://github.com/greenpeace/planet4-styleguide/pull/104)
- [master-theme](https://github.com/greenpeace/planet4-master-theme/pull/1323)