### PR TITLE
add bullets in jsx with aria-hidden to article preview

### DIFF
--- a/assets/src/blocks/Articles/ArticlePreview.js
+++ b/assets/src/blocks/Articles/ArticlePreview.js
@@ -41,16 +41,13 @@ export class ArticlePreview extends Component {
 
     if (authorName) {
       return (
-        <>
-          <span className="article-list-item-author">
-            {!isLink ?
-              authorName
-              :
-              <a href={authorLink}>{authorName}</a>
-            }
-          </span>
-          <span className="article-list-item-bullet" aria-hidden="true">&#8226;</span>
-        </>
+        <span className="article-list-item-author">
+          {!isLink ?
+            authorName
+            :
+            <a href={authorLink}>{authorName}</a>
+          }
+        </span>
       );
     }
   }
@@ -110,6 +107,7 @@ export class ArticlePreview extends Component {
     } = this.props;
 
     const articleClassName = tags.reduce((classname, tag) => classname + ` tag-${tag.slug}`, 'article-list-item');
+    const authorLink = this.getAuthorLink()
 
     return (
       <article className={articleClassName} >
@@ -121,7 +119,9 @@ export class ArticlePreview extends Component {
                 this.getPageTypesTags(page_type, page_type_link)
               }
 
-              <span className="tag-wrap-bullet" aria-hidden="true">&#8226;</span>
+              {(tags.length > 0 && page_type) && (
+                <span className="tag-wrap-bullet" aria-hidden="true">&#8226;</span>
+              )}
 
               {tags.length > 0 &&
                 <div className="tag-wrap tags">
@@ -155,7 +155,12 @@ export class ArticlePreview extends Component {
               </h4>
             }
             <p className="article-list-item-meta">
-              {this.getAuthorLink()}
+              {authorLink}
+
+              {(authorLink && date_formatted) && (
+                <span className="article-list-item-bullet" aria-hidden="true">&#8226;</span>
+              )}
+
               {date_formatted &&
               <time className="article-list-item-date" dateTime="">
                 {date_formatted}

--- a/assets/src/blocks/Articles/ArticlePreview.js
+++ b/assets/src/blocks/Articles/ArticlePreview.js
@@ -41,13 +41,16 @@ export class ArticlePreview extends Component {
 
     if (authorName) {
       return (
-        <span className="article-list-item-author">
-          {!isLink ?
-            authorName
-            :
-            <a href={authorLink}>{authorName}</a>
-          }
-        </span>
+        <>
+          <span className="article-list-item-author">
+            {!isLink ?
+              authorName
+              :
+              <a href={authorLink}>{authorName}</a>
+            }
+          </span>
+          <span className="article-list-item-bullet" aria-hidden="true">&#8226;</span>
+        </>
       );
     }
   }
@@ -117,6 +120,8 @@ export class ArticlePreview extends Component {
               {page_type &&
                 this.getPageTypesTags(page_type, page_type_link)
               }
+
+              <span className="tag-wrap-bullet" aria-hidden="true">&#8226;</span>
 
               {tags.length > 0 &&
                 <div className="tag-wrap tags">

--- a/assets/src/styles/blocks/Articles.scss
+++ b/assets/src/styles/blocks/Articles.scss
@@ -106,12 +106,9 @@
   }
 }
 
-.article-list-item-author {
-  &:after {
-    content: "\2022";
-    display: inline-block;
-    padding: 0 3px 0 $n5;
-  }
+.article-list-item-bullet {
+  display: inline-block;
+  padding: 0 3px 0 $n5;
 }
 
 .article-list-item-content {


### PR DESCRIPTION
Ref: 2/2 of https://github.com/greenpeace/planet4/issues/114

Sibling PR: https://github.com/greenpeace/planet4-master-theme/pull/1367


## Description

1. Add the bullets into the ArticlePreview component so that we can hide them from the screenreader (tested on MacOS VoiceOver) ✅

2. Hide the `#` that appears in the ArticlePreview component from the screenreader ⁉️
    - I wanted to push back on this one a little bit. It seems that we are already marking this symbol with the `aria-label="hashtag"` which seems appropriate for the screenreader to read. Not totally against removing it, but wanted to double check that we really _do_ want to remove it first.
    
## Potential Issues

None that I can see


## Screenshot

![Screen Shot 2021-04-15 at 5 18 09 PM](https://user-images.githubusercontent.com/10778294/115069217-1c371b80-9ea8-11eb-897f-ef79e518f4a1.png)

---

<!--
Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
