### PR TITLE
PLANET-6105 Remove GalleryCarousel arrows z-index to fix indicators

### DIFF
--- a/assets/src/styles/blocks/Gallery_carousel.scss
+++ b/assets/src/styles/blocks/Gallery_carousel.scss
@@ -188,7 +188,6 @@
     height: 100%;
     top: 0;
     width: 30%;
-    z-index: 3;
     cursor: pointer;
     background: transparent;
     border: 0;


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-6105

I'm not sure why we were changing the z-index value for the arrows 🤔 they seem to work just fine with the original Bootstrap value. Our override was causing the "next" button to show on top of the indicators, and therefore clicking on the indicators was actually clicking on the button, hence the broken behaviour.

### Testing

Add a Gallery block, carousel style, with 3 or more images and make sure the indicators and the prev/next buttons work as intended.

- [Broken example](https://www.greenpeace.org/international/act/sail-aboard-a-greenpeace-ship/)
- [Fixed example](https://www-dev.greenpeace.org/test-iocaste/story/46720/since-fukushima-disaster-decade/)