### PR TITLE
No ticket - Fix Table block placeholder

### DIFF
--- a/assets/src/styles/blocks/core-overrides/TableEditor.scss
+++ b/assets/src/styles/blocks/core-overrides/TableEditor.scss
@@ -1,0 +1,3 @@
+.blocks-table__placeholder-form {
+  flex-direction: row !important;
+}

--- a/assets/src/styles/editorStyle.scss
+++ b/assets/src/styles/editorStyle.scss
@@ -20,6 +20,7 @@
 @import "blocks/SplitTwoColumnsEditor";
 @import "blocks/SubmenuEditor";
 @import "blocks/HappypointEditor";
+@import "blocks/core-overrides/TableEditor";
 
 @import "components/LayoutSelector";
 @import "components/EmptyMessage";


### PR DESCRIPTION
### Description

I'm not sure where this change came from and when (it's not from us, seems to be from WP's core files) but there is now `    flex-direction: column;` added to this placeholder and it looks weird. So this PR just makes a quick fix for it!

- Broken:
<img width="1052" alt="Screenshot 2021-04-14 at 14 08 33" src="https://user-images.githubusercontent.com/6949075/114709634-208af980-9d2d-11eb-912f-98f86591464f.png">

- Fixed:
<img width="713" alt="Screenshot 2021-04-14 at 14 14 49" src="https://user-images.githubusercontent.com/6949075/114709656-27b20780-9d2d-11eb-951c-84379fdf0df7.png">
