### PR TITLE
PLANET-6080 Move fonts out of CSS file

### DIFF
--- a/assets/src/styles/campaigns/base/_fonts.scss
+++ b/assets/src/styles/campaigns/base/_fonts.scss
@@ -35,9 +35,3 @@
   font-weight: bold;
   font-style: italic;
 }
-
-@import url("https://fonts.googleapis.com/css?family=Montserrat:300,400,500,600,700,800");
-@import url("https://fonts.googleapis.com/css?family=Kanit:400,500,600,800");
-@import url("https://fonts.googleapis.com/css?family=Open+Sans:400,500,600,800");
-@import url("https://fonts.googleapis.com/css?family=Anton:400,500,600,800");
-@import url("https://fonts.googleapis.com/css?family=Amiko:400,500,600,800");

--- a/assets/src/styles/campaigns/base/_google_fonts.scss
+++ b/assets/src/styles/campaigns/base/_google_fonts.scss
@@ -1,0 +1,5 @@
+@import url("https://fonts.googleapis.com/css?family=Montserrat:300,400,500,600,700,800");
+@import url("https://fonts.googleapis.com/css?family=Kanit:400,500,600,800");
+@import url("https://fonts.googleapis.com/css?family=Open+Sans:400,500,600,800");
+@import url("https://fonts.googleapis.com/css?family=Anton:400,500,600,800");
+@import url("https://fonts.googleapis.com/css?family=Amiko:400,500,600,800");

--- a/assets/src/styles/editorStyle.scss
+++ b/assets/src/styles/editorStyle.scss
@@ -26,6 +26,7 @@
 @import "components/Preview";
 @import "components/CharacterCounter";
 @import "campaigns/base/fonts";
+@import "campaigns/base/google_fonts";
 @import "components/FormSectionTitle";
 @import "components/FormHelp";
 @import "components/InlineFormFeedback";


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6080

---
* Moved to [HTML head in the theme](https://github.com/greenpeace/planet4-master-theme/pull/1364/files#diff-a40ff5ae673d9e734e86aef984e9588608dee8d8e31ee3da3a1a5b845101ea3cR3-R5), so that Cloudflare can optimize them.
* Preserve in a separate file so the editor can still load them.

