### PR TITLE
PLANET-6136 Add select for new themes

### DIFF
--- a/assets/src/components/Sidebar/CampaignSidebar.js
+++ b/assets/src/components/Sidebar/CampaignSidebar.js
@@ -23,8 +23,10 @@ const loadTheme = async (value) => {
   if ( value === '' || !value ) {
     value = 'default';
   }
+  const withoutNew = value.replace(/-new$/, '');
+  const name = isLegacy(withoutNew) ? withoutNew : 'default';
   const baseUrl = window.location.href.split( '/wp-admin' )[ 0 ];
-  const themeJsonUrl = `${ baseUrl }/wp-content/themes/planet4-master-theme/campaign_themes/${ value }.json`;
+  const themeJsonUrl = `${ baseUrl }/wp-content/themes/planet4-master-theme/campaign_themes/${ name }.json`;
 
   const json = await fetch(themeJsonUrl);
   return await json.json();
@@ -141,15 +143,13 @@ export class CampaignSidebar extends Component {
         >
           { !!parent && <PostParentLink parent={ parent }/> }
           { !parent && meta && <NewThemeSettings currentTheme={meta.theme} onChange={ async value => {
-            if (isLegacy(value)) {
-              const theme = await loadTheme();
-              this.setState({ theme });
-            }
+            const theme = await loadTheme(value);
+            this.setState({ theme });
           } }/> }
-          { !parent && theme && isLegacyTheme && <LegacyThemeSettings
-            disableStyles={!!theme}
+          { !parent && <LegacyThemeSettings
             theme={ theme }
             handleThemeSwitch={ this.handleThemeSwitch }
+            isLegacyTheme={isLegacyTheme}
           /> }
         </PluginSidebar>
       </>

--- a/assets/src/components/Sidebar/CampaignSidebar.js
+++ b/assets/src/components/Sidebar/CampaignSidebar.js
@@ -143,8 +143,7 @@ export class CampaignSidebar extends Component {
         >
           { !!parent && <PostParentLink parent={ parent }/> }
           { !parent && meta && <NewThemeSettings currentTheme={meta.theme} onChange={ async value => {
-            const theme = await loadTheme(value);
-            this.setState({ theme });
+            this.handleThemeSwitch('theme', value, meta);
           } }/> }
           { !parent && <LegacyThemeSettings
             theme={ theme }

--- a/assets/src/components/Sidebar/CampaignSidebar.js
+++ b/assets/src/components/Sidebar/CampaignSidebar.js
@@ -6,6 +6,18 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 import { savePreviewMeta } from '../../saveMetaToPreview';
 import { PostParentLink } from './PostParentLink';
 import { LegacyThemeSettings } from './LegacyThemeSettings';
+import { NewThemeSettings } from './NewThemeSettings';
+
+const isLegacy= theme => [
+  'default',
+  'antarctic',
+  'arctic',
+  'climate',
+  'oceans',
+  'oil',
+  'plastic',
+  'forest',
+].includes(theme) || !theme;
 
 const loadTheme = async (value) => {
   if ( value === '' || !value ) {
@@ -13,11 +25,11 @@ const loadTheme = async (value) => {
   }
   const baseUrl = window.location.href.split( '/wp-admin' )[ 0 ];
   const themeJsonUrl = `${ baseUrl }/wp-content/themes/planet4-master-theme/campaign_themes/${ value }.json`;
-  console.log( `fetching theme ${ value }` );
 
   const json = await fetch(themeJsonUrl);
   return await json.json();
 }
+
 export class CampaignSidebar extends Component {
   static getId() {
     return 'planet4-campaign-sidebar';
@@ -40,15 +52,15 @@ export class CampaignSidebar extends Component {
   // When theme switches, we need to check if any options were previously chosen that are not allowed in the new theme.
   // For each of these, we either set them to the default value
   async handleThemeSwitch( metaKey, value, meta ) {
-    const theme = await loadTheme( value )
+    const newTheme = await loadTheme( value )
     const prevTheme = this.state.theme;
-    this.setState({ theme });
+    this.setState({ theme: newTheme });
 
     // Loop through the new theme's fields, and check whether any of the already chosen options has a value that is not
     // available anymore.
     const invalidatedFields = prevTheme.fields.filter( field => {
 
-      const resolvedField = resolveField(theme, field.id, meta);
+      const resolvedField = resolveField(newTheme, field.id, meta);
 
       const currentValue = meta[ field.id ];
 
@@ -58,7 +70,7 @@ export class CampaignSidebar extends Component {
 
       return !(resolvedField.options.some( option => option.value === currentValue) );
 
-    } ).map( field => resolveField( theme, field.id, meta ) )
+    } ).map( field => resolveField( newTheme, field.id, meta ) )
 
     // Set each of the invalidated fields to their default value, or unset them.
     return invalidatedFields.reduce( ( result, field ) => {
@@ -96,7 +108,7 @@ export class CampaignSidebar extends Component {
         this.state.theme === null
       ) {
         const theme = await loadTheme(themeName);
-        this.setState({ theme });
+        this.setState({ theme: theme });
       }
     } );
     wp.data.subscribe( () => {
@@ -112,7 +124,9 @@ export class CampaignSidebar extends Component {
   }
 
   render() {
-    const { parent, theme } = this.state;
+    const { parent, theme, meta } = this.state;
+
+    const isLegacyTheme = !theme || isLegacy(theme.id);
 
     return (
       <>
@@ -123,14 +137,20 @@ export class CampaignSidebar extends Component {
         </PluginSidebarMoreMenuItem>
         <PluginSidebar
           name={ CampaignSidebar.getId() }
-          title={ __( 'Campaign Options', 'planet4-blocks-backend' ) }
+          title={ __('Campaign Options', 'planet4-blocks-backend') }
         >
-          { parent ? <PostParentLink parent={ parent }/> :
-            <LegacyThemeSettings
-              theme={theme}
-              handleThemeSwitch={ this.handleThemeSwitch }
-            />
-          }
+          { !!parent && <PostParentLink parent={ parent }/> }
+          { !parent && meta && <NewThemeSettings currentTheme={meta.theme} onChange={ async value => {
+            if (isLegacy(value)) {
+              const theme = await loadTheme();
+              this.setState({ theme });
+            }
+          } }/> }
+          { !parent && theme && isLegacyTheme && <LegacyThemeSettings
+            disableStyles={!!theme}
+            theme={ theme }
+            handleThemeSwitch={ this.handleThemeSwitch }
+          /> }
         </PluginSidebar>
       </>
     );

--- a/assets/src/components/Sidebar/LegacyThemeSettings.js
+++ b/assets/src/components/Sidebar/LegacyThemeSettings.js
@@ -75,7 +75,7 @@ export const LegacyThemeSettings = props => {
     <div className="components-panel__body is-opened">
       <ThemeSelect
         metaKey='theme'
-        label={ __( 'Theme', 'planet4-blocks-backend' ) }
+        label={ __( 'Legacy Theme', 'planet4-blocks-backend' ) }
         options={ themeOptions }
         getNewMeta={ handleThemeSwitch }
       />

--- a/assets/src/components/Sidebar/LegacyThemeSettings.js
+++ b/assets/src/components/Sidebar/LegacyThemeSettings.js
@@ -75,7 +75,7 @@ export const LegacyThemeSettings = props => {
     <div className="components-panel__body is-opened">
       <ThemeSelect
         metaKey='theme'
-        label={ __( 'Legacy Theme', 'planet4-blocks-backend' ) }
+        label={ __( 'Theme', 'planet4-blocks-backend' ) }
         options={ themeOptions }
         getNewMeta={ handleThemeSwitch }
       />

--- a/assets/src/components/Sidebar/NewThemeSettings.js
+++ b/assets/src/components/Sidebar/NewThemeSettings.js
@@ -70,10 +70,14 @@ export const NewThemeSettings = ({ onChange, currentTheme }) => {
 
   useAppliedCssVariables(serverThemes, currentTheme);
 
+  if (Object.keys(serverThemes).length === 0) {
+    return null;
+  }
+
   return <div className="components-panel__body is-opened">
     <span>
-      NOTE: This checkbox is to make it easier to compare the old and new version and check if they're the same.
-      It will not be used on production.
+      This dropdown contains themes that were created on this instance. It will be empty on production, as these won't
+      have any themes created. Once we confirmed the created themes we add them to below dropdown.
     </span>
     <SelectControl
       label={ __('New Theme', 'planet4-blocks-backend') }

--- a/assets/src/components/Sidebar/NewThemeSettings.js
+++ b/assets/src/components/Sidebar/NewThemeSettings.js
@@ -1,0 +1,86 @@
+import { SelectControl } from '@wordpress/components';
+import { useState, useEffect } from 'react';
+import { p4ServerThemes } from '../../theme/p4ServerThemes';
+import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+
+const keysAsLabel = obj => Object.keys(obj).map(k => ({ label: k, value: k }));
+
+// Just a lightweight way to have a separate UI element in the sidebar so that it's clear which themes are legacy and
+// which are new. This is likely just for internal usage to facilitate reviewing the refactored version, eventually
+// editors will work with a single select.
+const useServerThemes = () => {
+  const [serverThemes, setServerThemes] = useState({});
+
+  useEffect(() => {
+    (async () => {
+      const themes = await p4ServerThemes.fetchThemes();
+      setServerThemes(themes);
+    })();
+  }, []);
+
+  return serverThemes;
+};
+
+const getAllDefinedProps = () => Object.values(document.documentElement.style).filter(k => {
+  return 'string' === typeof k && k.match(/^--/);
+});
+
+const useAppliedCssVariables = (serverThemes, currentTheme) => {
+  const [initialVars] = useState(() => getAllDefinedProps(), []);
+
+  const applyChangesToDom = () => {
+    console.log('Applying ');
+    const theme = serverThemes[currentTheme] || {};
+    if (!theme) {
+      return;
+    }
+    Object.entries(theme).forEach(([name, value]) => {
+      // This will only work reliably if no other code is adding new custom properties to the root element after this
+      // component is first rendered. This should be the case in the post editor.
+      document.documentElement.style.setProperty(name, value);
+    });
+
+    const customProps = getAllDefinedProps();
+
+    customProps.forEach(k => {
+      if (!Object.keys(theme).includes(k) && !initialVars.includes(k)) {
+        console.log('removing', k);
+        document.documentElement.style.removeProperty(k);
+      }
+    });
+  };
+  useEffect(applyChangesToDom, [serverThemes, currentTheme]);
+};
+
+export const NewThemeSettings = ({ onChange, currentTheme }) => {
+  const [selectedTheme, setSelectedTheme] = useState(currentTheme);
+  const {editPost} = useDispatch('core/editor');
+  const serverThemes = useServerThemes();
+
+  const emitOnChange = () => {
+    if (selectedTheme !== null) {
+      const meta = { theme: selectedTheme };
+      console.log(meta);
+      onChange(selectedTheme);
+      editPost({meta});
+    }
+  };
+  useEffect(emitOnChange, [selectedTheme]);
+
+  useAppliedCssVariables(serverThemes, currentTheme);
+
+  return <div className="components-panel__body is-opened">
+    <span>
+      NOTE: This checkbox is to make it easier to compare the old and new version and check if they're the same.
+      It will not be used on production.
+    </span>
+    <SelectControl
+      label={ __('New Theme', 'planet4-blocks-backend') }
+      title={ __('Only for reviewing themes, not intended to be 2 drop downs in the final version.', 'planet4-blocks-backend') }
+      options={ [{ label: 'Legacy', value: '' }, ...keysAsLabel(serverThemes)] }
+      onChange={ setSelectedTheme }
+      value={ selectedTheme || '' }
+    />
+  </div>;
+};

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -11,6 +11,7 @@ namespace P4GBKS;
 use P4\MasterTheme\Features;
 use P4\MasterTheme\MigrationLog;
 use P4\MasterTheme\Migrations\M001EnableEnFormFeature;
+use P4\MasterTheme\PostCampaign;
 use P4GBKS\Controllers;
 use P4GBKS\Views\View;
 use WP_CLI;
@@ -463,7 +464,9 @@ final class Loader {
 
 		$campaign_theme = $post->theme ?? $post->custom['_campaign_page_template'] ?? null;
 
-		if ( ! is_string( $campaign_theme ) || empty( $campaign_theme ) ) {
+		if ( ! is_string( $campaign_theme ) || empty( $campaign_theme )
+			|| ! in_array( $campaign_theme, PostCampaign::LEGACY_THEMES, true )
+		) {
 			return;
 		}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2306,9 +2306,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "version": "7.14.8",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
+          "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -9466,9 +9466,9 @@
       "dev": true
     },
     "hotkeys-js": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.8.3.tgz",
-      "integrity": "sha512-rUmoryG4lEAtkjF5tcYaihrVoE86Fdw1BLqO/UiBWOOF56h32a6ax8oV4urBlinVtNNtArLlBq8igGfZf2tQnw=="
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.8.7.tgz",
+      "integrity": "sha512-ckAx3EkUr5XjDwjEHDorHxRO2Kb7z6Z2Sxul4MbBkN8Nho7XDslQsgMJT+CiJ5Z4TgRxxvKHEpuLE3imzqy4Lg=="
     },
     "hsl-regex": {
       "version": "1.0.0",
@@ -14956,11 +14956,11 @@
       }
     },
     "react-hotkeys-hook": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-3.3.1.tgz",
-      "integrity": "sha512-y6eCMEysh09lIgRQvIC76L7ehqUWf/7h8VlqT6w7RRnim5CX5CXldo64+CjWanIcgr++q5yTNwr7A/8DXA1u9A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-3.3.2.tgz",
+      "integrity": "sha512-sR98wtrz3qyVZ5G3I5TTRy7Odm1I9poGt1VwT4RN1ztnobRV/pNGja+6B+LONv+IBIyHLvidzW8IZRB7AuAUkw==",
       "requires": {
-        "hotkeys-js": "3.8.3"
+        "hotkeys-js": "3.8.7"
       }
     },
     "react-is": {
@@ -18227,9 +18227,9 @@
       "dev": true
     },
     "use-theme-editor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/use-theme-editor/-/use-theme-editor-1.0.3.tgz",
-      "integrity": "sha512-4ppYOIj8hAyeat4oaBJBwo/bv817XVBkq+XLb1cm1T/FE+fr3eHtGajh4YVlDlxHc/V/Bnt7OKGco7QPxHa9sA==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/use-theme-editor/-/use-theme-editor-1.0.9.tgz",
+      "integrity": "sha512-C33/eB6YJmedf33nNW+NakDnif7/sO6LVDgpX3wDP8WmsiCoAm3haVhZ5tarjlXFyRhwoyqyOVUcrN6qtOu3cQ==",
       "requires": {
         "balanced-match": "^2.0.0",
         "font-picker-react": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "classnames": "^2.2.6",
     "jest-environment-node": "^26.0.1",
     "photoswipe": "^4.1.3",
-    "use-theme-editor": "^1.0.3"
+    "use-theme-editor": "^1.0.9"
   }
 }

--- a/templates/blocks/css_variables.twig
+++ b/templates/blocks/css_variables.twig
@@ -1,7 +1,7 @@
 {% spaceless %}
 style="
 	{% for key,value in css_variables %}
-		--{{ key }}: {{ value }};
+		--{{ key|trim('--', 'left') }}: {{ value|raw }};
 	{% endfor %}
 	"
 {% endspaceless %}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6136

---

This PR makes it possible to use a theme that was created with the experimental theme editor on a campaign. The theme name is still stored in the same meta field.

To make it possible to use the same options as one of the legacy themes, you can create a theme with the same name but `-new` appended, in which case those sidebar options are loaded. This is not intended to be used by end users, just an easy way for us to ensure the same options still work on the newer version.

As a bonus, it also includes the code needed to apply the theme's variables in the post editor. I didn't intend to do that, but it didn't require a lot of changes. It doesn't work 100% of the time, since not all front end CSS is used in the editor. But most things do and we can add the variables to the editor specific CSS later.

This PR should leave functionality unchanged on production, since there it won't have any created themes.

Review/test tips:
* We probably also want to test this on an instance that doesn't have any themes so we can verify it doesn't break that case. To do that you can change the label on this PR to another instance, and re-run the workflow to make it deploy.