### PR TITLE
PLANET-6015: Handle post locking in subscriber

### DIFF
--- a/assets/src/blocks/Carouselheader/CarouselHeaderBlock.js
+++ b/assets/src/blocks/Carouselheader/CarouselHeaderBlock.js
@@ -158,7 +158,7 @@ export class CarouselHeaderBlock {
             const messages = invalidSlides.map( invalidSlide => {
               return `Carousel Header Block: Slide ${ slides.findIndex( slide => slide === invalidSlide ) + 1 } has no image`
             });
-      
+
             return { isValid, messages };
           }
         },


### PR DESCRIPTION
* This was handled in a component's render method. So the post was only
accurately locked/unlocked when something triggered this component to
render. Somehow in WP 5.6 this was not working for us anymore, probably
because the component doesn't render as frequently anymore.
* Instead a subscriber is added here to update this on changes to the
post. HOWEVER...
* The subscriber runs very often, since Gutenberg stores everything in
one store. This might affect performance if we have heavy validation
logic.
* To make things worse, the editor API allows access to post meta. But
this is not updated (sigh) when the CMB2 boxes are changed. Even now it
still relies on grabbing the metabox's value when you press the save
button, and doesn't update earlier like other things such as post
content or title.
* ~~We have 2 options: make the validation read the metaboxes anyway
(probably bad performance), or not use CMB2 for the settings and
implement an input for meta that works in a sane way.~~

I earlier overlooked an easier third option that seems to work. Adding a document listener for the metabox input.
That listener updates the WP meta data store, so that the component can listen for changes using `useSelect`.

This PR should make the tests pass, once https://github.com/greenpeace/planet4-master-theme/pull/1340 is merged.

This is the best I could come up with for now. The root cause of this issue is that WordPress does not provide any
kind of specific API for post validation yet. The subscriber runs too often, but this doesn't seem to be an issue, since
it only uses things that are in memory. It also only dispatches the post locking/unlocking when the validity changes.

Ref: https://jira.greenpeace.org/browse/PLANET-6015

How to test:

1. Create a new campaign.
2. Confirm you cannot save.
3. Enter the "Global project" in "Analytics & Tracking" in the document sidebar (labeled "campaign" now in 5.6 to match the post type)
4. This should immediately unlock the post publishing.
5. Remove the field again, post publishing should get locked again immediately.
6. Add field again.
7. Add a CarouselHeader block, leave it with a slide with no image.
8. Confirm post is locked.
9. Add an image or remove the block.
10. Confirm post is unlocked.

---

<!--
Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
