### PR TITLE
PLANET-5981 Fix CarouselHeader indicators

### DIFF
--- a/assets/src/blocks/Carouselheader/FullWidthCarouselHeader.js
+++ b/assets/src/blocks/Carouselheader/FullWidthCarouselHeader.js
@@ -93,7 +93,7 @@ export const FullWidthCarouselHeader = {
     me.$CarouselHeaderWrapper.on('click', '.carousel-indicators li', function (evt) {
       evt.preventDefault();
       me.cancelAutoplayInterval();
-      me.activate($(evt.target).data('slide-to'));
+      me.activate($(evt.target).data('bs-slide-to'));
     });
 
     /* Carousel header swipe on mobile */

--- a/assets/src/styles/blocks/CarouselHeader_full_width_classic.scss
+++ b/assets/src/styles/blocks/CarouselHeader_full_width_classic.scss
@@ -653,7 +653,7 @@ $medium-image-height: 600px;
       height: 46px;
       cursor: pointer;
       background: url("../../public/images/carousel-arrow-next.png");
-      background-size: contain;
+      background-size: cover;
       display: none;
 
       @include large-and-up {


### PR DESCRIPTION
Small extra fix for Bootstrap5, the indicators were no longer working properly in the CarouselHeader due to the missing new `bs-` prefix.

Also added a small fix for the "next" arrow, which had the background image slightly off!