### PR TITLE
PLANET-6030 Unset 100vw width of Carousel Header in editor

### DIFF
--- a/assets/src/styles/blocks/CarouselHeaderEditorOverrides.scss
+++ b/assets/src/styles/blocks/CarouselHeaderEditorOverrides.scss
@@ -13,8 +13,14 @@
   .carousel-header_full-width-classic {
     width: unset;
 
-    .carousel-item.active {
-      position: relative !important;
+    .carousel-item {
+      .background-holder {
+        width: unset;
+      }
+
+      &.active {
+        position: relative !important;
+      }
     }
   }
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6030
---

This was increasing the editor width, pushing the sidebar off the right side of the screen.

Probably in WP 5.6 the editor overflow CSS changed. Or maybe one of ouroverrides stopped working, hard to tell what's going on.

**caveat** Does make it display not as nicely as before, but the block is converted to wysiwyg soon anyway. Removing the `100vw` width results in the text sticking to the left side of the carousel, whereas before it was centered.
Fixing it seems non trivial since a lot of factors changed. But if you know how it can be fixed we can include that.
