### PR TITLE
PLANET-4535: Happypoint is not displayed on frontend

### DIFF
--- a/classes/blocks/class-happypoint.php
+++ b/classes/blocks/class-happypoint.php
@@ -21,7 +21,7 @@ class Happypoint extends Base_Block {
 	 *
 	 * @const string BLOCK_NAME.
 	 */
-	const BLOCK_NAME = 'happy-point';
+	const BLOCK_NAME = 'happypoint';
 
 	/**
 	 * Happypoint constructor.


### PR DESCRIPTION
Related to: https://jira.greenpeace.org/browse/PLANET-4535

---

Happypoint block doesn't appear on frontend anymore (no display and no mention in the html source), because of a typo in the block name.

## Fix 

Fixing the block name to match what is registered in posts sources `<!-- wp:planet4-blocks/happypoint /-->`.

## Test

- Create a new post
- Insert a Happypoint with a background image
  - on master branch, the block appears in the editor but not in the frontend preview
  - on this branch, the block also appears on the frontend
