### PR TITLE
[No issue]: Check for a truish value in err before logging it

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -138,7 +138,7 @@ module.exports = {
           fs.writeFile(
             './assets/build/css-variables.json',
             JSON.stringify( mergedUsages, null, 2 ),
-            err => console.log( err )
+            err => !!err && console.log( err )
           );
           // todo: handle multiple files. The next line only works as intended if there is one style file.
           // allCssVars = {}


### PR DESCRIPTION
This is just to remove a `null` string in the Webpack build logs.

```
[./assets/src/theme/initializeThemeEditor.js] 6.42 KiB {themeEditor} [built]
    + 504 hidden modules
null    <---- this thingy
```
