### PR TITLE
PLANET-6072 Fix Sentry issue: PLANET4-RS

### DIFF
--- a/classes/blocks/class-spreadsheet.php
+++ b/classes/blocks/class-spreadsheet.php
@@ -73,6 +73,13 @@ class Spreadsheet extends Base_Block {
 
 		$url = "https://docs.google.com/spreadsheets/d/e/${sheet_id}/pub?output=csv";
 
+		$headers = get_headers( $url );
+
+		// Handle 500, 404 errors.
+		if ( ! $headers || strpos( $headers[0], '500' ) || strpos( $headers[0], '404' ) ) {
+			return null;
+		}
+
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
 		$handle = fopen( $url, 'rb' );
 


### PR DESCRIPTION
Ref: [JIRA 6072](https://jira.greenpeace.org/browse/PLANET-6072)

---

Fix Sentry error : [PLANET4-RS](https://sentry.greenpeace.org/greenpeace/planet4/issues/1564/)

`Warning: fopen(https://docs.google.com/spreadsheets/d/e/2PACX-1vR2LTvb__ifqY0ayZzqWyzkJGPyMUyUvili9YotHs_1YymJqjSeECFImhzlJfN3k9xw0CVBwR4HuTOg/pub?output=csv): failed to open stream: HTTP request failed! HTTP/1.0 500 Internal Server Error`
