### PR TITLE
PLANET-5983 Bump to theme editor with fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16872,9 +16872,9 @@
       "dev": true
     },
     "use-theme-editor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/use-theme-editor/-/use-theme-editor-1.0.3.tgz",
-      "integrity": "sha512-4ppYOIj8hAyeat4oaBJBwo/bv817XVBkq+XLb1cm1T/FE+fr3eHtGajh4YVlDlxHc/V/Bnt7OKGco7QPxHa9sA==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/use-theme-editor/-/use-theme-editor-1.0.6.tgz",
+      "integrity": "sha512-YuSSJ8/8nz7iLki0hivdtDJCis+7thY6ehMV6D0tYkeZ7q5dZZTpUgV86afYO9lvMdMBzZMqIHMglkL53yi+zA==",
       "requires": {
         "balanced-match": "^2.0.0",
         "font-picker-react": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "classnames": "^2.2.6",
     "jest-environment-node": "^26.0.1",
     "photoswipe": "^4.1.3",
-    "use-theme-editor": "^1.0.3"
+    "use-theme-editor": "^1.0.6"
   }
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5983

---

This version fixes a bug with the history behavior. Previously the `future` was not unset when making new changes, so pressing redo would put you in an old state, potentially losing work.