### PR TITLE
PLANET-6040 Fix articles block, Block validation error

### DIFF
--- a/assets/src/blocks/Articles/ArticlesBlock.js
+++ b/assets/src/blocks/Articles/ArticlesBlock.js
@@ -22,6 +22,7 @@ export class ArticlesBlock {
         },
         articles_description: {
           type: 'string',
+          default: ''
         },
         article_count: {
           type: 'integer',


### PR DESCRIPTION
Ref: [JIRA 6040](https://jira.greenpeace.org/browse/PLANET-6040)

---

**Issue:**
- While editing the articles block in block editor, it throws a "Block validation failed" error.

**How to reproduce?**
- Add a new articles block on page/campaign, insert “articles description” save/publish page.
- Here on page refresh, error reproduces.

The console error log shows a difference in “Content generated by `save` function” and “Content retrieved from post body”
![image](https://user-images.githubusercontent.com/5357471/115345530-9202f600-a1cc-11eb-93d3-d68d8f85b572.png)

**Fix :**
~~- Added a fix which sort attributes in `FrontendRenderOrdered.js` file.~~
- Added migration script in [other PR](https://github.com/greenpeace/planet4-master-theme/pull/1402), and as per discussion in current PR comment updated the [ArticlesBlock.js](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/546/files#diff-0310f71cfbb8cca8b0ee6794da3bd1abbc0dbac0f5d1a04d14d60ad9e2394a07R25) file.

**Note:** While testing please check for existing articles block edit functionality  🛠️ 