### PR TITLE
PLANET-5983: Simple way to save themes, some small improvements

### DIFF
--- a/assets/src/styles/components/VarPicker.scss
+++ b/assets/src/styles/components/VarPicker.scss
@@ -16,6 +16,10 @@ html.hide-wp-admin-bar {
   }
 }
 
+.server-theme {
+  background: white;
+}
+
 .server-theme-current _-- {
   background: rgba(246, 246, 89, 0.63);
 }

--- a/assets/src/styles/components/VarPicker.scss
+++ b/assets/src/styles/components/VarPicker.scss
@@ -4,6 +4,22 @@
   line-height: initial !important;
 }
 
+html.hide-wp-admin-bar {
+  margin-top: 0 !important;
+
+  #wpadminbar {
+    display: none;
+  }
+
+  nav#header {
+    top: 0;
+  }
+}
+
+.server-theme-current _-- {
+  background: rgba(246, 246, 89, 0.63);
+}
+
 .var-picker > ul {
   padding: 0;
   max-height: 80vh;

--- a/assets/src/theme/VarPicker.js
+++ b/assets/src/theme/VarPicker.js
@@ -141,7 +141,11 @@ export const VarPicker = (props) => {
 
   const [shouldGroup, setShouldGroup] = useState(true);
 
-  const [fileName, setFileName] = useState('');
+  const [fileName, setFileName] = useState(() => localStorage.getItem('p4-theme-name'));
+
+  useEffect(() => {
+    localStorage.setItem('p4-theme-name', fileName);
+  }, [fileName]);
 
   const [themesDirty, setThemesDirty] = useState(false);
 
@@ -180,7 +184,7 @@ export const VarPicker = (props) => {
         style={{textAlign: 'center', fontSize: '14px', height: '21px', marginBottom: '4px', clear: 'both'}}
       >
         {name}
-        <button
+        {name !== 'default' && <button
           style={{float: 'right'}}
           onClick={ async () => {
             if (!confirm('Delete theme from server?')) {
@@ -189,7 +193,8 @@ export const VarPicker = (props) => {
             await deleteTheme(name);
             setThemesDirty(!themesDirty);
           }}
-        >Delete</button>
+        >Delete</button>}
+
         <button
           style={{float: 'right'}}
           onClick={() => {

--- a/assets/src/theme/VarPicker.js
+++ b/assets/src/theme/VarPicker.js
@@ -180,7 +180,7 @@ export const VarPicker = (props) => {
     { !collapsed && !!serverThemes && <ul style={{maxHeight: '140px'}}>
       {Object.entries(serverThemes).map(([name, serverTheme]) => <li
         title={diffSummary(serverTheme, theme)}
-        className={fileName === name ? 'server-theme-current' : ''}
+        className={'server-theme ' + (fileName === name ? 'server-theme-current' : '')}
         style={{textAlign: 'center', fontSize: '14px', height: '21px', marginBottom: '4px', clear: 'both'}}
       >
         {name}
@@ -221,7 +221,7 @@ export const VarPicker = (props) => {
                  onChange={ event => setFileName(event.target.value) }/>
         </label>
         <button
-          title={'Share this theme on the server. For now you cannot update a theme, but you can delete and re-add it.'}
+          title={existsOnServer ? 'Save on server' : 'Upload this theme to the server. You can upload as many as you want.'}
           style={{clear: 'both'}}
           disabled={!fileName || Object.keys(theme).length === 0}
           onClick={ async () => {

--- a/assets/src/theme/VarPicker.js
+++ b/assets/src/theme/VarPicker.js
@@ -176,7 +176,8 @@ export const VarPicker = (props) => {
     { !collapsed && !!serverThemes && <ul style={{maxHeight: '140px'}}>
       {Object.entries(serverThemes).map(([name, serverTheme]) => <li
         title={diffSummary(serverTheme, theme)}
-        style={{textAlign: 'center', fontSize: '14px',height: '21px', marginBottom: '4px', clear: 'both', background: fileName === name ? 'green' : 'white'}}
+        className={fileName === name ? 'server-theme-current' : ''}
+        style={{textAlign: 'center', fontSize: '14px', height: '21px', marginBottom: '4px', clear: 'both'}}
       >
         {name}
         <button

--- a/assets/src/theme/VarPicker.js
+++ b/assets/src/theme/VarPicker.js
@@ -158,7 +158,7 @@ export const VarPicker = (props) => {
     </label> }
     { !!serverThemes && <ul>
       {Object.entries(serverThemes).map(([name, serverTheme]) => <li
-        style={{height: '32px', marginBottom: '4px', clear: 'both', background: fileName === name ? 'green' : 'white'}}
+        style={{textAlign: 'center', fontSize: '14px',height: '21px', marginBottom: '4px', clear: 'both', background: fileName === name ? 'green' : 'white'}}
       >
         {name}
         <button
@@ -197,6 +197,7 @@ export const VarPicker = (props) => {
                  onChange={ event => setFileName(event.target.value) }/>
         </label>
         <button
+          title={'Share this theme on the server. For now you cannot update a theme, but you can delete and re-add it.'}
           style={{clear: 'both'}}
           disabled={!fileName || Object.keys(theme).length === 0}
           onClick={ async () => {

--- a/assets/src/theme/VariableControl.js
+++ b/assets/src/theme/VariableControl.js
@@ -89,7 +89,7 @@ const renderShow = ({cssVar, toggleSelectors}) => <pre
 const showUsages = (cssVar, showSelectors, toggleSelectors) => {
 
   return <div
-    style={ { display: 'inline-block', fontSize: '11px', position: 'relative', marginTop: '16px' } }
+    style={ { display: 'inline-block', fontSize: '11px', position: 'relative', marginTop: '16px', minWidth: '40%' } }
   >
       <span
         key={ 3 }

--- a/assets/src/theme/VariableControl.js
+++ b/assets/src/theme/VariableControl.js
@@ -35,12 +35,13 @@ const formatTitle = (cssVar, isRepeat) => {
   </Fragment>;
 };
 
+const GRADIENT_REGEX = /linear-gradient\(.+\)/;
 const previewValue = (value, cssVar, onClick, isDefault) => {
   const size = '30px';
 
   const title = `${value}${ !isDefault ? '' : ' (default)' }`;
 
-  if (value && `${value}`.match(COLOR_VALUE_REGEX)) {
+  if (value && `${value}`.match(COLOR_VALUE_REGEX) || `${value}`.match(GRADIENT_REGEX)) {
     return <span
       key={ 1 }
       onClick={ onClick }
@@ -50,7 +51,7 @@ const previewValue = (value, cssVar, onClick, isDefault) => {
         height: size,
         border: '1px solid black',
         borderRadius: '6px',
-        backgroundColor: value,
+        background: value,
         float: 'right',
         marginTop: '7px',
       } }/>;

--- a/assets/src/theme/dragElement.js
+++ b/assets/src/theme/dragElement.js
@@ -31,7 +31,7 @@ export const dragElement = (draggedElement) => {
     if (e.altKey) {
       firstOne = false;
       setTimeout(()=> {
-        const ul = draggedElement.querySelector('div > ul');
+        const ul = draggedElement.querySelector('div > ul.group-list');
         ul.style.maxHeight = `${ maxHeight - 2  }px`;
       }, 300);
     }
@@ -66,7 +66,7 @@ export const dragElement = (draggedElement) => {
     e = e || window.event;
     e.preventDefault();
     draggedElement.classList.add('dragging')
-    const maxHeight = window.outerHeight - draggedElement.offsetTop - 210;
+    const maxHeight = window.outerHeight - draggedElement.offsetTop - 300;
     // calculate the new cursor position:
     posX1 = posX2 - e.clientX;
     posY1 = posY2 - e.clientY;
@@ -105,7 +105,7 @@ export const dragElement = (draggedElement) => {
     }
     localStorage.setItem(DRAG_KEY, JSON.stringify({ x: draggedElement.offsetLeft, y: draggedElement.offsetTop, maxHeight }));
 
-    const ul = draggedElement.querySelector('div > ul');
+    const ul = draggedElement.querySelector('div > ul.group-list');
     ul.style.maxHeight = `${ maxHeight  }px`;
   }
 

--- a/assets/src/theme/dragElement.js
+++ b/assets/src/theme/dragElement.js
@@ -1,4 +1,4 @@
-export const DRAG_KEY = 'dragThiny';
+export const DRAG_KEY = 'dragThingy';
 function detectLeftButton(event) {
   if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
     return false;
@@ -66,7 +66,7 @@ export const dragElement = (draggedElement) => {
     e = e || window.event;
     e.preventDefault();
     draggedElement.classList.add('dragging')
-    const maxHeight = window.outerHeight - draggedElement.offsetTop - 300;
+    const maxHeight = window.outerHeight - draggedElement.offsetTop - 318;
     // calculate the new cursor position:
     posX1 = posX2 - e.clientX;
     posY1 = posY2 - e.clientY;

--- a/assets/src/theme/getMatchingVars.js
+++ b/assets/src/theme/getMatchingVars.js
@@ -12,7 +12,7 @@ const matchVar = async ( cssVar, target ) => {
 
     return `${ selector }${ !shouldIncludeStar ? '' : `, ${ selector } *` }`;
     // Remove any pseudo selectors that might not match the clicked element right now.
-  } ).join().replace( allStateSelectorsRegexp, '' );
+  } ).filter(selector => !/:(before|after)/.test(selector)).join().replace( allStateSelectorsRegexp, '' );
 
 
   if ( target.matches( combinedSelector ) ) {

--- a/assets/src/theme/groupVars.js
+++ b/assets/src/theme/groupVars.js
@@ -2,7 +2,7 @@ import { getMatchingVars } from './getMatchingVars';
 
 const toLabel = element => {
   const idPart = !element.id ? '' : `#${ element.id }`;
-  const classPart = !element.className ? '' : `.${ element.className.trim().replace(/ /g, '.') }`;
+  const classPart = typeof element.className !== 'string' ? '' : `.${ element.className.trim().replace(/ /g, '.') }`;
 
   return element.tagName.toLowerCase() + idPart + classPart;
 };

--- a/assets/src/theme/initializeThemeEditor.js
+++ b/assets/src/theme/initializeThemeEditor.js
@@ -62,6 +62,7 @@ const setup = async () => {
     if (!event.altKey) {
       return;
     }
+    document.documentElement.classList.add('hide-wp-admin-bar');
     event.preventDefault();
 
     const matchedVars = await getMatchingVars({ cssVars, target: event.target });

--- a/assets/src/theme/typedControl.js
+++ b/assets/src/theme/typedControl.js
@@ -1,4 +1,4 @@
-import {  TextControl, FontSizePicker} from '@wordpress/components';
+import {  TextControl } from '@wordpress/components';
 import { SketchPicker as ColorPicker} from 'react-color';
 import tinycolor from 'tinycolor2';
 import { Fragment } from '@wordpress/element';
@@ -141,18 +141,18 @@ export const TypedControl = ({ cssVar, theme, value, onChange, dispatch }) => {
 
   if (cssVar.usages.some(usage => sizeLikeProperties.includes(usage.property))) {
     return <div>
-      <div key={ 1 }>
-        <span>px</span>
-        <FontSizePicker
+      <div key={ 1 } style={{clear: 'both'}}>
+        <input
+          type={ 'number' }
           value={ isPx(value) ? value.replace('px', '') : convertRemToPixels(parseFloat(value.replace('rem', ''))) }
-          onChange={ value => {
-            onChange(`${ value }px`);
+          onChange={ event => {
+            onChange(`${ event.currentTarget.value }px`);
           } }
           style={ { minWidth: '100px' } }
         />
+        <span>px</span>
       </div>
       <div key={ 2 }>
-        <span>rem</span>
         <input
           type={ 'number' }
           value={ isRem(value) ? value.replace('rem', '') : convertPixelsToRem(parseFloat(value.replace('px', ''))) }
@@ -161,6 +161,7 @@ export const TypedControl = ({ cssVar, theme, value, onChange, dispatch }) => {
           } }
           style={ { minWidth: '100px' } }
         />
+        <span>rem</span>
       </div>
       <TextControl
         value={ value }

--- a/assets/src/theme/typedControl.js
+++ b/assets/src/theme/typedControl.js
@@ -171,11 +171,11 @@ export const TypedControl = ({ cssVar, theme, value, onChange, dispatch }) => {
 
   if (cssVar.usages.some(usage => usage.property === 'font-family')) {
     return <Fragment>
-      <FontPicker
-        apiKey={ googleApiKey }
-        activeFontFamily={ value }
-        onChange={ value => onChange(value.family) }
-      />
+      {/*<FontPicker*/}
+      {/*  apiKey={ googleApiKey }*/}
+      {/*  activeFontFamily={ value }*/}
+      {/*  onChange={ value => onChange(value.family) }*/}
+      {/*/>*/}
       <TextControl
         value={ value }
         onChange={ onChange }

--- a/assets/src/theme/typedControl.js
+++ b/assets/src/theme/typedControl.js
@@ -55,7 +55,7 @@ export const TypedControl = ({ cssVar, theme, value, onChange, dispatch }) => {
 
   if (cssVar.usages.some(usage =>
     !!usage.property.match(/color$/)
-    || ['background'].includes(usage.property)
+    || ['background', 'fill'].includes(usage.property)
   )) {
     const colorUsages = extractColorUsages(theme);
 

--- a/assets/src/theme/typedControl.js
+++ b/assets/src/theme/typedControl.js
@@ -133,9 +133,12 @@ export const TypedControl = ({ cssVar, theme, value, onChange, dispatch }) => {
     'padding-left',
     'padding-right',
     'padding-top',
+    'width',
     'height',
     'min-width',
     'max-width',
+    'min-height',
+    'max-height',
     'letter-spacing',
   ];
 

--- a/assets/src/theme/useServerThemes.js
+++ b/assets/src/theme/useServerThemes.js
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+const uploadTheme = async (name, theme) => {
+  return wp.apiFetch({
+    path: 'planet4/v1/add-theme/',
+    method: 'POST',
+    data: {
+      name,
+      theme,
+    }
+  });
+}
+
+const deleteTheme = async (name) => {
+  return wp.apiFetch({
+    path: 'planet4/v1/delete-theme/',
+    method: 'POST',
+    data: {
+      name,
+    }
+  });
+}
+
+export const useServerThemes = () => {
+  const [serverThemes, setServerThemes] = useState([]);
+  const [dirty, setDirty] = useState(false);
+  useEffect(() => {
+    const doApiCall = async () => {
+      const themes = await wp.apiFetch({
+        path: 'planet4/v1/themes/',
+        method: 'GET',
+      });
+      setServerThemes(themes);
+    }
+    doApiCall();
+  }, [dirty]);
+
+  return {
+    serverThemes,
+    uploadTheme: async (name, theme) => {
+      await uploadTheme(name, theme);
+      setDirty(!dirty);
+    },
+    deleteTheme: async (name) => {
+      await deleteTheme(name);
+      setDirty(!dirty);
+    }
+  };
+}
+

--- a/assets/src/theme/useThemeEditor.js
+++ b/assets/src/theme/useThemeEditor.js
@@ -189,6 +189,7 @@ const ACTIONS = {
     };
   },
   LOAD_THEME: ({ defaultValues, history, theme: oldTheme }, { theme }) => {
+    dropProps(oldTheme, theme, {}, {});
     Object.keys(lastWritten).forEach(k => lastWritten[k] = null);
     Object.keys(theme).forEach(k => keysToRemove[k] = true);
 
@@ -282,7 +283,7 @@ const applyPseudoPreviews = (defaultValues, resolvedValues, previewPseudoVars) =
         k
           .replace(withoutProperty, '')
           .replace(/^-+/, '');
-      
+
       if (!lastPart.startsWith(elementState)) {
         return false;
       }

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -415,7 +415,11 @@ final class Loader {
 			self::enqueue_local_script(
 				'theme-editor',
 				'assets/build/themeEditor.js',
-				[ 'wp-components' ],
+				[
+					'wp-components',
+					'wp-url',
+					'wp-api-fetch',
+				],
 				false
 			);
 		}

--- a/classes/rest/class-rest-api.php
+++ b/classes/rest/class-rest-api.php
@@ -252,6 +252,68 @@ class Rest_Api {
 				],
 			]
 		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'add-theme',
+			[
+				[
+					'permission_callback' => static function () {
+						return is_user_logged_in();
+					},
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => static function ( WP_REST_Request $request ) {
+						$payload = $request->get_json_params();
+
+						$current_themes = json_decode( get_option( 'planet4_themes' ), true ) ?? [];
+
+						$current_themes[ $payload['name'] ] = $payload['theme'];
+						update_option( 'planet4_themes', wp_json_encode( $current_themes ) );
+
+						return new \WP_REST_Response( 'Theme added', 200 );
+					},
+				],
+			]
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'delete-theme',
+			[
+				[
+					'permission_callback' => static function () {
+						return is_user_logged_in();
+					},
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => static function ( WP_REST_Request $request ) {
+						$payload = $request->get_json_params();
+
+						$current_themes = json_decode( get_option( 'planet4_themes' ), true ) ?? [];
+						unset( $current_themes[ $payload['name'] ] );
+						update_option( 'planet4_themes', wp_json_encode( $current_themes ) );
+
+						return new \WP_REST_Response( 'Theme deleted', 200 );
+					},
+				],
+			]
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'themes',
+			[
+				[
+					'permission_callback' => static function () {
+						return true;
+					},
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => static function ( WP_REST_Request $request ) {
+						return new \WP_REST_Response( json_decode( get_option( 'planet4_themes', '[]' ) ), 200 );
+					},
+				],
+			]
+		);
+
 	}
 
 	/**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5983

---

Allow saving a created theme on the server. This is a very simple implementation using a WordPress option to store a created theme, so that it doesn't only live in the browser local storage.

Also includes some small improvements:
- Fix spacing issues
- Preserve the filename in local storage so it doesn't disappear on reload
- Make gradients also work in color previews
- Fix crash if last clicked element is an SVG (then `className` is an object)
- Hide ugly wp admin bar once theme editor is opened
- Fix broken font size control
- Ensure when loading a theme that the right properties are removed
- Replace font picker with a text field again, as it crashes when the value is not in the list of fonts.

I started adding these changes to https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/523/commits, but it got a bit too much, so I separated them to its own branch. I'll rebase that PR after this one is merged.

All of these changes should be only to the experimental theme editor, and should not affect any features used in production.