### PR TITLE
PLANET-5985: Too much padding bottom for new YouTube embed

### DIFF
--- a/assets/src/styles/blocks/Media.scss
+++ b/assets/src/styles/blocks/Media.scss
@@ -16,12 +16,20 @@
   }
 }
 
-.embed-container, .wp-block-embed-youtube .wp-block-embed__wrapper, .wp-block-embed-vimeo .wp-block-embed__wrapper, .wp-block-embed-dailymotion .wp-block-embed__wrapper, .wp-block-embed-kickstarter .wp-block-embed__wrapper {
+.embed-container,
+.wp-block-embed-youtube .wp-block-embed__wrapper,
+.wp-block-embed-vimeo .wp-block-embed__wrapper,
+.wp-block-embed-dailymotion .wp-block-embed__wrapper,
+.wp-block-embed-kickstarter .wp-block-embed__wrapper {
   position: relative;
-  padding-bottom: 56.25%;
   overflow: hidden;
   max-width: 100%;
   max-height: 100%;
+  // This combination of height: 0, and padding-bottom: 56.25%
+  // is to force the aspect ratio of the video to 16:9, based
+  // on the width. See: https://css-tricks.com/fluid-width-video/
+  padding-bottom: 56.25%;
+  height: 0;
 }
 
 .embed-container iframe, .wp-block-embed-youtube iframe, .wp-block-embed-vimeo iframe, .wp-block-embed-dailymotion iframe, .wp-block-embed-kickstarter iframe {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5985

The bottom padding was set following this technique for responsive iframe-based videos:
https://css-tricks.com/fluid-width-video/

For the technique to work, `height` has to be `0`.

---

<!--
Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
