### PR TITLE
PLANET-5983: Enable high level overview of loading code

### DIFF
--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -354,22 +354,5 @@ function p4_blocks_en_forms_twig_filters( $twig ) {
 	L O A D  P L U G I N
 ==========================
 */
-P4GBKS\Loader::get_instance(
-	[
-		// --- Add here your own Block Controller ---
-		// DEPRECATED: Blocks could be registered inside Loader class
-		// 'P4GBKS\Controllers\Blocks\NewCovers_Controller'
-		\P4GBKS\Controllers\Menu\Settings_Controller::class,
-		\P4GBKS\Controllers\Menu\Blocks_Usage_Controller::class,
-		\P4GBKS\Controllers\Menu\Classic_Blocks_Usage::class,
-		\P4GBKS\Controllers\Menu\Reusable_Blocks_Controller::class,
-		\P4GBKS\Controllers\Menu\Archive_Import::class,
-		\P4GBKS\Controllers\Menu\Postmeta_Check_Controller::class,
-		\P4GBKS\Controllers\Menu\Enform_Post_Controller::class,
-		\P4GBKS\Controllers\Menu\En_Settings_Controller::class,
-		\P4GBKS\Controllers\Api\Rest_Controller::class,
-	],
-	\P4GBKS\Views\View::class
-);
-
+P4GBKS\Loader::get_instance();
 \P4GBKS\Rest\Rest_Api::add_endpoints();


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5983

---
I need to make some changes in this file, but first it really needs a clean up. The code currently is hard to make sense of. The naming is not accurate, it's deeply nested and does a lot of unnecessary things.

I moved the error output to the respective functions that check them, so they don't need to return a boolean and can just die inside if requirements are not satisfied.

The goal is to make it possible to have a high level overview of what's happening in this file.

This relates to the ticket in the following way: we're moving parts of the styleguide into master theme to more easily change them. First we need to move parts of `editorStyle` into master theme to remove the dependency for the plugin. For that I need to replicate the loading of that file in master theme.