### PR TITLE
PLANET-5983: Add variables to blocks CSS, part I

### DIFF
--- a/assets/src/styles/blocks/Articles.scss
+++ b/assets/src/styles/blocks/Articles.scss
@@ -2,17 +2,20 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  background-color: transparentize($white, .2);
-  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
   margin-top: $space-lg;
+
+  --block-articles--article-- {
+    background-color: transparentize($white, .2);
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
+
+    @include large-and-up {
+      background-color: transparent;
+      box-shadow: none;
+    }
+  }
 
   @include medium-and-up {
     flex-direction: row;
-  }
-
-  @include large-and-up {
-    background-color: transparent;
-    box-shadow: none;
   }
 
   &:first-of-type {
@@ -86,24 +89,26 @@
   }
 }
 
-.article-list-item-headline {
+.article-list-item-headline --block-articles--article--headline-- {
   font-weight: 500;
-  color: var(--article-list-item-headline-color, $grey-80);
-  margin: $space-xxs 0;
+  color: $grey-80;
+  margin: 4px 0;
 }
 
 .article-list-item-meta {
-  color: var(--article-list-item-meta-color, $grey-60);
-  font-family: $roboto;
-  font-style: italic;
-  font-size: 0.875rem;
-  font-weight: 300;
-  margin: 0;
+  --block-articles--article--meta-- {
+    color: $grey-60;
+    font-family: $roboto;
+    font-style: italic;
+    font-size: 0.875rem;
+    font-weight: 300;
 
-  @include large-and-up {
-    font-size: 0.9375rem;
-    width: 80%;
+    @include large-and-up {
+      font-size: 0.9375rem;
+      width: 80%;
+    }
   }
+  margin: 0;
 }
 
 .article-list-item-author {

--- a/assets/src/styles/blocks/Articles.scss
+++ b/assets/src/styles/blocks/Articles.scss
@@ -120,6 +120,9 @@
 }
 
 .article-list-item-content {
+  --block-articles--article--content-- {
+    font-size: inherit;
+  }
   display: none;
   margin: $space-xs 0 0;
   width: 80%;

--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -4,10 +4,6 @@
       font-weight: inherit;
     }
 
-    &.btn-primary {
-      color: $white;
-    }
-
     &.btn-secondary {
       width: 100%;
     }

--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -15,20 +15,22 @@
 
   h3, h3 > a {
     line-height: 1.6rem;
-    font-size: $font-size-lg;
-    font-family: $roboto;
-    font-weight: 700;
 
     --block-columns--column-heading-- {
+      font-size: $font-size-lg;
+      font-family: $roboto;
+      font-weight: 700;
       color: $grey-80;
-    }
+      margin-bottom: .5rem;
+      text-transform: none;
 
-    @include medium-and-up {
-      font-size: 1.5rem;
-    }
+      @include medium-and-up {
+        font-size: 1.5rem;
+      }
 
-    @include large-and-up {
-      font-size: 1.5rem;
+      @include large-and-up {
+        font-size: 1.5rem;
+      }
     }
   }
 

--- a/assets/src/styles/blocks/Covers/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionCovers.scss
@@ -154,12 +154,14 @@
       display: block;
 
       --block-covers--card-btn-- {
+        color: white;
         background-color: $orange;
         border-color: $orange;
       }
 
-      &:hover, &:focus, &:focus-within {
+      &:hover, &:focus {
         --block-covers--card-btn-hover-- {
+          color: white;
           background-color: $orange-hover;
           border-color: $orange-hover;
         }
@@ -268,13 +270,15 @@
 }
 
 .cover-card-btn {
+  --block-covers--card-button-- {
+    display: none;
+  }
   position: absolute;
   bottom: 0;
   left: 0;
   right: 0;
   margin: $n15 auto;
   width: 92%;
-  display: none;
   z-index: 1;
   pointer-events: all;
 }

--- a/assets/src/styles/blocks/Covers/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionCovers.scss
@@ -157,10 +157,8 @@
         color: white;
         background-color: $orange;
         border-color: $orange;
-      }
 
-      &:hover, &:focus {
-        --block-covers--card-btn-hover-- {
+        &:hover, &:focus {
           color: white;
           background-color: $orange-hover;
           border-color: $orange-hover;
@@ -242,6 +240,11 @@
 .cover-card-tag {
   --block-covers--card-tag-- {
     color: $yellow;
+
+    &:hover {
+      text-decoration: underline;
+      color: $yellow;
+    }
   }
 
   display: inline-block;
@@ -253,14 +256,6 @@
   pointer-events: all;
   position: relative;
   margin-inline-end: 8px;
-
-  &:hover {
-    text-decoration: underline;
-
-    --block-covers--card-tag-hover-- {
-      color: $yellow;
-    }
-  }
 
   @include large-and-up {
     margin-bottom: 0;

--- a/assets/src/styles/blocks/Covers/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionCovers.scss
@@ -150,20 +150,8 @@
       }
     }
 
-    .btn {
+    .cover-card-btn {
       display: block;
-
-      --block-covers--card-btn-- {
-        color: white;
-        background-color: $orange;
-        border-color: $orange;
-
-        &:hover, &:focus {
-          color: white;
-          background-color: $orange-hover;
-          border-color: $orange-hover;
-        }
-      }
     }
   }
 
@@ -267,6 +255,15 @@
 .cover-card-btn {
   --block-covers--card-button-- {
     display: none;
+    color: white;
+    background-color: $orange;
+    border-color: $orange;
+
+    &:hover, &:focus {
+      color: white;
+      background-color: $orange-hover;
+      border-color: $orange-hover;
+    }
   }
   position: absolute;
   bottom: 0;

--- a/assets/src/styles/blocks/ENForm/components/_enform.scss
+++ b/assets/src/styles/blocks/ENForm/components/_enform.scss
@@ -1,22 +1,27 @@
 .form-caption {
   float: none;
   width: 100%;
-  padding-top: 53px;
-  padding-bottom: 53px;
-  padding-left: $n15;
-  padding-right: $n15;
 
-  @include medium-and-up {
-    padding-top: 106px;
-    padding-bottom: 106px;
+  --block-enform--caption-- {
+    padding-top: 53px;
+    padding-bottom: 53px;
+    padding-left: 15px;
+    padding-right: 15px;
+
+    @include medium-and-up {
+      padding-top: 106px;
+      padding-bottom: 106px;
+    }
+
+    @include large-and-up {
+      padding-top: 117px;
+      padding-left: 0;
+      padding-right: 0;
+      width: 50%;
+    }
   }
-
   @include large-and-up {
     float: left;
-    padding-top: 117px;
-    width: 50%;
-    padding-left: 0;
-    padding-right: 0;
 
     html[dir="rtl"] & {
       float: right;
@@ -28,7 +33,10 @@
   }
 
   h1, h2, h3 {
-    color: white;
+    --block-enform--caption-heading-- {
+      color: white;
+    }
+
     font-family: var(--headings--font-family, var(--header-primary-font)) !important;
   }
 
@@ -64,10 +72,12 @@
   }
 
   p {
-    color: white;
-    font-family: $roboto;
-    font-size: 1rem;
-    line-height: 1.37rem;
+    --block-enform--caption--paragraph-- {
+      color: white;
+      font-family: $roboto;
+      font-size: 1rem;
+      line-height: 1.37rem;
+    }
 
     html[dir="rtl"] & {
       font-size: 1rem;
@@ -78,6 +88,14 @@
     max-height: 17.5rem;
     margin-bottom: 2rem;
   }
+}
+
+.form-description p:first-child --block-enform--caption--paragraph--first-- {
+  font-weight: inherit;
+  font-size: 1rem;
+  text-transform: none;
+  font-family: $roboto;
+  margin-bottom: auto;
 }
 
 .enform {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1256,9 +1256,9 @@
       }
     },
     "@greenpeace/dashdash": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@greenpeace/dashdash/-/dashdash-1.0.3.tgz",
-      "integrity": "sha512-aS85RTkLbSM2LBok43wC1+8TPz/vz19RE5BlJfOSx5Z14EuDlKHRl9uF72qJXrsHyZsWuDcbRpcOOd2O6BvAhA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@greenpeace/dashdash/-/dashdash-1.1.1.tgz",
+      "integrity": "sha512-bFMEtgXBxFTj5Ls3A2GqYn5lu8Cbb+RaN0cIIHv6mgEHcZ1HRDJROud6dHGhcIkdPN+M2cAymr+4MC4t2Q7MVg==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.32"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-nullish-coalescing-operator": "*",
     "@babel/plugin-proposal-optional-chaining": "*",
-    "@greenpeace/dashdash": "^1.0.3",
+    "@greenpeace/dashdash": "^1.1.1",
     "@wordpress/components": "^8.3.2",
     "@wordpress/data": "^4.9.2",
     "@wordpress/e2e-test-utils": "^4.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,13 @@ const cssVariables = require( '@greenpeace/planet4-postcss-css-variables' );
 const VariableCombinePlugin = require( '@greenpeace/planet4-postcss-css-variables/variableCombinePlugin' )
 
 const allCssVars = {};
+const mediaQueryAliases = {
+  '(max-width: 576px)': 'mobile-only',
+  '(min-width: 576px)': 'small-and-up',
+  '(min-width: 768px)': 'medium-and-up',
+  '(min-width: 992px)': 'large-and-up',
+  '(min-width: 1200px)': 'x-large-and-up',
+};
 
 const entryPoints = blockName => {
   return {
@@ -65,7 +72,7 @@ module.exports = {
             options: {
               ident: 'postcss',
               plugins: () => [
-                dashDash(),
+                dashDash({mediaQueryAliases, mediaQueryAtStart: false}),
                 cssVariables( { preserve: true, exportVarUsagesTo: allCssVars } ),
                 require('autoprefixer'),
               ],


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5983

---
https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/523/files?diff=split&w=1

There are some more to do, but we can already assess this first batch of blocks. Shouldn't be an issue to merge this in multiple chunks.

~~Master theme PR: https://github.com/greenpeace/planet4-master-theme/pull/1325~~ merged
New master theme PR with variables I needed to add because of blocks CSS: https://github.com/greenpeace/planet4-master-theme/pull/1360

Initially my plan was to replicate the existing themes in code. But while doing that I found it's quite clear cut which variables need to be added in most cases, while trying to make a theme work property by property without having the variables yet is a slow process. With the simple way of saving themes on the server, it's a lot easier to create these on the fly. So I'll do that and add them to Git in the end.

Some things that we may want to reconsider before adding variables:
- Articles: Uses the same CSS for the tags as the one used for the tags at the top of the page in master theme. I'm adding them now anyway since the top tags need them. But maybe it's better to separate these. Mainly the font size and spacing requirements for both places could be different.

TO TEST/REVIEW:
All these changes should leave existing content unchanged. I had to make minor changes to the CSS structure, but each of them seemed safe to do. Left a comment on the PR where I did so.