### PR TITLE
PLANET-5983 Make CSS variables file work with WPML

### DIFF
--- a/assets/src/theme/initializeThemeEditor.js
+++ b/assets/src/theme/initializeThemeEditor.js
@@ -7,7 +7,9 @@ import { groupVars } from './groupVars';
 import { fetchJson } from '../functions/fetchJson';
 
 const setup = async () => {
-  const baseUrl = document.body.dataset.nro;
+  // Quick way to make it work with WPML. In case of NL, which doesn't have WPML, it doesn't match because without
+  // WPML there is no slash at the end...
+  const baseUrl = document.body.dataset.nro.replace(/(\/\w\w\/)$/, '');
   const blockVarsPromise = fetchJson(`${ baseUrl }/wp-content/plugins/planet4-plugin-gutenberg-blocks/assets/build/css-variables.json`);
   const themeVarsPromise = fetchJson(`${ baseUrl }/wp-content/themes/planet4-master-theme/assets/build/css-variables.json`);
   const editorRoot = document.createElement( 'div' );


### PR DESCRIPTION
Ref: <!-- Please add a url to the ticket this change is addressing. -->

---

Just a quick fix to make it usable when WPML is installed and `document.body.dataset.nro` contains the language suffix. This removes what looks like a language suffix from the end, except for NL (see comment).
