### PR TITLE
PLANET-5990 Enable Social Media block on Posts

### DIFF
--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -110,8 +110,9 @@ const POST_BLOCK_TYPES = [
 	'planet4-blocks/accordion',
 	'planet4-blocks/counter',
 	'planet4-blocks/gallery',
-	'planet4-blocks/take-action-boxout',
+	'planet4-blocks/social-media',
 	'planet4-blocks/spreadsheet',
+	'planet4-blocks/take-action-boxout',
 	'planet4-blocks/timeline',
 ];
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5990

---

Since native embed block doesn't support latest Facebook API changes anymore,
we need this in order to enable people to be able to embed FB/IG content
in Posts.

> _[Test post](https://www-dev.greenpeace.org/test-proteus/story/1007/social-media-test/)_