### PR TITLE
PLANET-5983 Theme editor quick UX wins

### DIFF
--- a/assets/src/theme/dragElement.js
+++ b/assets/src/theme/dragElement.js
@@ -44,7 +44,7 @@ export const dragElement = (draggedElement) => {
     if (!detectLeftButton(e)) {
       return;
     }
-    if (e.target.matches('ul *, input')) {
+    if (e.target.matches('ul, ul *, input')) {
       return;
     }
     e = e || window.event;

--- a/assets/src/theme/groupVars.js
+++ b/assets/src/theme/groupVars.js
@@ -8,7 +8,6 @@ const toLabel = element => {
 };
 
 export const byNameStateProp = ({name: nameA},{name: nameB}) => {
-  console.log('sorting')
   const reg = /--(?<element>\w+(-?-\w+)*)(--(?<state>(active|focus|visited|hover|disabled)))?--(?<prop>\w+(-\w+)*)/;
   try {
 

--- a/assets/src/theme/typedControl.js
+++ b/assets/src/theme/typedControl.js
@@ -98,7 +98,7 @@ export const TypedControl = ({ cssVar, theme, value, onChange, dispatch }) => {
           marginRight: '5px',
           marginBottom: '2px',
           borderRadius: '6px',
-          backgroundColor: color,
+          background: color,
           display: 'inline-block',
           marginTop: '2px',
           fontSize: '8px',

--- a/assets/src/theme/typedControl.js
+++ b/assets/src/theme/typedControl.js
@@ -83,11 +83,9 @@ export const TypedControl = ({ cssVar, theme, value, onChange, dispatch }) => {
           onChange(color, true);
         } }
         onMouseEnter={ () => {
-          // console.log('enter preview span')
           dispatch({ type: THEME_ACTIONS.START_PREVIEW, payload: { name: cssVar.name, value: color } });
         }}
         onMouseLeave={ () => {
-          // console.log('exit preview span')
           dispatch({ type: THEME_ACTIONS.END_PREVIEW, payload: { name: cssVar.name } });
         }}
         title={ `${ color }\nUsed for:\n` + usages.join('\n') }

--- a/assets/src/theme/useLocalStorage.js
+++ b/assets/src/theme/useLocalStorage.js
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+export const useLocalStorage = (key, defaultValue) => {
+  const [value, setValue] = useState(() => {
+    const stored = localStorage.getItem(key);
+
+    return stored === null ? defaultValue : stored;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(key, value);
+  }, [value]);
+
+  return [
+    value,
+    setValue
+  ];
+}

--- a/assets/src/theme/useServerThemes.js
+++ b/assets/src/theme/useServerThemes.js
@@ -23,6 +23,7 @@ const deleteTheme = async (name) => {
 
 export const useServerThemes = () => {
   const [serverThemes, setServerThemes] = useState([]);
+  const [loading, setLoading] = useState(true);
   const [dirty, setDirty] = useState(false);
 
   useEffect(() => {
@@ -31,6 +32,7 @@ export const useServerThemes = () => {
         path: 'planet4/v1/themes/',
         method: 'GET',
       });
+      setLoading(false);
       setServerThemes({
         'default': {},
         ...themes,
@@ -41,11 +43,14 @@ export const useServerThemes = () => {
 
   return {
     serverThemes,
+    loading,
     uploadTheme: async (name, theme) => {
+      setLoading(true);
       await uploadTheme(name, theme);
       setDirty(!dirty);
     },
     deleteTheme: async (name) => {
+      setLoading(true);
       await deleteTheme(name);
       setDirty(!dirty);
     }

--- a/assets/src/theme/useServerThemes.js
+++ b/assets/src/theme/useServerThemes.js
@@ -24,13 +24,17 @@ const deleteTheme = async (name) => {
 export const useServerThemes = () => {
   const [serverThemes, setServerThemes] = useState([]);
   const [dirty, setDirty] = useState(false);
+
   useEffect(() => {
     const doApiCall = async () => {
       const themes = await wp.apiFetch({
         path: 'planet4/v1/themes/',
         method: 'GET',
       });
-      setServerThemes(themes);
+      setServerThemes({
+        'default': {},
+        ...themes,
+      });
     }
     doApiCall();
   }, [dirty]);


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5983

---

Some small quality of life improvements:
- Scroll the active theme into view when loading server themes
- Remove excessive `console.log`s
- Allow changing the height of server themes, save it in local storage
- Include the "default" theme by default.
- Simple loading state for server themes
- Fix color previews not working for gradients