### PR TITLE
Improve ordering and exclude bootstrap variables

### DIFF
--- a/assets/src/theme/getMatchingVars.js
+++ b/assets/src/theme/getMatchingVars.js
@@ -22,10 +22,19 @@ const matchVar = async ( cssVar, target ) => {
   return [];
 };
 
+const excludedVars = [
+  '--bs-gutter-x',
+  '--bs-gutter-y',
+  '--bs-font-sans-serif',
+  '--bs-font-monospace',
+  '--bs-aspect-ratio',
+  '--bs-gradient',
+];
+
 export const getMatchingVars = async ( { cssVars, target } ) => {
 
   const uniqueVars = cssVars.reduce( ( carry, cssVar ) => {
-    if ( !carry.some( collected => collected.name === cssVar.name ) ) {
+    if (!excludedVars.includes(cssVar.name) && !carry.some(collected => collected.name === cssVar.name)) {
       carry.push( cssVar );
     }
     return carry;

--- a/assets/src/theme/groupVars.js
+++ b/assets/src/theme/groupVars.js
@@ -14,13 +14,14 @@ export const byNameStateProp = ({name: nameA},{name: nameB}) => {
     const {element: elementA, state: stateA, prop: propA } = nameA.match(reg).groups;
     const {element: elementB, state: stateB, prop: propB } = nameB.match(reg).groups;
 
+    if (propA !== propB) {
+      return propA < propB ? -1 : 1;
+    }
     if (elementA !== elementB) {
       return elementA < elementB ? -1 : 1;
     }
-    if (stateA !== stateB) {
-      return stateA < stateB ? -1 : 1;
-    }
-    return propA < propB ? -1 : 1;
+
+    return stateA < stateB ? -1 : 1;
   } catch (e) {
     console.log(e)
     console.log('A', nameA, 'B', nameB);


### PR DESCRIPTION
Ref: <!-- Please add a url to the ticket this change is addressing. -->

---

Bootstrap variables mostly have no effect for us, and the selectors match a lot of elements. For now it's better to exclude them.

Sort by property name first instead of last, which makes it easier to find things in the list.

Previous ordering:
<img src="https://user-images.githubusercontent.com/7604138/115561485-ea61f280-a2b5-11eb-8c8b-96c0420cbf78.png" width="200">

New ordering:
<img src="https://user-images.githubusercontent.com/7604138/115561513-f2ba2d80-a2b5-11eb-9fa4-b4000af6b1ac.png" width="200">
