### PR TITLE
PLANET-6002 Remove Submenu back to top button

### DIFF
--- a/assets/src/blocks/Submenu/SubmenuFrontend.js
+++ b/assets/src/blocks/Submenu/SubmenuFrontend.js
@@ -1,27 +1,9 @@
-import { useEffect } from '@wordpress/element';
 import { getSubmenuStyle } from './getSubmenuStyle';
 import { SubmenuItems } from './SubmenuItems';
 import { makeHierarchical } from './makeHierarchical';
 import { getHeadingsFromDom } from './getHeadingsFromDom';
 
 export const SubmenuFrontend = ({ title, className, levels, submenu_style }) => {
-
-  const enableBackTop = () => {
-    const backTop = document.querySelector('.back-top');
-    if (!backTop) {
-      return;
-    }
-    document.addEventListener('scroll', () => {
-      if (document.documentElement.scrollTop > 400) {
-        backTop.classList.remove('d-none');
-      } else {
-        backTop.classList.add('d-none');
-      }
-    });
-  };
-
-  // Enable back top on initial render.
-  useEffect(enableBackTop, []);
 
   const headings = getHeadingsFromDom(levels);
   const menuItems = makeHierarchical(headings);

--- a/assets/src/styles/blocks/Submenu.scss
+++ b/assets/src/styles/blocks/Submenu.scss
@@ -114,27 +114,3 @@ div[data-render="planet4-blocks/submenu"] {
     }
   }
 }
-
-.back-top,
-div.page-template > .back-top {
-  background-image: url("../../public/images/arrow-up.svg");
-  background-repeat: no-repeat;
-  position: fixed;
-  height: 44px;
-  width: 44px;
-  left: calc(85% - 26px);
-  bottom: 50px;
-  background-color: $dark-blue;
-  text-align: center;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
-  z-index: 1000;
-
-  @include x-large-and-up {
-    height: 60px;
-    width: 60px;
-  }
-
-  &:hover {
-    text-decoration: none;
-  }
-}


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-6002

### Testing

Go to a long page with a Submenu block (for example Copyright or maybe Privacy) and make sure that the button doesn't appear when you scroll down.


#### Related PRs
- https://github.com/greenpeace/planet4-master-theme/pull/1380