### PR TITLE
PLANET-6004 Fix external and pdf link icons in campaigns

### DIFF
--- a/assets/src/styles/campaigns/themes/_theme_antarctic.scss
+++ b/assets/src/styles/campaigns/themes/_theme_antarctic.scss
@@ -1,3 +1,8 @@
+:root {
+  --link--color: #c44bc4;
+  --link-hover--color: #ff80e9;
+}
+
 body.theme-antarctic {
   $sanctuary: "Sanctuary", sans-serif;
   $montserrat: "Montserrat", sans-serif;
@@ -49,12 +54,7 @@ body.theme-antarctic {
   }
 
   .page-template a:not(.btn):not(.share-btn) {
-    color: $antarctic-purple;
     text-transform: uppercase;
-
-    &:hover {
-      color: $antarctic-pink;
-    }
   }
 
   .page-header {

--- a/assets/src/styles/campaigns/themes/_theme_arctic.scss
+++ b/assets/src/styles/campaigns/themes/_theme_arctic.scss
@@ -1,3 +1,8 @@
+:root {
+  --link--color: #f06e6e;
+  --link-hover--color: #ec4a4a;
+}
+
 body.theme-arctic {
   $open-sans: "Open Sans", sans-serif;
   $save-the-arctic: "Save the Arctic", sans-serif;
@@ -53,12 +58,7 @@ body.theme-arctic {
 
   .page-template a {
     &:not(.btn):not(.share-btn) {
-      color: $arctic-faded-red;
       text-transform: uppercase;
-
-      &:hover {
-        color: $arctic-red;
-      }
     }
 
     &.btn-primary {

--- a/assets/src/styles/campaigns/themes/_theme_climate.scss
+++ b/assets/src/styles/campaigns/themes/_theme_climate.scss
@@ -1,3 +1,8 @@
+:root {
+  --link--color: #007eff;
+  --link-hover--color: #837ac3;
+}
+
 body.theme-climate {
   $jost: "Jost", sans-serif;
 
@@ -84,12 +89,7 @@ body.theme-climate {
 
   .page-template a {
     &:not(.btn):not(.share-btn) {
-      color: $climate-blue;
       text-transform: uppercase;
-
-      &:hover {
-        color: $climate-purple-2;
-      }
     }
   }
 

--- a/assets/src/styles/campaigns/themes/_theme_forest.scss
+++ b/assets/src/styles/campaigns/themes/_theme_forest.scss
@@ -1,3 +1,8 @@
+:root {
+  --link--color: #1b4a1b;
+  --link-hover--color: #2caf4f;
+}
+
 body.theme-forest {
   $kanit: "Kanit", sans-serif;
   $open-sans: "Open Sans", sans-serif;
@@ -32,12 +37,7 @@ body.theme-forest {
 
   .page-template {
     a:not(.btn):not(.share-btn) {
-      color: $forest-dark-green;
       text-transform: uppercase;
-
-      &:hover {
-        color: $forest-green;
-      }
     }
 
     .btn-primary {

--- a/assets/src/styles/campaigns/themes/_theme_oceans.scss
+++ b/assets/src/styles/campaigns/themes/_theme_oceans.scss
@@ -1,3 +1,8 @@
+:root {
+  --link--color: #2cabb1;
+  --link-hover--color: #044362;
+}
+
 body.theme-oceans {
   $montserrat: "Montserrat", sans-serif;
 
@@ -50,14 +55,6 @@ body.theme-oceans {
 
   .page-section-header {
     @include page-section-header($montserrat, $oceans-blue, $extra-bold, 3.75rem);
-  }
-
-  .page-template a {
-    color: $oceans-aqua;
-
-    &:hover {
-      color: $oceans-blue;
-    }
   }
 
   .page-header {

--- a/assets/src/styles/campaigns/themes/_theme_oil.scss
+++ b/assets/src/styles/campaigns/themes/_theme_oil.scss
@@ -1,3 +1,8 @@
+:root {
+  --link--color: #007eff;
+  --link-hover--color: #837ac3;
+}
+
 body.theme-oil {
   $anton: "Anton", sans-serif;
   $amiko: "Amiko", sans-serif;
@@ -43,12 +48,7 @@ body.theme-oil {
 
   .page-template {
     a:not(.btn):not(.share-btn) {
-      color: $oil-blue;
       text-transform: uppercase;
-
-      &:hover {
-        color: $oil-purple-2;
-      }
     }
 
     .btn-primary {


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-6004

This PR fixes the icons in campaigns, in particular their (hover) colors in the different themes.

### Testing

You can see the fixed links & buttons on [this page](https://www-dev.greenpeace.org/test-leda/links-and-buttons-with-icons/) for example. You can also test the links with the different campaign themes (I added the links all the way at the bottom of the pages):
- [Antartic](https://www-dev.greenpeace.org/test-leda/campaign/antarctic/)
- [Arctic](https://www-dev.greenpeace.org/test-leda/campaign/arctic/)
- [Climate](https://www-dev.greenpeace.org/test-leda/campaign/climate-emergency-template-demo/)
- [Default](https://www-dev.greenpeace.org/test-leda/campaign/default-template/)
- [Forests](https://www-dev.greenpeace.org/test-leda/campaign/forests-template-demo/)
- [Oceans](https://www-dev.greenpeace.org/test-leda/campaign/oceans-template-demo/)
- [Oil](https://www-dev.greenpeace.org/test-leda/campaign/oil-template-demo/)
- [Plastics](https://www-dev.greenpeace.org/test-leda/campaign/plastics-template-demo/)

Note: the issue with the width of the secondary buttons will be solved as part of [PLANET-5980](https://jira.greenpeace.org/browse/PLANET-5980).

### Related PRs
- [master-theme](https://github.com/greenpeace/planet4-master-theme/pull/1335)