### PR TITLE
PLANET-6010 Send dataLayer event when render is finished

### DIFF
--- a/assets/src/PortalHost.js
+++ b/assets/src/PortalHost.js
@@ -1,0 +1,46 @@
+import { Fragment, useEffect } from '@wordpress/element';
+import { SpreadsheetFrontend } from './blocks/Spreadsheet/SpreadsheetFrontend';
+import { CounterFrontend } from './blocks/Counter/CounterFrontend';
+import { ArticlesFrontend } from './blocks/Articles/ArticlesFrontend';
+import { CookiesFrontend } from './blocks/Cookies/CookiesFrontend';
+import { SplittwocolumnsFrontend } from './blocks/Splittwocolumns/SplittwocolumnsFrontend';
+import { HappypointFrontend } from './blocks/Happypoint/HappypointFrontend';
+import { GalleryFrontend } from './blocks/Gallery/GalleryFrontend';
+import { TimelineFrontend } from './blocks/Timeline/TimelineFrontend';
+import { SubmenuFrontend } from './blocks/Submenu/SubmenuFrontend';
+import { MediaFrontend } from './blocks/Media/MediaFrontend';
+import { ColumnsFrontend } from './blocks/Columns/ColumnsFrontend';
+
+// Render React components
+const COMPONENTS = {
+  'planet4-blocks/spreadsheet': SpreadsheetFrontend,
+  'planet4-blocks/counter': CounterFrontend,
+  'planet4-blocks/articles': ArticlesFrontend,
+  'planet4-blocks/cookies': CookiesFrontend,
+  'planet4-blocks/split-two-columns': SplittwocolumnsFrontend,
+  'planet4-blocks/happypoint': HappypointFrontend,
+  'planet4-blocks/gallery': GalleryFrontend,
+  'planet4-blocks/timeline': TimelineFrontend,
+  'planet4-blocks/submenu': SubmenuFrontend,
+  'planet4-blocks/media-video': MediaFrontend,
+  'planet4-blocks/columns': ColumnsFrontend,
+};
+
+export const PortalHost = ({blocks}) => {
+  useEffect(() => {
+    dataLayer in window && dataLayer.push({event: 'blocksRendered', time: performance.now()})
+  }, []);
+
+  return <Fragment>
+    {blocks.map(block=> {
+      const blockName = block.dataset.render;
+      const BlockFrontend = COMPONENTS[ blockName ];
+      if (!BlockFrontend) {
+        return null;
+      }
+      const attributes = JSON.parse( block.dataset.attributes );
+
+      return wp.element.createPortal(<BlockFrontend {...attributes.attributes } />, block);
+    })}
+  </Fragment>
+}

--- a/assets/src/PortalHost.js
+++ b/assets/src/PortalHost.js
@@ -31,9 +31,12 @@ export const PortalHost = ({blocks}) => {
   useEffect(() => {
     const time = performance.now();
     const event = {event: 'blocksRendered', time };
-    dataLayer.push(event)
     console.log(event);
-  }, []);
+
+    if (!blocks.some(b => b.dataset.render === 'planet4-blocks/articles')) {
+      dataLayer.push(event)
+    }
+  }, [blocks]);
 
   return <Fragment>
     {blocks.map(block=> {

--- a/assets/src/PortalHost.js
+++ b/assets/src/PortalHost.js
@@ -10,6 +10,7 @@ import { TimelineFrontend } from './blocks/Timeline/TimelineFrontend';
 import { SubmenuFrontend } from './blocks/Submenu/SubmenuFrontend';
 import { MediaFrontend } from './blocks/Media/MediaFrontend';
 import { ColumnsFrontend } from './blocks/Columns/ColumnsFrontend';
+const dataLayer = window.dataLayer || [];
 
 // Render React components
 const COMPONENTS = {
@@ -30,7 +31,7 @@ export const PortalHost = ({blocks}) => {
   useEffect(() => {
     const time = performance.now();
     const event = {event: 'blocksRendered', time };
-    dataLayer in window && dataLayer.push(event)
+    dataLayer.push(event)
     console.log(event);
   }, []);
 

--- a/assets/src/PortalHost.js
+++ b/assets/src/PortalHost.js
@@ -28,7 +28,10 @@ const COMPONENTS = {
 
 export const PortalHost = ({blocks}) => {
   useEffect(() => {
-    dataLayer in window && dataLayer.push({event: 'blocksRendered', time: performance.now()})
+    const time = performance.now();
+    const event = {event: 'blocksRendered', time };
+    dataLayer in window && dataLayer.push(event)
+    console.log(event);
   }, []);
 
   return <Fragment>

--- a/assets/src/blocks/Articles/ArticlesFrontend.js
+++ b/assets/src/blocks/Articles/ArticlesFrontend.js
@@ -1,3 +1,4 @@
+import { useEffect } from '@wordpress/element';
 import { ArticlesList } from './ArticlesList';
 import { useArticlesFetch } from './useArticlesFetch';
 
@@ -20,7 +21,16 @@ export const ArticlesFrontend = (props) => {
 
   const postCategories = props.post_categories || [];
 
-  const { posts, loadNextPage, hasMorePages, loading } = useArticlesFetch(props, postType, postId, document.body.dataset.nro, postCategories);
+  const { posts, loadNextPage, hasMorePages, initialized, loading } = useArticlesFetch(props, postType, postId, document.body.dataset.nro, postCategories);
+
+  useEffect(() => {
+    if ( initialized) {
+      const time = performance.now();
+      const event = {event: 'blocksRendered', time };
+      window.dataLayer && window.dataLayer.push(event);
+      console.log(event);
+    }
+  }, [initialized]);
 
   if (!posts.length) {
     return null;

--- a/assets/src/blocks/Articles/useArticlesFetch.js
+++ b/assets/src/blocks/Articles/useArticlesFetch.js
@@ -9,6 +9,7 @@ export const useArticlesFetch = (attributes, postType, postId, baseUrl = null, p
 
   const [totalPosts, setTotalPosts] = useState(null);
   const [displayedPosts, setDisplayedPosts] = useState([]);
+  const [initialized, setInitialized] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
@@ -44,6 +45,7 @@ export const useArticlesFetch = (attributes, postType, postId, baseUrl = null, p
       const newPosts = [...prevPosts, ...response.recent_posts];
 
       setDisplayedPosts(newPosts);
+      setInitialized(true);
 
       if (response.total_posts !== undefined && response.total_posts !== totalPosts) {
         setTotalPosts(response.total_posts);
@@ -65,6 +67,7 @@ export const useArticlesFetch = (attributes, postType, postId, baseUrl = null, p
   return {
     posts: displayedPosts,
     totalPosts,
+    initialized,
     loading,
     error,
     hasMorePages: totalPosts > displayedPosts.length,

--- a/assets/src/frontendIndex.js
+++ b/assets/src/frontendIndex.js
@@ -1,43 +1,16 @@
-import { SpreadsheetFrontend } from './blocks/Spreadsheet/SpreadsheetFrontend';
-import { CounterFrontend } from './blocks/Counter/CounterFrontend';
-import { ArticlesFrontend } from './blocks/Articles/ArticlesFrontend';
-import { CookiesFrontend } from './blocks/Cookies/CookiesFrontend';
-import { SplittwocolumnsFrontend } from "./blocks/Splittwocolumns/SplittwocolumnsFrontend";
-import { HappypointFrontend } from './blocks/Happypoint/HappypointFrontend';
-import { GalleryFrontend } from './blocks/Gallery/GalleryFrontend';
-import { TimelineFrontend } from './blocks/Timeline/TimelineFrontend';
-import { SubmenuFrontend } from './blocks/Submenu/SubmenuFrontend';
-import { MediaFrontend } from './blocks/Media/MediaFrontend';
-import { ColumnsFrontend } from './blocks/Columns/ColumnsFrontend';
 import { setupMediaElementJS } from './blocks/Media/setupMediaElementJS';
 import { setupLightboxForImages } from './components/Lightbox/setupLightboxForImages';
+import { PortalHost } from './PortalHost';
 
+const dataLayer = window.dataLayer || [];
+
+dataLayer.push({ event: 'frontendIndexStart', time: performance.now()});
 // Render React components
-const COMPONENTS = {
-  'planet4-blocks/spreadsheet': SpreadsheetFrontend,
-  'planet4-blocks/counter': CounterFrontend,
-  'planet4-blocks/articles': ArticlesFrontend,
-  'planet4-blocks/cookies': CookiesFrontend,
-  'planet4-blocks/split-two-columns': SplittwocolumnsFrontend,
-  'planet4-blocks/happypoint': HappypointFrontend,
-  'planet4-blocks/gallery': GalleryFrontend,
-  'planet4-blocks/timeline': TimelineFrontend,
-  'planet4-blocks/submenu': SubmenuFrontend,
-  'planet4-blocks/media-video': MediaFrontend,
-  'planet4-blocks/columns': ColumnsFrontend,
-};
-
-document.querySelectorAll( `[data-render]` ).forEach(
-  blockNode => {
-    const blockName = blockNode.dataset.render;
-    const BlockFrontend = COMPONENTS[ blockName ];
-    if (!BlockFrontend) {
-      return;
-    }
-    const attributes = JSON.parse( blockNode.dataset.attributes );
-    wp.element.render( <BlockFrontend { ...attributes.attributes } />, blockNode );
-  }
-);
+// Empty react root so we can do a single render with portals to all the blocks.
+const reactRoot = document.createElement('div');
+const blocks = [...document.querySelectorAll( `[data-render]` )];
+wp.element.render(<PortalHost blocks={blocks} />, reactRoot);
 
 setupMediaElementJS();
 setupLightboxForImages();
+dataLayer.push({ event: 'frontendIndexDone', time: performance.now() });

--- a/assets/src/frontendIndex.js
+++ b/assets/src/frontendIndex.js
@@ -5,6 +5,7 @@ import { PortalHost } from './PortalHost';
 const dataLayer = window.dataLayer || [];
 
 dataLayer.push({ event: 'frontendIndexStart', time: performance.now()});
+
 // Render React components
 // Empty react root so we can do a single render with portals to all the blocks.
 const reactRoot = document.createElement('div');


### PR DESCRIPTION
* To check if this resolves/reduces GTM blocking issues.
* In order to "know" when all blocks are done, we need to render them in
a single React element using portals, instead of doing separate renders.
* Also emit event at start and finish of frontendIndex.js.

Ref: <!-- Please add a url to the ticket this change is addressing. -->

---

<!--
Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
