### PR TITLE
Responsive theme editor

### DIFF
--- a/assets/src/styles/components/VarPicker.scss
+++ b/assets/src/styles/components/VarPicker.scss
@@ -1,7 +1,50 @@
+html,
+body {
+  scroll-behavior: auto !important;
+}
+
 .var-picker * {
   font-family: Roboto, sans-serif !important;
   color: black !important;
   line-height: initial !important;
+}
+
+.simulating-touch-device body {
+  &::-webkit-scrollbar {
+    width: 9px;
+  }
+
+  &::-webkit-scrollbar-track {
+    border-radius: 5px;
+    background: rgba(140, 140, 140, 0.2);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 5px;
+    background: rgba(140, 140, 140, 0.4);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: rgba(140, 140, 140, 0.5);
+  }
+
+  &::-webkit-scrollbar-thumb:window-inactive {
+    background: rgba(140, 140, 140, 0.05);
+  }
+}
+
+.responsive-frame-container {
+  transform-origin: 0 0;
+}
+
+.responsive-frame-container::-webkit-scrollbar {
+  color: transparent;
+  background-color: transparent;
+}
+
+.responsive-frame-container::-webkit-resizer {
+  color: green;
+  background-color: green;
 }
 
 html.hide-wp-admin-bar {

--- a/assets/src/styles/components/VarPicker.scss
+++ b/assets/src/styles/components/VarPicker.scss
@@ -3,6 +3,13 @@ body {
   scroll-behavior: auto !important;
 }
 
+.theme-length-controls {
+  input _-- {
+    margin-right: 5px;
+    text-align: right;
+  }
+}
+
 .var-picker * {
   font-family: Roboto, sans-serif !important;
   color: black !important;

--- a/assets/src/theme/ResizableFrame.js
+++ b/assets/src/theme/ResizableFrame.js
@@ -1,0 +1,152 @@
+import { Fragment, createPortal } from '@wordpress/element';
+import { useEffect } from 'react';
+import { RadioControl, RangeControl } from '@wordpress/components';
+import { useLocalStorage } from './useLocalStorage';
+
+const screenOptions = [
+  { dims: [360, 640], label: 'Phone' },
+  { dims: [360, 780], label: 'Apple iPhone 12 mini' },
+  { dims: [390, 844], label: 'Apple iPhone 12 Pro', },
+  { dims: [768, 1024], label: 'Tablet Portrait' },
+  { dims: [1024, 768], label: 'Tablet Landscape' },
+  { dims: [1366, 768], label: 'Laptop Small' },
+  { dims: [1440, 900], label: 'Laptop Medium' },
+  { dims: [1536, 864], label: 'Laptop Wide' },
+  { dims: [1920, 1080], label: 'Full HD' },
+  { dims: [2560, 1080], label: 'Ultrawide HD' },
+  { dims: [2560, 1440], label: 'UHD' },
+  { dims: [3440, 1440], label: 'Ultrawide UHD' },
+  { dims: [3840, 2160], label: '4K' },
+].map(({ dims, label }) => ({
+  label: `${label} (${dims.join(' x ')})`,
+  value: dims.join(),
+}));
+
+const wrapperMargin = 28;
+
+export const ResizableFrame = props => {
+  const {
+    src,
+  } = props;
+
+  const [
+    width,
+    setWidth,
+  ] = useLocalStorage('responsive-width', 360);
+  const [
+    height,
+    setHeight,
+  ] = useLocalStorage('responsive-height', 640);
+  const [
+    scale,
+    setScale,
+  ] = useLocalStorage('responsive-scale', 1);
+
+  useEffect(() => {
+    const orig = document.body.style.maxHeight;
+    const scrollPosition = window.pageYOffset;
+    document.body.style.top = `-${ scrollPosition }px`;
+    document.body.style.postition = 'sticky';
+    document.body.style.maxHeight = '100vh';
+
+    return () => {
+      document.body.style.maxHeight = orig;
+      document.body.style.position = 'static';
+      document.body.style.top = 0;
+      window.scrollTo(0, scrollPosition);
+      window.scrollTo({
+        top: scrollPosition,
+        behavior: 'auto'
+      });
+
+    }
+  }, [])
+
+  return createPortal(<Fragment>
+    <div
+      className="responsive-overlay"
+      style={ {
+        zIndex: 999,
+        background: 'grey',
+        opacity: 0.99,
+        position: 'fixed',
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+      } }
+    />
+    <div
+      style={ {
+        position: 'fixed',
+        top: '8px',
+        left: '400px',
+        zIndex: 1000,
+      } }
+    >
+      <RangeControl
+        value={scale}
+        onChange={ value => setScale(value) }
+        min={.2}
+        max={1}
+        step={.02}
+        initialPosition={scale}
+      />
+      <span>Dimensions: <input
+        type="number" onChange={ event => setWidth(parseInt(event.target.value)) } value={ width }
+      /> x <input
+        type="number" onChange={ event => setHeight(parseInt(event.target.value)) } value={ height }
+      /></span>
+    </div>
+
+    <div style={{
+      zIndex: 1000,
+      position: 'fixed',
+      top: '20px',
+      right: '100px',
+    }}>
+      <RadioControl
+        options={ screenOptions }
+        selected={ [width, height].join() }
+        onChange={ value => {
+          const [newWidth, newHeight] = value.split(',');
+          setWidth(parseInt(newWidth));
+          setHeight(parseInt(newHeight));
+        } }
+      />
+    </div>
+
+    <div
+      className='responsive-frame-container'
+      onMouseMove={ (event) => {
+        if (event.buttons !== 1 || event.currentTarget.className !== 'responsive-frame-container') {
+          return;
+        }
+        const newHeight = parseInt(event.currentTarget.style.height.replace('px', ''));
+        const newWidth = parseInt(event.currentTarget.style.width.replace('px', ''));
+        setHeight(newHeight - wrapperMargin);
+        setWidth(newWidth - wrapperMargin);
+      } }
+      style={ {
+        transform: `scale(${scale})`,
+        position: 'fixed',
+        top: '100px',
+        left: '400px',
+        zIndex: 1000,
+        resize: 'both',
+        overflow: 'scroll',
+        minWidth: '200px',
+        width: `${ wrapperMargin + parseInt(width) }px`,
+        minHeight: '200px',
+        height: `${ wrapperMargin + parseInt(height) }px`,
+        padding: '0',
+        boxSizing: 'border-box',
+      } }
+    >
+      <iframe
+        className='responsive-frame'
+        { ...{ src, width: parseInt(width) + 12, height: parseInt(height + 12) } }
+      />
+    </div>
+  </Fragment>, document.body);
+};

--- a/assets/src/theme/ResizableFrame.js
+++ b/assets/src/theme/ResizableFrame.js
@@ -145,7 +145,7 @@ export const ResizableFrame = props => {
     >
       <iframe
         className='responsive-frame'
-        { ...{ src, width: parseInt(width) + 12, height: parseInt(height + 12) } }
+        { ...{ src, width: parseInt(width) + 12, height: parseInt(height) + 12 } }
       />
     </div>
   </Fragment>, document.body);

--- a/assets/src/theme/VarPicker.js
+++ b/assets/src/theme/VarPicker.js
@@ -9,6 +9,10 @@ import { useToggle } from './useToggle';
 import { ResizableFrame } from './ResizableFrame';
 import { useHotkeys } from 'react-hotkeys-hook';
 
+const hotkeysOptions = {
+  enableOnTags: ['INPUT'],
+}
+
 export const LOCAL_STORAGE_KEY = 'p4-theme';
 
 const byName = (a, b) => a.name > b.name ? 1 : (a.name === b.name ? 0 : -1);
@@ -127,10 +131,13 @@ export const VarPicker = (props) => {
   }, [serverThemes])
 
   const existsOnServer = serverThemes && Object.keys(serverThemes).some(t => t === fileName);
+  const modifiedServerVersion = existsOnServer && diffThemes(serverThemes[fileName], theme).hasChanges;
 
-  const modifiedServerVersion = fileName
-    && serverThemes[fileName]
-    && diffThemes(serverThemes[fileName], theme).hasChanges
+  useHotkeys('alt+s', () => {
+    if (fileName && fileName !== 'default' && modifiedServerVersion) {
+      uploadTheme(fileName, theme);
+    }
+  },hotkeysOptions, [fileName, modifiedServerVersion, theme]);
 
   return <div
     className='var-picker'

--- a/assets/src/theme/VarPicker.js
+++ b/assets/src/theme/VarPicker.js
@@ -5,6 +5,9 @@ import { whileHoverHighlight } from './highlight';
 import { exportCss, exportJson } from './export';
 import { useServerThemes } from './useServerThemes';
 import { useLocalStorage } from './useLocalStorage';
+import { useToggle } from './useToggle';
+import { ResizableFrame } from './ResizableFrame';
+import { useHotkeys } from 'react-hotkeys-hook';
 
 export const LOCAL_STORAGE_KEY = 'p4-theme';
 
@@ -87,39 +90,28 @@ export const VarPicker = (props) => {
     {
       theme,
       defaultValues,
-      hasHistory,
-      hasFuture,
     },
     dispatch,
   ] = useThemeEditor(config);
 
-  const setProperty = (name, value) => {
-    dispatch({ type: THEME_ACTIONS.SET, payload: { name, value } });
-  };
-
-  const unsetProperty = (name) => {
-    dispatch({ type: THEME_ACTIONS.UNSET, payload: { name } });
-  };
-
-  const [collapsed, setCollapsed] = useState(false);
-  const toggleCollapsed = () => {
-    setCollapsed(!collapsed);
-  };
+  const [collapsed, toggleCollapsed] = useToggle(false);
 
   const [shouldGroup, setShouldGroup] = useState(true);
 
   const [fileName, setFileName] = useLocalStorage('p4-theme-name', 'theme');
 
+  const [storedIsResponsive, setResponsive] = useLocalStorage('p4-theme-responsive', false);
+
+  const isResponsive = !!storedIsResponsive && storedIsResponsive !== 'false';
+
+  useHotkeys('alt+v', () => {
+    setResponsive(!isResponsive);
+  }, [isResponsive]);
+
   const [
     serverThemesHeight,
     setServerThemesHeight
   ] = useLocalStorage('p4-theme-server-theme-height-list', '140px');
-
-  useEffect(() => {
-    localStorage.setItem('p4-theme-name', fileName);
-  }, [fileName]);
-
-  const activeThemeRef = useRef();
 
   const {
     serverThemes,
@@ -127,6 +119,8 @@ export const VarPicker = (props) => {
     uploadTheme,
     deleteTheme,
   } = useServerThemes();
+
+  const activeThemeRef = useRef();
 
   useEffect(() => {
     activeThemeRef?.current?.scrollIntoView();
@@ -141,7 +135,8 @@ export const VarPicker = (props) => {
   return <div
     className='var-picker'
   >
-      <span
+    {!!isResponsive && <ResizableFrame src={window.location.href} />}
+    <span
         style={ {
           fontSize: '10px',
           border: '1px solid grey',
@@ -154,13 +149,32 @@ export const VarPicker = (props) => {
       >
         { collapsed ? 'show' : 'hide' }
     </span>
+    <input
+      type="checkbox"
+      readOnly
+      checked={ shouldGroup }
+      onClick={ () => { setShouldGroup(!shouldGroup); } }
+    />
     { !collapsed && <label
-      htmlFor=""
       onClick={ () => setShouldGroup(!shouldGroup) }
       style={ { marginBottom: '2px' } }
     >
-      <input type="checkbox" readOnly checked={ shouldGroup }/>
       { 'Group last clicked element' }
+    </label> }
+    <br/>
+    <input
+      type="checkbox"
+      readOnly
+      checked={ isResponsive }
+      onClick={ () => { setResponsive(!isResponsive); } }
+    />
+    { !collapsed && <label
+      onClick={ () => {
+        setResponsive(!isResponsive);
+      } }
+      style={ { marginBottom: '2px' } }
+    >
+      { 'Responsive view' }
     </label> }
     { !collapsed && serverThemesLoading && <span>Loading server themes...</span> }
     { !collapsed && !!serverThemes && !serverThemesLoading && <ul
@@ -198,6 +212,7 @@ export const VarPicker = (props) => {
         >Switch</button>
       </li>)}
     </ul>}
+
     { !collapsed && <div
       title='Click and hold to drag'
       className="themer-controls">
@@ -230,7 +245,6 @@ export const VarPicker = (props) => {
       </div>
       <div>
         <label
-          // Only tested on Chrome
           style={ {
             display: 'inline-block',
             maxWidth: '33%',
@@ -259,7 +273,8 @@ export const VarPicker = (props) => {
         </label>
       </div>
     </div> }
-    { shouldGroup && !collapsed && <ul className={'group-list'}>
+
+    { !collapsed && shouldGroup && <ul className={'group-list'}>
       { groups.map(({ element, label, vars }) => (
         <li className={ 'var-group' } key={ label } style={ { marginBottom: '12px' } }>
           <h4
@@ -281,10 +296,12 @@ export const VarPicker = (props) => {
                     dispatch,
                   } }
                   key={ cssVar.name }
-                  onChange={ (value) => {
-                    setProperty(cssVar.name, value);
+                  onChange={ value => {
+                    dispatch({ type: THEME_ACTIONS.SET, payload: { name: cssVar.name, value } });
                   } }
-                  onUnset={ () => unsetProperty(cssVar.name) }
+                  onUnset={ () => {
+                    dispatch({ type: THEME_ACTIONS.UNSET, payload: { name: cssVar.name } });
+                  } }
                 />;
               }
             ) }
@@ -293,7 +310,7 @@ export const VarPicker = (props) => {
       )) }
     </ul> }
 
-    { !shouldGroup && !collapsed && <ul>
+    { !collapsed && !shouldGroup && <ul>
       <span>
         showing { activeVars.length } propert{ activeVars.length === 1 ? 'y' : 'ies' }
       </span>
@@ -313,9 +330,9 @@ export const VarPicker = (props) => {
             }
             }
             key={ cssVar.name }
-            onUnset={ () => unsetProperty(cssVar.name) }
+            onUnset={ () => dispatch({ type: THEME_ACTIONS.UNSET, payload: { name: cssVar.name } }) }
             onCloseClick={ deactivate }
-            onChange={ value => setProperty(cssVar.name, value) }
+            onChange={ value => dispatch({ type: THEME_ACTIONS.SET, payload: { name: cssVar.name, value } }) }
           />;
         }
       ) }

--- a/assets/src/theme/VariableControl.js
+++ b/assets/src/theme/VariableControl.js
@@ -1,7 +1,7 @@
 import { useState} from 'react';
 import { Fragment} from '@wordpress/element';
 import { COLOR_VALUE_REGEX, TypedControl } from './typedControl';
-import { IconButton } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { PSEUDO_REGEX, THEME_ACTIONS} from './useThemeEditor';
 import classnames from 'classnames';
 
@@ -134,7 +134,6 @@ export const VariableControl = (props) => {
   ] = useState(false);
 
   const toggleSelectors = () => setShowSelectors(!showSelectors)
-  // The theme ensures that if the property is not returned, it can be safely read from the window.
   const value = theme[cssVar.name] || defaultValue;
   const isDefault = value === defaultValue;
 
@@ -151,11 +150,19 @@ export const VariableControl = (props) => {
       cursor: isOpen ? 'auto' : 'pointer',
     } }
   >
-    { !!onCloseClick && <IconButton
-      icon={ 'minus' }
-      style={ { float: 'right', height: '29px' } }
-      onClick={ () => onCloseClick(cssVar) }
-    /> }
+    { !!onCloseClick && <Button
+      style={ {
+        float: 'right',
+        borderRadius: '7px',
+        marginTop: '9px',
+        marginLeft: '9px',
+        padding: '3px 10px',
+        height: '29px',
+        fontSize: '32px',
+        border: '1px solid black'
+      } }
+      title='Close'
+      onClick={ () => onCloseClick(cssVar) }>-</Button> }
     { previewValue(value, cssVar, toggleOpen, isDefault) }
     <h5
       style={ {  fontSize: '16px', padding: '2px 4px 0', fontWeight: '400', userSelect: 'none', cursor: 'pointer' } }
@@ -165,16 +172,18 @@ export const VariableControl = (props) => {
     </h5>
     { isOpen && (
       <div
-        onMouseEnter={()=> {
-          if (PSEUDO_REGEX.test(cssVar.name)) {
-            dispatch({type: THEME_ACTIONS.START_PREVIEW_PSEUDO_STATE, payload: {name: cssVar.name}});
-          }
-        }}
-        onMouseLeave={()=> {
-          if (PSEUDO_REGEX.test(cssVar.name)) {
-            dispatch({type: THEME_ACTIONS.END_PREVIEW_PSEUDO_STATE, payload: {name: cssVar.name}})
-          }
-        }}
+        onMouseEnter={ () => {
+          PSEUDO_REGEX.test(cssVar.name) && dispatch({
+            type: THEME_ACTIONS.START_PREVIEW_PSEUDO_STATE,
+            payload: { name: cssVar.name }
+          });
+        } }
+        onMouseLeave={ () => {
+          PSEUDO_REGEX.test(cssVar.name) && dispatch({
+            type: THEME_ACTIONS.END_PREVIEW_PSEUDO_STATE,
+            payload: { name: cssVar.name }
+          });
+        } }
       >
         <div>{cssVar.name}</div>
         { showUsages(cssVar, showSelectors,toggleSelectors) }

--- a/assets/src/theme/VariableControl.js
+++ b/assets/src/theme/VariableControl.js
@@ -131,7 +131,7 @@ export const VariableControl = (props) => {
 
   const [
     showSelectors, setShowSelectors
-  ] = useState(false);
+  ] = useState(true);
 
   const toggleSelectors = () => setShowSelectors(!showSelectors)
   const value = theme[cssVar.name] || defaultValue;

--- a/assets/src/theme/getMatchingVars.js
+++ b/assets/src/theme/getMatchingVars.js
@@ -47,7 +47,7 @@ export const getMatchingVars = async ( { cssVars, target } ) => {
 
   const results = await Promise.allSettled( promises );
 
-  results.filter( wasRejected ).forEach( console.log );
+  // results.filter( wasRejected ).forEach( console.log );
 
   const arrays = results.filter( wasFulfilled ).map( result => result.value );
 

--- a/assets/src/theme/highlight.js
+++ b/assets/src/theme/highlight.js
@@ -1,6 +1,6 @@
 const HIGHLIGHT_CLASS = 'theme-editor-highlight';
-export const addHighlight = element => element.classList.add(HIGHLIGHT_CLASS);
-export const removeHighlight = element => element.classList.remove(HIGHLIGHT_CLASS);
+export const addHighlight = element => !!element && element.classList.add(HIGHLIGHT_CLASS);
+export const removeHighlight = element => !!element && element.classList.remove(HIGHLIGHT_CLASS);
 
 export const whileHoverHighlight = element => ({
   onMouseEnter: () => addHighlight(element),

--- a/assets/src/theme/initializeThemeEditor.js
+++ b/assets/src/theme/initializeThemeEditor.js
@@ -6,38 +6,80 @@ import { addHighlight, removeHighlight } from './highlight';
 import { groupVars } from './groupVars';
 import { extractPageVariables } from './extractPageVariables';
 
-const setup = async () => {
-  const editorRoot = document.createElement( 'div' );
-  editorRoot.id = 'theme-editor-root';
-  document.body.appendChild( editorRoot );
-  dragElement( editorRoot );
-  const storedLocation = localStorage.getItem(DRAG_KEY);
-  try {
-    const {x,y} = JSON.parse(storedLocation);
-    if (x) {
-      const maxX = window.outerWidth - 300;
-      editorRoot.style.left = `${ Math.min(x, maxX) }px`;
-    }
-    if (y) {
-      const maxY = window.outerHeight - 300;
-      editorRoot.style.top = `${ Math.min(y, maxY) }px`;
-    }
-  } catch (e) {
-    console.log('No position found in local storage', e)
+const isRunningAsFrame = window.self !== window.top;
+
+const lastRead = {};
+
+const applyFromLocalStorage = (key) => {
+  let storedVars;
+  const json = localStorage.getItem( key );
+
+  if (lastRead[key] === json) {
+    return;
   }
 
-  const json = localStorage.getItem( LOCAL_STORAGE_KEY );
   try {
-    const storedVars = JSON.parse(json);
-
-    if (storedVars) {
-      Object.keys(storedVars).forEach(name => {
-        const value = storedVars[name];
-        document.documentElement.style.setProperty(name, value);
-      });
-    }
+    storedVars = JSON.parse(json);
   } catch (e) {
     console.log(json);
+  }
+
+  if (!storedVars) {
+    return;
+  }
+
+  Object.keys(storedVars).forEach(name => {
+    const value = storedVars[name];
+    document.documentElement.style.setProperty(name, value);
+  });
+
+  const customProps = Object.entries(document.documentElement.style).filter(([, k]) => {
+    return !!('string' === typeof k && k.match(/^--/));
+  });
+
+  customProps.forEach(([, k]) => {
+    if (!Object.keys(storedVars).includes(k)) {
+      document.documentElement.style.removeProperty(k);
+    }
+  });
+  lastRead[key] = json;
+}
+
+const setup = async () => {
+  applyFromLocalStorage(LOCAL_STORAGE_KEY);
+
+  if (isRunningAsFrame) {
+    document.documentElement.classList.add('simulating-touch-device');
+    document.documentElement.classList.add('hide-wp-admin-bar');
+    const refreshLoop = () => {
+      applyFromLocalStorage('theme-with-previews');
+    }
+    const fps = 60;
+    setInterval(refreshLoop, 1000 / 60);
+  }
+
+  // Quick way to make it work with WPML. In case of NL, which doesn't have WPML, it doesn't match because without
+  // WPML there is no slash at the end...
+  const editorRoot = document.createElement( 'div' );
+
+  if (!isRunningAsFrame) {
+    editorRoot.id = 'theme-editor-root';
+    document.body.appendChild( editorRoot );
+    dragElement( editorRoot );
+    const storedLocation = localStorage.getItem(DRAG_KEY);
+    try {
+      const {x,y} = JSON.parse(storedLocation);
+      if (x) {
+        const maxX = window.outerWidth - 300;
+        editorRoot.style.left = `${ Math.min(x, maxX) }px`;
+      }
+      if (y) {
+        const maxY = window.outerHeight - 300;
+        editorRoot.style.top = `${ Math.min(y, maxY) }px`;
+      }
+    } catch (e) {
+      console.log('No position found in local storage', e)
+    }
   }
 
   const allVars = extractPageVariables();
@@ -51,6 +93,15 @@ const setup = async () => {
     ),
   ], []);
 
+  window.addEventListener('message', event => {
+    const { type, payload } = event.data;
+    if (type !== 'render-vars') {
+      return;
+    }
+    renderSelectedVars(editorRoot, payload.matchedVars, null, payload.groups, cssVars);
+
+  }, false);
+
   document.addEventListener('click', async event => {
     if (!event.altKey) {
       return;
@@ -62,7 +113,19 @@ const setup = async () => {
 
     const groups = await groupVars(matchedVars, event.target);
 
-    renderSelectedVars(editorRoot, matchedVars, event.target, groups, cssVars);
+    if (isRunningAsFrame) {
+      window.parent.postMessage(
+        {
+          type: 'render-vars', payload: {
+            matchedVars,
+            groups: groups.map(({ element, ...rest }) => rest),
+          }
+        },
+        window.location.href,
+      );
+    } else {
+      renderSelectedVars(editorRoot, matchedVars, event.target, groups, cssVars);
+    }
 
     addHighlight(event.target);
     setTimeout(() => removeHighlight(event.target), 700);

--- a/assets/src/theme/renderSelectedVars.js
+++ b/assets/src/theme/renderSelectedVars.js
@@ -1,15 +1,13 @@
 import { VarPicker } from './VarPicker';
 
-export const renderSelectedVars = ( rootElement, cssVars = [], lastTarget, groups, allVars ) => {
-
+export const renderSelectedVars = (rootElement, cssVars = [], lastTarget, groups, allVars) => {
   wp.element.render(
     <VarPicker
       initialOpen={ false }
       selectedVars={ cssVars }
-      groups={groups}
-      onCloseClick={ close }
+      groups={ groups }
       lastTarget={ lastTarget }
-      allVars={allVars}
+      allVars={ allVars }
     />,
     rootElement
   );

--- a/assets/src/theme/typedControl.js
+++ b/assets/src/theme/typedControl.js
@@ -12,8 +12,11 @@ export const COLOR_VALUE_REGEX = /(#[\da-fA-F]{3}|rgba?\()/;
 const convertRemToPixels = (rem) => rem * parseFloat(getComputedStyle(document.documentElement).fontSize);
 const convertPixelsToRem = (px) => px / parseFloat(getComputedStyle(document.documentElement).fontSize);
 
-const isPx = value => !!value && !!value.match(/[\d.]+px$/);
-const isRem = value => !!value && !!value.match(/[\d.]+rem$/);
+const isPx = value => value && value.match(/[\d.]+px$/);
+const isRem = value => value && value.match(/[\d.]+rem$/);
+const isPercent = value => value && value.match(/\d%$/);
+const isVh = value => value && value.match(/vh$/);
+const isVw = value => value && value.match(/vw$/);
 
 const extractColorUsages = theme => {
   if (null === theme) {
@@ -138,14 +141,17 @@ export const TypedControl = ({ cssVar, theme, value, onChange, dispatch }) => {
     'min-height',
     'max-height',
     'letter-spacing',
+    'outline-offset',
   ];
 
   if (cssVar.usages.some(usage => sizeLikeProperties.includes(usage.property))) {
-    return <div>
+    const pxValue = isPx(value) ? value.replace('px', '') : isRem(value) ? convertRemToPixels(parseFloat(value.replace('rem', ''))) : '';
+    const remValue = isRem(value) ? value.replace('rem', '') : isPx(value) ? convertPixelsToRem(parseFloat(value.replace('px', ''))) : '';
+    return <div className='theme-length-controls'>
       <div key={ 1 } style={{clear: 'both'}}>
         <input
           type={ 'number' }
-          value={ isPx(value) ? value.replace('px', '') : convertRemToPixels(parseFloat(value.replace('rem', ''))) }
+          value={pxValue}
           onChange={ event => {
             onChange(`${ event.currentTarget.value }px`);
           } }
@@ -156,13 +162,46 @@ export const TypedControl = ({ cssVar, theme, value, onChange, dispatch }) => {
       <div key={ 2 }>
         <input
           type={ 'number' }
-          value={ isRem(value) ? value.replace('rem', '') : convertPixelsToRem(parseFloat(value.replace('px', ''))) }
+          value={remValue}
           onChange={ event => {
             onChange(`${ event.currentTarget.value }rem`);
           } }
           style={ { minWidth: '100px' } }
         />
         <span>rem</span>
+      </div>
+      <div key={ 3 }>
+        <input
+          type={ 'number' }
+          value={ isPercent(value) ? value.replace('%', '') : ''}
+          onChange={ event => {
+            onChange(`${ event.currentTarget.value }%`);
+          } }
+          style={ { minWidth: '100px' } }
+        />
+        <span>%</span>
+      </div>
+      <div key={ 4 }>
+        <input
+          type={ 'number' }
+          value={ isVh(value) ? value.replace('vh', '') : ''}
+          onChange={ event => {
+            onChange(`${ event.currentTarget.value }vh`);
+          } }
+          style={ { minWidth: '100px' } }
+        />
+        <span>vh</span>
+      </div>
+      <div key={ 5 }>
+        <input
+          type={ 'number' }
+          value={ isVw(value) ? value.replace('vw', '') : ''}
+          onChange={ event => {
+            onChange(`${ event.currentTarget.value }vw`);
+          } }
+          style={ { minWidth: '100px' } }
+        />
+        <span>vw</span>
       </div>
       <TextControl
         value={ value }

--- a/assets/src/theme/useThemeEditor.js
+++ b/assets/src/theme/useThemeEditor.js
@@ -340,6 +340,7 @@ export const useThemeEditor = (
   useEffect(() => {
     processRemovals(defaultValues);
     writeNewValues(withPseudoPreviews);
+    localStorage.setItem('theme-with-previews', JSON.stringify(withPseudoPreviews));
   }, [JSON.stringify(withPseudoPreviews)]);
 
   const hotkeysOptions = {

--- a/assets/src/theme/useToggle.js
+++ b/assets/src/theme/useToggle.js
@@ -1,0 +1,9 @@
+import { useState, useCallback} from 'react';
+
+export const useToggle = (initialState = false) => {
+  // Initialize the state
+  const [state, setState] = useState(initialState);
+  const toggle = useCallback(() => setState(state => !state), []);
+
+  return [state, toggle]
+}


### PR DESCRIPTION
Ref: https://docs.google.com/document/d/1-UX-5TNLow9766yaTGUa0I2KxpfeUtgl6sf0iCizWoM/edit

---

Added a new mode that finally allows to theme for smaller screen sizes (or bigger). If the mode is enabled, the current page is shown in an iframe. You can change the iframe's width and height, choose one of the presets, and scale it down in case it doesn't fit on your screen.

Temporarily added a commit so it can be used without logging in on my instance.

Also:
* Fix broken "minus" icon button. I used another technique of adding a button with a minus sign: a button with a minus sign in it.

TODO:
* Tune the frame's width and height offsets (to account for the scrollbar size) so that the inner frame gets exactly the chosen resolution. I just eyeballed this for now.
* Give more space to the sidebar. It's still the same dragable overlay as I created for the first "in-page" version.
* Make the theme editor more "aware" of media queries if a variable is used in one. So that we can show only the ones applying to the current screen size.