### PR TITLE
Default to "large" instead of null

### DIFF
--- a/classes/blocks/class-gallery.php
+++ b/classes/blocks/class-gallery.php
@@ -132,7 +132,7 @@ class Gallery extends Base_Block {
 
 		foreach ( $exploded_images as $image_id ) {
 			$image_size = $fields['gallery_image_size'] ?? (
-				$fields['gallery_block_style'] ? $image_sizes[ $fields['gallery_block_style'] ] : null
+				$fields['gallery_block_style'] ? $image_sizes[ $fields['gallery_block_style'] ] : 'large'
 			);
 
 			$image_data = [];


### PR DESCRIPTION
* ~~Otherwise no srcset is used, so the browser loads a bigger image.~~ I was wrong, turned out to work as intended. The problem was missing image size data.

Ref: <!-- Please add a url to the ticket this change is addressing. -->

---

<!--
Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
