### PR TITLE
PLANET-5983: Properly extract vars from multiple files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1292,6 +1292,35 @@
         }
       }
     },
+    "@greenpeace/planet4-postcss-css-variables": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@greenpeace/planet4-postcss-css-variables/-/planet4-postcss-css-variables-0.2.0.tgz",
+      "integrity": "sha512-n9rzhf9DB8mJk8qH88OtqnRqYg/ZtszQzseqLtagNFKjWSL76XqYNRvyK6Zu5kMSN1H/m1xa4VHb6GpRF6rdIw==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "escape-string-regexp": "^1.0.3",
+        "extend": "^3.0.1",
+        "postcss": "^6.0.8",
+        "shallow-equal": "^1.2.1"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "@icons/material": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
@@ -4530,6 +4559,12 @@
           "requires": {
             "yallist": "^3.0.2"
           }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
@@ -9961,6 +9996,12 @@
             "strip-ansi": "^5.0.0"
           }
         },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
         "yargs": {
           "version": "13.3.2",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
@@ -12703,35 +12744,6 @@
       "requires": {
         "postcss": "^7.0.0",
         "postcss-value-parser": "^3.0.0"
-      }
-    },
-    "postcss-css-variables-extract": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-css-variables-extract/-/postcss-css-variables-extract-0.1.3.tgz",
-      "integrity": "sha512-OoF40JXG9HK4Wz2/MzlBBe4/7DeDkkwcu7Q9wTWmE8KMDCmlQBIcm+DM0/HENCkDzdAtqDuCcbVewA9ArHNATg==",
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "escape-string-regexp": "^1.0.3",
-        "extend": "^3.0.1",
-        "postcss": "^6.0.8",
-        "shallow-equal": "^1.2.1"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
       }
     },
     "postcss-discard-comments": {
@@ -15984,6 +15996,12 @@
             "source-map": "~0.6.1"
           }
         },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -16620,6 +16638,12 @@
           "requires": {
             "safe-buffer": "^5.1.1"
           }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
         }
       }
     },
@@ -17691,6 +17715,12 @@
             "strip-ansi": "^5.0.0"
           }
         },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
         "yargs": {
           "version": "13.2.4",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
@@ -17973,9 +18003,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
     "webpack-fix-style-only-entries": "^0.3.1"
   },
   "dependencies": {
+    "@greenpeace/planet4-postcss-css-variables": "^0.2.0",
     "classnames": "^2.2.6",
     "font-picker-react": "^3.5.2",
     "jest-environment-node": "^26.0.1",
     "photoswipe": "^4.1.3",
-    "postcss-css-variables-extract": "^0.1.2",
     "react-color": "^2.19.3",
     "react-hotkeys-hook": "^3.0.3",
     "tinycolor2": "^1.4.2"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,12 +5,10 @@ const TerserJSPlugin = require('terser-webpack-plugin');
 const FixStyleOnlyEntriesPlugin = require("webpack-fix-style-only-entries");
 const RemovePlugin = require('remove-files-webpack-plugin');
 const dashDash = require('@greenpeace/dashdash');
-const cssVariables = require( 'postcss-css-variables-extract' );
-const fs = require( 'fs' );
-const collectVarUsages = require( 'postcss-css-variables-extract/lib/scss-var-usages' );
-const mergeVarUsages = require( 'postcss-css-variables-extract/lib/merge-var-usages' );
+const cssVariables = require( '@greenpeace/planet4-postcss-css-variables' );
+const VariableCombinePlugin = require( '@greenpeace/planet4-postcss-css-variables/variableCombinePlugin' )
 
-let allCssVars = {};
+const allCssVars = {};
 
 const entryPoints = blockName => {
   return {
@@ -127,25 +125,7 @@ module.exports = {
         ]
       }
     }),
-    {
-      apply: ( compiler ) => {
-        compiler.hooks.done.tap( 'DoneWriteCssVars', ( ) => {
-          // We use postcss to get the selector and resolved default value. For the original file and line number
-          // we use a separate scripts which loops through all scss files. Only variables that are in the final css
-          // are included.
-          const scssUsages = collectVarUsages( './assets/src' );
-          const mergedUsages = mergeVarUsages( allCssVars, scssUsages );
-          fs.writeFile(
-            './assets/build/css-variables.json',
-            JSON.stringify( mergedUsages, null, 2 ),
-            err => !!err && console.log( err )
-          );
-          // todo: handle multiple files. The next line only works as intended if there is one style file.
-          // allCssVars = {}
-        } );
-      }
-    }
-
+    VariableCombinePlugin({filename: './assets/build/css-variables.json', allCssVars})
   ],
   optimization: {
     ...defaultConfig.optimization,


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5983

---

The previous version of this plugin didn't account for multiple entrypoints. To resolve this the new version now writes to a separate key per entrypoint.

The plugin to combine these and write the file is now also included. Before this was in both repos using this package.

This also disables extracting the variables from the source SCSS files. Nothing was done with the result yet, and probably the same can be achieved directly in the postcss plugin by ensuring the rules source is properly set.