### PR TITLE
A11y: Convert anchor to button

### DIFF
--- a/assets/src/blocks/Splittwocolumns/SplittwocolumnsFrontend.js
+++ b/assets/src/blocks/Splittwocolumns/SplittwocolumnsFrontend.js
@@ -91,8 +91,12 @@ export const SplittwocolumnsFrontend = ({
             />
           }
           {button_text && button_link &&
-            <a className="btn btn-primary btn-block split-two-column-item-button"
-                href={button_link}
+            <button className="btn btn-primary btn-block split-two-column-item-button"
+                onClick={(e) => {
+                    e.preventDefault();
+                    window.location.href = button_link;
+                  }
+                }
                 {...analytics('Call to Action')}
                 dangerouslySetInnerHTML={{__html: button_text}}
             />


### PR DESCRIPTION
Ref: <!-- Please add a url to the ticket this change is addressing. -->
Fixes https://github.com/greenpeace/planet4/issues/125

Converts one more anchor to a button. According to the linked issue,
this is the last one that should change.
---

<!--
Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
