### PR TITLE
PLANET-6136 Make legacy sidebar code manageable

### DIFF
--- a/assets/src/components/Sidebar/CampaignSidebar.js
+++ b/assets/src/components/Sidebar/CampaignSidebar.js
@@ -7,7 +7,7 @@ import { savePreviewMeta } from '../../saveMetaToPreview';
 import { PostParentLink } from './PostParentLink';
 import { LegacyThemeSettings } from './LegacyThemeSettings';
 
-const loadTheme = async( value ) => {
+const loadTheme = async (value) => {
   if ( value === '' || !value ) {
     value = 'default';
   }
@@ -44,6 +44,8 @@ export class CampaignSidebar extends Component {
     const prevTheme = this.state.theme;
     this.setState({ theme });
 
+    // Loop through the new theme's fields, and check whether any of the already chosen options has a value that is not
+    // available anymore.
     const invalidatedFields = prevTheme.fields.filter( field => {
 
       const resolvedField = resolveField(theme, field.id, meta);
@@ -58,7 +60,13 @@ export class CampaignSidebar extends Component {
 
     } ).map( field => resolveField( theme, field.id, meta ) )
 
+    // Set each of the invalidated fields to their default value, or unset them.
     return invalidatedFields.reduce( ( result, field ) => {
+      // Adding this check to prevent a crash. Probably the previous code can be rewritten to not produce null, but
+      // that would probably cascade into many changes and this is code we'll probably remove soon.
+      if (!field) {
+        return result;
+      }
       return {
         ...result,
         [ field.id ]: field.default || null,
@@ -69,7 +77,7 @@ export class CampaignSidebar extends Component {
   }
 
   componentDidMount() {
-    wp.data.subscribe( async() => {
+    wp.data.subscribe(async () => {
       const meta = wp.data.select( 'core/editor' ).getEditedPostAttribute( 'meta' );
 
       if (!meta) {

--- a/assets/src/components/Sidebar/CampaignSidebar.js
+++ b/assets/src/components/Sidebar/CampaignSidebar.js
@@ -1,75 +1,23 @@
 import { PluginSidebar, PluginSidebarMoreMenuItem } from "@wordpress/edit-post";
 import { Component } from '@wordpress/element';
-import { PanelBody, RadioControl, SelectControl } from '@wordpress/components';
-import { compose } from '@wordpress/compose';
-import ColorPaletteControl from '../ColorPaletteControl/ColorPaletteControl';
-import { withPostMeta } from '../PostMeta/withPostMeta';
-import { withDefaultLabel } from '../withDefaultLabel/withDefaultLabel';
 import { __ } from '@wordpress/i18n';
-import { fromThemeOptions, getFieldFromTheme } from '../fromThemeOptions/fromThemeOptions';
+import { resolveField } from '../fromThemeOptions/fromThemeOptions';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { savePreviewMeta } from '../../saveMetaToPreview';
+import { PostParentLink } from './PostParentLink';
+import { LegacyThemeSettings } from './LegacyThemeSettings';
 
-const themeOptions = [
-  {
-    value: '',
-    label: 'Default',
-  },
-  {
-    value: 'antarctic',
-    label: 'Antarctic',
-  },
-  {
-    value: 'arctic',
-    label: 'Arctic',
-  },
-  {
-    value: 'climate',
-    label: 'Climate Emergency',
-  },
-  {
-    value: 'forest',
-    label: 'Forest',
-  },
-  {
-    value: 'oceans',
-    label: 'Oceans',
-  },
-  {
-    value: 'oil',
-    label: 'Oil',
-  },
-  {
-    value: 'plastic',
-    label: 'Plastics',
-  },
+const loadTheme = async( value ) => {
+  if ( value === '' || !value ) {
+    value = 'default';
+  }
+  const baseUrl = window.location.href.split( '/wp-admin' )[ 0 ];
+  const themeJsonUrl = `${ baseUrl }/wp-content/themes/planet4-master-theme/campaign_themes/${ value }.json`;
+  console.log( `fetching theme ${ value }` );
 
-];
-
-const ThemeSelect = withPostMeta( SelectControl );
-
-const SelectWithDefaultLabel = compose(
-  fromThemeOptions,
-  withPostMeta,
-  withDefaultLabel,
-)( SelectControl );
-
-const Select = compose(
-  fromThemeOptions,
-  withPostMeta,
-)( SelectControl );
-
-const Radio = compose(
-  fromThemeOptions,
-  withPostMeta,
-)( RadioControl );
-
-const ColorPalette = compose(
-  fromThemeOptions,
-  withPostMeta,
-)( ColorPaletteControl );
-
-
+  const json = await fetch(themeJsonUrl);
+  return await json.json();
+}
 export class CampaignSidebar extends Component {
   static getId() {
     return 'planet4-campaign-sidebar';
@@ -87,15 +35,18 @@ export class CampaignSidebar extends Component {
       parent: null,
     };
     this.handleThemeSwitch = this.handleThemeSwitch.bind( this );
-    this.loadTheme = this.loadTheme.bind( this );
   }
 
+  // When theme switches, we need to check if any options were previously chosen that are not allowed in the new theme.
+  // For each of these, we either set them to the default value
   async handleThemeSwitch( metaKey, value, meta ) {
-    await this.loadTheme( value )
+    const theme = await loadTheme( value )
+    const prevTheme = this.state.theme;
+    this.setState({ theme });
 
-    const invalidatedFields = this.state.theme.fields.filter( field => {
+    const invalidatedFields = prevTheme.fields.filter( field => {
 
-      const resolvedField = getFieldFromTheme(this.state.theme, field.id, meta);
+      const resolvedField = resolveField(theme, field.id, meta);
 
       const currentValue = meta[ field.id ];
 
@@ -105,7 +56,7 @@ export class CampaignSidebar extends Component {
 
       return !(resolvedField.options.some( option => option.value === currentValue) );
 
-    } ).map( field => getFieldFromTheme( this.state.theme, field.id, meta ) )
+    } ).map( field => resolveField( theme, field.id, meta ) )
 
     return invalidatedFields.reduce( ( result, field ) => {
       return {
@@ -118,23 +69,26 @@ export class CampaignSidebar extends Component {
   }
 
   componentDidMount() {
-    wp.data.subscribe( () => {
+    wp.data.subscribe( async() => {
       const meta = wp.data.select( 'core/editor' ).getEditedPostAttribute( 'meta' );
 
-      if ( meta ) {
-        let theme = meta[ 'theme' ];
-        if ( theme === '' ) {
-          theme = 'default';
-        }
-        if ( !isShallowEqual( this.state.meta, meta ) ) {
-          this.setState( { meta: meta } );
-          savePreviewMeta();
-          if (
-            this.state.theme === null
-          ) {
-            this.loadTheme( theme );
-          }
-        }
+      if (!meta) {
+        return;
+      }
+      let themeName = meta['theme'];
+      if (themeName === '') {
+        themeName = 'default';
+      }
+      if (isShallowEqual(this.state.meta, meta)) {
+        return;
+      }
+      this.setState({ meta });
+      savePreviewMeta();
+      if (
+        this.state.theme === null
+      ) {
+        const theme = await loadTheme(themeName);
+        this.setState({ theme });
       }
     } );
     wp.data.subscribe( () => {
@@ -149,21 +103,9 @@ export class CampaignSidebar extends Component {
     } );
   }
 
-  loadTheme( value ) {
-    if ( value === '' || !value ) {
-      value = 'default';
-    }
-    const baseUrl = window.location.href.split( '/wp-admin' )[ 0 ];
-    const themeJsonUrl = `${ baseUrl }/wp-content/themes/planet4-master-theme/campaign_themes/${ value }.json`;
-    console.log( `fetching theme ${ value }` );
-    return fetch( themeJsonUrl )
-      .then( response => response.json() )
-      .then( json => {
-        this.setState( { theme: json } );
-      } );
-  }
-
   render() {
+    const { parent, theme } = this.state;
+
     return (
       <>
         <PluginSidebarMoreMenuItem
@@ -175,118 +117,11 @@ export class CampaignSidebar extends Component {
           name={ CampaignSidebar.getId() }
           title={ __( 'Campaign Options', 'planet4-blocks-backend' ) }
         >
-          { this.state.parent
-            ?
-            <div className="components-panel__body is-opened">
-              <p>{ __( 'This is a sub-page of', 'planet4-blocks-backend' ) }</p>
-              <a
-                href={ window.location.href.replace( /\?post=\d+/, `?post=${ this.state.parent.id }` ) }>
-                { this.state.parent.title.raw }
-              </a>
-              <p>{ __( 'Style and analytics settings from the parent page will be used.', 'planet4-blocks-backend' ) }</p>
-            </div>
-            :
-            <>
-              <div className="components-panel__body is-opened">
-                <ThemeSelect
-                  metaKey='theme'
-                  label={ __( 'Theme', 'planet4-blocks-backend' ) }
-                  options={ themeOptions }
-                  getNewMeta={ this.handleThemeSwitch }
-                />
-              </div>
-              <PanelBody
-                title={ __( "Navigation", 'planet4-blocks-backend' ) }
-                initialOpen={ true }
-              >
-                <Radio
-                  metaKey='campaign_nav_type'
-                  theme={ this.state.theme }
-                />
-                <ColorPalette
-                  metaKey='campaign_nav_color'
-                  label={ __( 'Navigation Background Color', 'planet4-blocks-backend' ) }
-                  disableCustomColors
-                  clearable={ false }
-                  theme={ this.state.theme }
-                />
-                <Radio
-                  metaKey='campaign_nav_border'
-                  label={ __( 'Navigation bottom border', 'planet4-blocks-backend' ) }
-                  theme={ this.state.theme }
-                />
-                {
-                  <Select
-                    metaKey='campaign_logo'
-                    label={ __( 'Logo', 'planet4-blocks-backend' ) }
-                    theme={ this.state.theme }
-                  />
-                }
-                <Radio
-                  metaKey='campaign_logo_color'
-                  label={ __( 'Logo Color', 'planet4-blocks-backend' ) }
-                  help={ __( 'Change the campaign logo color (if not default)', 'planet4-blocks-backend' ) }
-                  theme={ this.state.theme }
-                />
-              </PanelBody>
-              {/*<PanelBody*/ }
-              {/*  title={ __( "Colors", 'planet4-blocks-backend' ) }*/ }
-              {/*  initialOpen={ true }*/ }
-              {/*>*/ }
-              {/*  <ColorPalette*/ }
-              {/*    metaKey='campaign_header_color'*/ }
-              {/*    label={ __( 'Header Text Color', 'planet4-blocks-backend' ) }*/ }
-              {/*    disableCustomColors*/ }
-              {/*    clearable={ false }*/ }
-              {/*    theme={ this.state.theme }*/ }
-              {/*  />*/ }
-              {/*  <ColorPalette*/ }
-              {/*    metaKey='campaign_primary_color'*/ }
-              {/*    label={ __( 'Primary Button Color', 'planet4-blocks-backend' ) }*/ }
-              {/*    disableCustomColors*/ }
-              {/*    clearable={ false }*/ }
-              {/*    theme={ this.state.theme }*/ }
-              {/*  />*/ }
-              {/*  <ColorPalette*/ }
-              {/*    metaKey='campaign_secondary_color'*/ }
-              {/*    label={ __( 'Secondary Button Color and Link Text Color', 'planet4-blocks-backend' ) }*/ }
-              {/*    disableCustomColors*/ }
-              {/*    theme={ this.state.theme }*/ }
-              {/*  />*/ }
-              {/*</PanelBody>*/ }
-              <PanelBody
-                title={ __( "Fonts", 'planet4-blocks-backend' ) }
-                initialOpen={ true }
-              >
-                <SelectWithDefaultLabel
-                  metaKey='campaign_header_primary'
-                  label={ __( 'Header Primary Font', 'planet4-blocks-backend' ) }
-                  theme={ this.state.theme }
-                />
-                <SelectWithDefaultLabel
-                  metaKey='campaign_body_font'
-                  label={ __( 'Body Font', 'planet4-blocks-backend' ) }
-                  theme={ this.state.theme }
-                />
-              </PanelBody>
-              <PanelBody
-                title={ __( "Footer", 'planet4-blocks-backend' ) }
-                initialOpen={ true }
-              >
-                <Radio
-                  metaKey='campaign_footer_theme'
-                  label={ __( 'Footer background color', 'planet4-blocks-backend' ) }
-                  theme={ this.state.theme }
-                />
-                <ColorPalette
-                  metaKey='footer_links_color'
-                  label={ __( 'Footer links color', 'planet4-blocks-backend' ) }
-                  disableCustomColors
-                  clearable={ false }
-                  theme={ this.state.theme }
-                />
-              </PanelBody>
-            </>
+          { parent ? <PostParentLink parent={ parent }/> :
+            <LegacyThemeSettings
+              theme={theme}
+              handleThemeSwitch={ this.handleThemeSwitch }
+            />
           }
         </PluginSidebar>
       </>

--- a/assets/src/components/Sidebar/LegacyThemeSettings.js
+++ b/assets/src/components/Sidebar/LegacyThemeSettings.js
@@ -1,0 +1,150 @@
+import { compose } from '@wordpress/compose';
+import { PanelBody, RadioControl, SelectControl } from '@wordpress/components';
+import { withPostMeta } from '../PostMeta/withPostMeta';
+import { fromThemeOptions } from '../fromThemeOptions/fromThemeOptions';
+import { withDefaultLabel } from '../withDefaultLabel/withDefaultLabel';
+import ColorPaletteControl from '../ColorPaletteControl/ColorPaletteControl';
+import { __ } from '@wordpress/i18n';
+
+const themeOptions = [
+  {
+    value: '',
+    label: 'Default',
+  },
+  {
+    value: 'antarctic',
+    label: 'Antarctic',
+  },
+  {
+    value: 'arctic',
+    label: 'Arctic',
+  },
+  {
+    value: 'climate',
+    label: 'Climate Emergency',
+  },
+  {
+    value: 'forest',
+    label: 'Forest',
+  },
+  {
+    value: 'oceans',
+    label: 'Oceans',
+  },
+  {
+    value: 'oil',
+    label: 'Oil',
+  },
+  {
+    value: 'plastic',
+    label: 'Plastics',
+  },
+
+];
+
+const ThemeSelect = withPostMeta( SelectControl );
+
+const SelectWithDefaultLabel = compose(
+  fromThemeOptions,
+  withPostMeta,
+  withDefaultLabel,
+)( SelectControl );
+
+const Select = compose(
+  fromThemeOptions,
+  withPostMeta,
+)( SelectControl );
+
+const Radio = compose(
+  fromThemeOptions,
+  withPostMeta,
+)( RadioControl );
+
+const ColorPalette = compose(
+  fromThemeOptions,
+  withPostMeta,
+)( ColorPaletteControl );
+
+export const LegacyThemeSettings = props => {
+  const {
+    handleThemeSwitch,
+    theme,
+  } = props;
+
+  return <>
+    <div className="components-panel__body is-opened">
+      <ThemeSelect
+        metaKey='theme'
+        label={ __( 'Theme', 'planet4-blocks-backend' ) }
+        options={ themeOptions }
+        getNewMeta={ handleThemeSwitch }
+      />
+    </div>
+    <PanelBody
+      title={ __( "Navigation", 'planet4-blocks-backend' ) }
+      initialOpen={ true }
+    >
+      <Radio
+        metaKey='campaign_nav_type'
+        theme={ theme }
+      />
+      <ColorPalette
+        metaKey='campaign_nav_color'
+        label={ __( 'Navigation Background Color', 'planet4-blocks-backend' ) }
+        disableCustomColors
+        clearable={ false }
+        theme={ theme }
+      />
+      <Radio
+        metaKey='campaign_nav_border'
+        label={ __( 'Navigation bottom border', 'planet4-blocks-backend' ) }
+        theme={ theme }
+      />
+      {
+        <Select
+          metaKey='campaign_logo'
+          label={ __( 'Logo', 'planet4-blocks-backend' ) }
+          theme={ theme }
+        />
+      }
+      <Radio
+        metaKey='campaign_logo_color'
+        label={ __( 'Logo Color', 'planet4-blocks-backend' ) }
+        help={ __( 'Change the campaign logo color (if not default)', 'planet4-blocks-backend' ) }
+        theme={ theme }
+      />
+    </PanelBody>
+    <PanelBody
+      title={ __( "Fonts", 'planet4-blocks-backend' ) }
+      initialOpen={ true }
+    >
+      <SelectWithDefaultLabel
+        metaKey='campaign_header_primary'
+        label={ __( 'Header Primary Font', 'planet4-blocks-backend' ) }
+        theme={ theme }
+      />
+      <SelectWithDefaultLabel
+        metaKey='campaign_body_font'
+        label={ __( 'Body Font', 'planet4-blocks-backend' ) }
+        theme={ theme }
+      />
+    </PanelBody>
+    <PanelBody
+      title={ __( "Footer", 'planet4-blocks-backend' ) }
+      initialOpen={ true }
+    >
+      <Radio
+        metaKey='campaign_footer_theme'
+        label={ __( 'Footer background color', 'planet4-blocks-backend' ) }
+        theme={ theme }
+      />
+      <ColorPalette
+        metaKey='footer_links_color'
+        label={ __( 'Footer links color', 'planet4-blocks-backend' ) }
+        disableCustomColors
+        clearable={ false }
+        theme={ theme }
+      />
+    </PanelBody>
+  </>
+}

--- a/assets/src/components/Sidebar/PostParentLink.js
+++ b/assets/src/components/Sidebar/PostParentLink.js
@@ -1,0 +1,12 @@
+import { __ } from '@wordpress/i18n';
+
+export const PostParentLink = ({ parent }) => {
+  return <div className="components-panel__body is-opened">
+    <p>{ __('This is a sub-page of', 'planet4-blocks-backend') }</p>
+    <a
+      href={ window.location.href.replace(/\?post=\d+/, `?post=${ parent.id }`) }>
+      { parent.title.raw }
+    </a>
+    <p>{ __('Style and analytics settings from the parent page will be used.', 'planet4-blocks-backend') }</p>
+  </div>;
+};

--- a/assets/src/components/fromThemeOptions/fromThemeOptions.js
+++ b/assets/src/components/fromThemeOptions/fromThemeOptions.js
@@ -4,7 +4,11 @@ function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component';
 }
 
-export const getFieldFromTheme = ( theme, fieldName, meta ) => {
+// Find the variant of a field that should be used, based on the other selected theme options (stored as post "meta").
+// Certain fields can have multiple sets of options, depending on which value is chosen for another field. For example,
+// we have a "default" and a "light" footer theme. Each of these results in a separate set of footer link colors.
+// See https://github.com/greenpeace/planet4-master-theme/blob/1905eee9f94ef1ac64aaed1570ea4150671684c1/campaign_themes/plastic.json#L176-L187
+export const resolveField = (theme, fieldName, meta ) => {
   if ( !theme ) {
     return null;
   }
@@ -98,7 +102,7 @@ export function fromThemeOptions( WrappedComponent ) {
 
       const meta = wp.data.select( 'core/editor' ).getEditedPostAttribute( 'meta' );
 
-      const field = getFieldFromTheme( theme, ownProps.metaKey, meta );
+      const field = resolveField( theme, ownProps.metaKey, meta );
 
       if ( !field || !field.options ) {
         return null;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6136

---

I first wanted to rewrite to hooks in one go, since this is the most confusing class components we have. However it's too complex to do at once.

This PR does a few low hanging fruit improvements that are easy to review without needing to go too much into the more confusing parts.

The most confusing being the 2 tightly coupled HOCs WithPostMeta and FromThemeOptions. I'm not sure yet at this point whether we want to try "save" the logic in them that handles the "theme field dependencies" (see [this added code comment](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/588/files#diff-0a557c7b06bf5a384f50fa0e07bbb3e59ba232e788d9125e74ddad2f20ce013aR7-R11)).

For now the purpose of the Jira ticket is just to have some way to select the newly created themes in the sidebar on the test instance, so that design can review the refactored version, compare with the original, and easily create small variations and switch campaigns to them.

* Move some of the logic to separate components so that it's not all inside of CampaignSidebar.
* Return early a few times.
* Some naming improvements.
* Add documentation for some obscure parts.

