### PR TITLE
Prevent unneeded prefixes, we autoprefix

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -87,6 +87,7 @@
     "no-unknown-animations": true,
     "no-invalid-double-slash-comments": true,
     "no-missing-end-of-source-newline": true,
-    "max-empty-lines": 1
+    "max-empty-lines": 1,
+    "property-no-vendor-prefix": true
   }
 }

--- a/assets/src/styles/blocks/Accordion.scss
+++ b/assets/src/styles/blocks/Accordion.scss
@@ -45,9 +45,6 @@
 
       &.open:after {
         transform: rotate(-90deg);
-        -webkit-transform: rotate(-90deg);
-        -moz-transform: rotate(-90deg);
-        -ms-transform: rotate(-90deg);
       }
 
       &:after {
@@ -63,18 +60,13 @@
         display: inline-block;
         transition: transform 0.8s ease;
         transform: rotate(90deg);
-        -webkit-transform: rotate(90deg);
-        -moz-transform: rotate(90deg);
-        -ms-transform: rotate(90deg);
 
         @supports (mask-repeat: no-repeat) or (-webkit-mask-repeat: no-repeat) {
           & {
             background-image: none;
             background-color: $white;
-            -webkit-mask-image: url("../../public/images/icons/angle-right.svg");
             mask-image: url("../../public/images/icons/angle-right.svg");
             mask-repeat: no-repeat;
-            -webkit-mask-repeat: no-repeat;
             margin-right: 0;
           }
         }
@@ -92,9 +84,6 @@
       color: $grey-80;
       overflow: hidden;
       transition: display 1s, opacity 1s, height 1s ease-in-out;
-      -webkit-transition: display 1s, opacity 1s, height 1s ease-in-out;
-      -moz-transition: display 1s, opacity 1s, height 1s ease-in-out;
-      -ms-transition: display 1s, opacity 1s, height 1s ease-in-out;
 
       &.panel-hidden {
         visibility: hidden;

--- a/assets/src/styles/blocks/Covers/TakeActionBoxoutBottom.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionBoxoutBottom.scss
@@ -74,7 +74,11 @@
     margin-bottom: 0;
     display: -webkit-box;
     -webkit-line-clamp: 2;
+    /* stylelint-disable property-no-vendor-prefix */
+    /*! autoprefixer: off */
     -webkit-box-orient: vertical;
+    /*! autoprefixer: on */
+    /* stylelint-enable property-no-vendor-prefix */
     overflow: hidden;
   }
 
@@ -135,7 +139,11 @@
       font-size: 14px;
       display: -webkit-box;
       -webkit-line-clamp: 3;
+      /* stylelint-disable property-no-vendor-prefix */
+      /*! autoprefixer: off */
       -webkit-box-orient: vertical;
+      /*! autoprefixer: on */
+      /* stylelint-enable property-no-vendor-prefix */
       overflow: hidden;
       margin: 0;
     }

--- a/assets/src/styles/blocks/Covers/TakeActionBoxoutScroll.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionBoxoutScroll.scss
@@ -76,7 +76,11 @@
     font-weight: 700;
     display: -webkit-box;
     -webkit-line-clamp: 2;
+    /* stylelint-disable property-no-vendor-prefix */
+    /*! autoprefixer: off */
     -webkit-box-orient: vertical;
+    /*! autoprefixer: on */
+    /* stylelint-enable property-no-vendor-prefix */
     overflow: hidden;
   }
 

--- a/assets/src/styles/blocks/Gallery_carousel.scss
+++ b/assets/src/styles/blocks/Gallery_carousel.scss
@@ -107,7 +107,11 @@
       margin-bottom: 0;
       display: -webkit-box;
       -webkit-line-clamp: 3;
+      /* stylelint-disable property-no-vendor-prefix */
+      /*! autoprefixer: off */
       -webkit-box-orient: vertical;
+      /*! autoprefixer: on */
+      /* stylelint-enable property-no-vendor-prefix */
       overflow: hidden;
     }
   }

--- a/assets/src/styles/blocks/SplitTwoColumns.scss
+++ b/assets/src/styles/blocks/SplitTwoColumns.scss
@@ -300,10 +300,8 @@
           & {
             background-image: none;
             background-color: $yellow;
-            -webkit-mask-image: url("../../public/images/icons/angle-right.svg");
             mask-image: url("../../public/images/icons/angle-right.svg");
             mask-repeat: no-repeat;
-            -webkit-mask-repeat: no-repeat;
             margin-right: 0;
           }
         }

--- a/assets/src/styles/blocks/Submenu.scss
+++ b/assets/src/styles/blocks/Submenu.scss
@@ -52,10 +52,8 @@ div[data-render="planet4-blocks/submenu"] {
           & {
             background-image: none;
             background-color: $grey-80;
-            -webkit-mask-image: url("../../public/images/icons/angle-right.svg");
             mask-image: url("../../public/images/icons/angle-right.svg");
             mask-repeat: no-repeat;
-            -webkit-mask-repeat: no-repeat;
             margin-right: 0;
           }
         }

--- a/assets/src/styles/campaigns/base/_mixins.scss
+++ b/assets/src/styles/campaigns/base/_mixins.scss
@@ -1,5 +1,4 @@
 @mixin monochrome {
-  -webkit-filter: grayscale(100%);
   filter: grayscale(100%);
 }
 

--- a/assets/src/styles/campaigns/themes/_theme_climate.scss
+++ b/assets/src/styles/campaigns/themes/_theme_climate.scss
@@ -238,7 +238,6 @@ body.theme-climate {
       }
 
       &:hover:after {
-        -webkit-filter: brightness(10);
         filter: brightness(10);
         opacity: 1;
       }

--- a/assets/src/styles/campaigns/themes/_theme_oil.scss
+++ b/assets/src/styles/campaigns/themes/_theme_oil.scss
@@ -223,7 +223,6 @@ body.theme-oil {
       }
 
       &:hover:after {
-        -webkit-filter: brightness(10);
         filter: brightness(10);
         opacity: 1;
       }

--- a/assets/src/styles/components/VarPicker.scss
+++ b/assets/src/styles/components/VarPicker.scss
@@ -16,13 +16,11 @@
   }
 
   &::-webkit-scrollbar-track {
-    -webkit-border-radius: 5px;
     border-radius: 5px;
     background: rgba(140, 140, 140, 0.2);
   }
 
   &::-webkit-scrollbar-thumb {
-    -webkit-border-radius: 5px;
     border-radius: 5px;
     background: rgba(140, 140, 140, 0.4);
   }

--- a/assets/src/styles/vendors/photoswipe/main.scss
+++ b/assets/src/styles/vendors/photoswipe/main.scss
@@ -9,12 +9,10 @@
   left: 0;
   top: 0;
   overflow: hidden;
-  -ms-touch-action: none;
   touch-action: none;
   z-index: $pswp__root-z-index;
-  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
   /* create separate layer, to avoid paint on window.onscroll in webkit/blink */
-  -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   outline: none;
 
@@ -77,7 +75,6 @@
   background: $pswp__background-color;
   opacity: 0;
   transform: translateZ(0);
-  -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   will-change: opacity;
   /* for open/close transition */
@@ -95,22 +92,18 @@
 
 .pswp__container,
 .pswp__zoom-wrap {
-  -ms-touch-action: none;
   touch-action: none;
   position: absolute;
   left: 0;
   right: 0;
   top: 0;
   bottom: 0;
-  -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
 }
 
 /* Prevent selection and tap highlights */
 .pswp__container,
 .pswp__img {
-  -webkit-user-select: none;
-  -moz-user-select: none;
   user-select: none;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   -webkit-touch-callout: none;
@@ -119,9 +112,6 @@
 .pswp__zoom-wrap {
   position: absolute;
   width: 100%;
-  -webkit-transform-origin: left top;
-  -moz-transform-origin: left top;
-  -ms-transform-origin: left top;
   transform-origin: left top;
   /* for open/close transition */
   transition: transform $pswp__show-hide-transition-duration cubic-bezier(.4, 0, .22, 1);
@@ -130,7 +120,6 @@
 .pswp--animated-in {
   .pswp__bg,
   .pswp__zoom-wrap {
-    -webkit-transition: none;
     transition: none;
   }
 }
@@ -158,7 +147,6 @@
 */
 
 .pswp__img--placeholder {
-  -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
 }
 

--- a/assets/src/styles/vendors/photoswipe/p4-skin.scss
+++ b/assets/src/styles/vendors/photoswipe/p4-skin.scss
@@ -32,7 +32,7 @@ Contents:
   background: none;
   cursor: pointer;
   overflow: visible;
-  -webkit-appearance: none;
+  appearance: none;
   display: block;
   border: 0;
   padding: 0;
@@ -179,8 +179,6 @@ Arrow buttons hit area
 
 .pswp__counter,
 .pswp__share-modal {
-  -webkit-user-select: none;
-  -moz-user-select: none;
   user-select: none;
 }
 
@@ -196,7 +194,6 @@ Arrow buttons hit area
   z-index: $pswp__root-z-index + 100;
   opacity: 0;
   transition: opacity 0.25s ease-out;
-  -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   will-change: opacity;
 }
@@ -217,7 +214,6 @@ Arrow buttons hit area
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.25);
   transform: translateY(6px);
   transition: transform 0.25s;
-  -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   will-change: transform;
 
@@ -491,7 +487,6 @@ You can play with it here - http://codepen.io/dimsemenov/pen/yyBWoR
 .pswp__top-bar,
 .pswp--has_mouse .pswp__button--arrow--left,
 .pswp--has_mouse .pswp__button--arrow--right {
-  -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   will-change: opacity;
   transition: opacity $pswp__controls-transition-duration cubic-bezier(.4, 0, .22, 1);


### PR DESCRIPTION
Ref: no ticket yet

---

Since we use autoprefixer, we can use a stylelintrule to detect any prefixes in our source that would be added during build anyway. This adds the rule and fixes violations, except `-webkit-box-orient` which is buggy.

