### PR TITLE
Prevent console flooded by warnings

### DIFF
--- a/assets/src/blocks/Articles/ArticlePreview.js
+++ b/assets/src/blocks/Articles/ArticlePreview.js
@@ -72,7 +72,7 @@ export class ArticlePreview extends Component {
           <img
             className="d-flex topicwise-article-image"
             src={thumbnail_url}
-            srcSet={thumbnail_srcset}
+            srcSet={thumbnail_srcset || null}
             alt={alt_text}
             loading="lazy"
             sizes={IMAGE_SIZES.preview}

--- a/assets/src/blocks/Articles/ArticlesList.js
+++ b/assets/src/blocks/Articles/ArticlesList.js
@@ -7,7 +7,7 @@ export const ArticlesList = (props) => {
     <div className="article-list-section clearfix">
       {posts && posts.length > 0 && posts.map(post =>
         <ArticlePreview
-          key={post.post_title}
+          key={post.ID}
           isCampaign={postType === 'campaign'}
           post={post}
         />


### PR DESCRIPTION
Ref: no dedicated ticket

---

These 2 things are causing the same warnings each time the block is rendered, which gets in the way of debugging other console output. The `srcset` should probably be further investigated, since we always want to use it, but for some reason it's `false` sometimes.
