### PR TITLE
PLANET-6125 Add 50 Years Guestbook block

### DIFF
--- a/assets/src/blocks/GuestBook/GuestBookBlock.js
+++ b/assets/src/blocks/GuestBook/GuestBookBlock.js
@@ -1,0 +1,22 @@
+import { frontendRendered } from '../frontendRendered';
+const { registerBlockType } = wp.blocks;
+const { __ } = wp.i18n;
+
+const BLOCK_NAME = 'planet4-blocks/guestbook';
+
+export const registerGuestBookBlock = () =>
+  registerBlockType(BLOCK_NAME, {
+    title: __('50 Years GuestBook', 'planet4-blocks-backend'),
+    icon: 'admin-site-alt2',
+    category: 'planet4-blocks',
+    supports: {
+      html: false, // Disable "Edit as HTMl" block option.
+      multiple: false, // Use the block just once per post.
+    },
+    edit: () => (
+      <p className='EmptyMessage'>
+        {__('This block only renders in the frontend', 'planet4-blocks-backend')}
+      </p>
+    ),
+    save: frontendRendered(BLOCK_NAME),
+  });

--- a/assets/src/blocks/GuestBook/GuestBookFrontend.js
+++ b/assets/src/blocks/GuestBook/GuestBookFrontend.js
@@ -1,0 +1,15 @@
+export const GuestBookFrontend = () => {
+  const buildURL = () => {
+    const hostname = window.location.hostname;
+    const pathname = window.location.pathname.slice(1);
+    const params = new URLSearchParams(window.location.search);
+    const storyID = params.get('id');
+    return `https://maps.greenpeace.org/maps/gpint/50th_guestbook/?origin_host=${hostname}&origin_path=${encodeURIComponent(pathname)}${storyID ? `&id=${storyID}` : ''}`;
+  }
+
+  return (
+    <p>
+      <iframe src={buildURL()} width='100%' height={700} frameBorder='0' />
+    </p>
+  );
+}

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -23,6 +23,7 @@ import { setUpCssVariables } from './connectCssVariables';
 import { SubPagesBlock } from './blocks/SubPages/SubPagesBlock';
 import { blockEditorValidation } from './BlockEditorValidation';
 import { ENFormBlock } from './blocks/ENForm/ENFormBlock';
+import { registerGuestBookBlock } from './blocks/GuestBook/GuestBookBlock';
 
 blockEditorValidation();
 new ArticlesBlock();
@@ -43,6 +44,7 @@ new SubPagesBlock();
 new TakeactionboxoutBlock();
 new ENFormBlock();
 registerTimelineBlock();
+registerGuestBookBlock();
 
 addBlockFilters();
 setupImageBlockExtension();

--- a/assets/src/frontendIndex.js
+++ b/assets/src/frontendIndex.js
@@ -9,6 +9,7 @@ import { TimelineFrontend } from './blocks/Timeline/TimelineFrontend';
 import { SubmenuFrontend } from './blocks/Submenu/SubmenuFrontend';
 import { MediaFrontend } from './blocks/Media/MediaFrontend';
 import { ColumnsFrontend } from './blocks/Columns/ColumnsFrontend';
+import { GuestBookFrontend } from './blocks/GuestBook/GuestBookFrontend';
 import { setupMediaElementJS } from './blocks/Media/setupMediaElementJS';
 import { setupLightboxForImages } from './components/Lightbox/setupLightboxForImages';
 
@@ -25,6 +26,7 @@ const COMPONENTS = {
   'planet4-blocks/submenu': SubmenuFrontend,
   'planet4-blocks/media-video': MediaFrontend,
   'planet4-blocks/columns': ColumnsFrontend,
+  'planet4-blocks/guestbook': GuestBookFrontend,
 };
 
 document.querySelectorAll( `[data-render]` ).forEach(

--- a/classes/blocks/class-guestbook.php
+++ b/classes/blocks/class-guestbook.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * GuestBook block class.
+ *
+ * @package P4GBKS
+ * @since 0.1
+ */
+
+namespace P4GBKS\Blocks;
+
+/**
+ * Class GuestBook
+ *
+ * @package P4GBKS\Blocks
+ */
+class GuestBook extends Base_Block {
+
+	/**
+	 * Block name.
+	 *
+	 * @const string BLOCK_NAME.
+	 */
+	const BLOCK_NAME = 'guestbook';
+
+	/**
+	 * GuestBook constructor.
+	 */
+	public function __construct() {
+		register_block_type(
+			self::get_full_block_name(),
+		);
+	}
+
+	/**
+	 * Required by the `Base_Block` class.
+	 *
+	 * @param array $fields Unused, required by the abstract function.
+	 */
+	public function prepare_data( $fields ): array {
+		return [];
+	}
+}

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -82,6 +82,7 @@ final class Loader {
 		new Blocks\Timeline();
 		new Blocks\SocialMediaCards();
 		new Blocks\ENForm();
+		new Blocks\GuestBook();
 	}
 
 	/**

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -134,6 +134,7 @@ const PAGE_BLOCK_TYPES = [
 	'planet4-blocks/submenu',
 	'planet4-blocks/timeline',
 	'planet4-blocks/enform',
+	'planet4-blocks/guestbook',
 ];
 
 const BETA_PAGE_BLOCK_TYPES = [
@@ -159,6 +160,7 @@ const CAMPAIGN_BLOCK_TYPES = [
 	'planet4-blocks/sub-pages',
 	'planet4-blocks/timeline',
 	'planet4-blocks/enform',
+	'planet4-blocks/guestbook',
 ];
 
 const BETA_CAMPAIGN_BLOCK_TYPES = [


### PR DESCRIPTION
### Description

See [PLANET-6125](https://jira.greenpeace.org/browse/PLANET-6125)

### Testing

The "50 Years GuestBook" block should now be available in Planet 4 blocks, and it should show the iframe properly in both the backend and frontend 🙂
If you want to make the iframe full-width, you can add the `block-wide` class in the sidebar in the additional classes!

**Question**: I'm not sure whether showing the actual iframe in the editor is the best, it makes it a bit difficult to select the block (you need to click right above it), maybe we should just show an image of the map there? 🤔 On the other hand it's nice to see how it will look like in the frontend and test the interactive aspect...