### PR TITLE
Add styles outside hover selector

### DIFF
--- a/assets/src/styles/blocks/Covers/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/TakeActionCovers.scss
@@ -152,18 +152,6 @@
 
     .btn {
       display: block;
-
-      --block-covers--card-btn-- {
-        color: white;
-        background-color: $orange;
-        border-color: $orange;
-
-        &:hover, &:focus {
-          color: white;
-          background-color: $orange-hover;
-          border-color: $orange-hover;
-        }
-      }
     }
   }
 
@@ -267,6 +255,15 @@
 .cover-card-btn {
   --block-covers--card-button-- {
     display: none;
+    color: white;
+    background-color: $orange;
+    border-color: $orange;
+
+    &:hover, &:focus {
+      color: white;
+      background-color: $orange-hover;
+      border-color: $orange-hover;
+    }
   }
   position: absolute;
   bottom: 0;


### PR DESCRIPTION
* Currently the button is hidden if the card is not hovered. So the
styles can be added to the regular selector since they're not visible
anyway.
* This allows to have the button be visible (and styled) by just
changing the `display: none` property. Before this change this would
result in a partially unstyled button.

Ref: <!-- Please add a url to the ticket this change is addressing. -->

---

<!--
Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
