### PR TITLE
PLANET-6027 Don't load icons twice

### DIFF
--- a/assets/src/styles/campaigns.scss
+++ b/assets/src/styles/campaigns.scss
@@ -4,7 +4,6 @@
 @import "styleguide/src/base/functions";
 @import "styleguide/src/base/mixins";
 @import "styleguide/src/base/fonts";
-@import "styleguide/src/base/icons";
 
 // Base
 @import "campaigns/base/variables";


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6027

---
* These are already loaded in the master theme's CSS. Furthermore
the paths of the icons only work when the styleguide is included through
the master theme.

What happened was that the CSS rule were included a second time, but then from the styleguide in blocks. From there the svg paths don't work, causing the icons to not display. Compare the links to other countries at the end of this page with the test instance https://www.greenpeace.org/international/campaign/climate-emergency/

Deployed on https://www-dev.greenpeace.org/test-sinope/campaign/climate-emergency/ (the missing image there is due to the data sync not using the stateless URL, so unrelated to these changes but maybe something we want to look at)

