### PR TITLE
PLANET-6156: Split Spreadsheet block scripts

### DIFF
--- a/assets/src/blocks/Spreadsheet/SpreadsheetBlock.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetBlock.js
@@ -1,42 +1,34 @@
-import { SpreadsheetEditor } from './SpreadsheetEditor';
+import { SpreadsheetEditor } from './SpreadsheetEditorScript';
 import { CSS_VARIABLES_ATTRIBUTE } from '../CssVariablesAttribute';
 import { frontendRendered } from '../frontendRendered';
 
+const {__} = wp.i18n;
 const BLOCK_NAME = 'planet4-blocks/spreadsheet';
 
-export class SpreadsheetBlock {
-  constructor() {
-    const { registerBlockType } = wp.blocks;
-    const { __ } = wp.i18n;
-    const attributes = {
-      url: {
-        type: 'string',
-        default: '',
-      },
-      css_variables: CSS_VARIABLES_ATTRIBUTE,
-    };
+const attributes = {
+  url: {
+    type: 'string',
+    default: '',
+  },
+  css_variables: CSS_VARIABLES_ATTRIBUTE,
+};
 
-    registerBlockType( BLOCK_NAME, {
-      title: __( 'Spreadsheet', 'planet4-blocks-backend' ),
-      icon: 'editor-table',
-      category: 'planet4-blocks',
-      attributes,
-      deprecated: [
-        {
-          attributes,
-          save() {
-            return null;
-          },
-        }
-      ],
-      edit: ( { isSelected, attributes, setAttributes } ) => {
-        return <SpreadsheetEditor
-          attributes={attributes}
-          setAttributes={setAttributes}
-          isSelected={ isSelected }
-        />
-      },
-      save: frontendRendered( BLOCK_NAME )
-    } );
-  };
+export const registerSpreadsheetBlock = () => {
+  const { registerBlockType } = wp.blocks;
+  registerBlockType( BLOCK_NAME, {
+    title: __( 'Spreadsheet', 'planet4-blocks-backend' ),
+    icon: 'editor-table',
+    category: 'planet4-blocks',
+    attributes,
+    deprecated: [
+      {
+        attributes,
+        save() {
+          return null;
+        },
+      }
+    ],
+    edit: SpreadsheetEditor,
+    save: frontendRendered( BLOCK_NAME )
+  });
 }

--- a/assets/src/blocks/Spreadsheet/SpreadsheetEditorScript.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetEditorScript.js
@@ -60,13 +60,14 @@ export class SpreadsheetEditor extends Component {
   }
 
   renderEdit() {
+
     const {__} = wp.i18n;
 
     const { attributes, setAttributes } = this.props;
 
     const toCssVariables = ( value ) => {
       setAttributes( {
-        css_variables: colors_variables_map[value]
+        css_variables: colors_variables_map[value] ?? {}
       } );
     };
 

--- a/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
@@ -133,7 +133,7 @@ export class SpreadsheetFrontend extends Component {
   renderRows() {
     const rows = this.sortRows( this.filterMatchingRows( this.getRows() ), this.state.sortColumnIndex );
 
-    return this.state.searchText.length > 1 && rows.length === 0
+    return this.state.searchText.length >= 1 && rows.length === 0
       ? <tr>
           <td colSpan="99999">
             <div className='spreadsheet-empty-message'>

--- a/assets/src/blocks/Spreadsheet/SpreadsheetScript.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetScript.js
@@ -1,0 +1,10 @@
+import { SpreadsheetFrontend } from './SpreadsheetFrontend';
+
+document.addEventListener( 'DOMContentLoaded', () => {
+  const spreadsheetBlocks = [...document.querySelectorAll('[data-render="planet4-blocks/spreadsheet"]')];
+
+  spreadsheetBlocks.forEach(blockNode => {
+    const attributes = JSON.parse( blockNode.dataset.attributes );
+    wp.element.render( <SpreadsheetFrontend { ...attributes.attributes } />, blockNode );
+  });
+});

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -16,7 +16,7 @@ import { registerTimelineBlock } from './blocks/Timeline/TimelineBlock';
 import { addBlockFilters } from './BlockFilters';
 import { setupImageBlockExtension } from './ImageBlockExtension';
 import { replaceTaxonomyTermSelectors } from './replaceTaxonomyTermSelectors';
-import { SpreadsheetBlock } from './blocks/Spreadsheet/SpreadsheetBlock'
+import { registerSpreadsheetBlock } from './blocks/Spreadsheet/SpreadsheetBlock'
 import { addButtonLinkPasteWarning } from './addButtonLinkPasteWarning';
 import { setupCustomSidebar } from './setupCustomSidebar';
 import { setUpCssVariables } from './connectCssVariables';
@@ -38,7 +38,7 @@ registerMediaBlock();
 new SocialmediaBlock();
 new SocialMediaCardsBlock();
 registerSplittwocolumnsBlock();
-new SpreadsheetBlock();
+registerSpreadsheetBlock();
 registerSubmenuBlock();
 new SubPagesBlock();
 new TakeactionboxoutBlock();

--- a/assets/src/frontendIndex.js
+++ b/assets/src/frontendIndex.js
@@ -1,4 +1,3 @@
-import { SpreadsheetFrontend } from './blocks/Spreadsheet/SpreadsheetFrontend';
 import { CounterFrontend } from './blocks/Counter/CounterFrontend';
 import { ArticlesFrontend } from './blocks/Articles/ArticlesFrontend';
 import { CookiesFrontend } from './blocks/Cookies/CookiesFrontend';
@@ -14,7 +13,6 @@ import { setupLightboxForImages } from './components/Lightbox/setupLightboxForIm
 
 // Render React components
 const COMPONENTS = {
-  'planet4-blocks/spreadsheet': SpreadsheetFrontend,
   'planet4-blocks/counter': CounterFrontend,
   'planet4-blocks/articles': ArticlesFrontend,
   'planet4-blocks/cookies': CookiesFrontend,

--- a/assets/src/styles/blocks.scss
+++ b/assets/src/styles/blocks.scss
@@ -16,7 +16,6 @@
 @import "blocks/Socialmedia";
 @import "blocks/SocialMediaCards";
 @import "blocks/SplitTwoColumns";
-@import "blocks/Spreadsheet";
 @import "blocks/Submenu";
 @import "blocks/Cookies";
 

--- a/assets/src/styles/blocks/Spreadsheet/SpreadsheetStyle.scss
+++ b/assets/src/styles/blocks/Spreadsheet/SpreadsheetStyle.scss
@@ -1,3 +1,8 @@
+@import "../../master-theme/assets/src/scss/base/variables";
+@import "../../master-theme/assets/src/scss/base/colors";
+@import "../../master-theme/assets/src/scss/base/mixins";
+@import "../../master-theme/assets/src/scss/base/fonts";
+
 .block-spreadsheet {
   display: inline-block;
   margin-top: $space-xs;

--- a/classes/blocks/class-base-block.php
+++ b/classes/blocks/class-base-block.php
@@ -130,11 +130,16 @@ abstract class Base_Block {
 	 * Editor script
 	 */
 	public static function enqueue_editor_script(): void {
+		$filepath = static::get_dir_path() . 'EditorScript.js';
+		if ( ! file_exists( $filepath ) ) {
+			return;
+		}
+
 		wp_enqueue_script(
 			static::get_full_block_name() . '-editor-script',
 			static::get_url_path() . 'EditorScript.js',
 			'planet4-blocks-editor-script',
-			\P4GBKS\Loader::file_ver( static::get_dir_path() . 'EditorScript.js' ),
+			\P4GBKS\Loader::file_ver( $filepath ),
 			true
 		);
 	}
@@ -143,11 +148,16 @@ abstract class Base_Block {
 	 * Editor style
 	 */
 	public static function enqueue_editor_style(): void {
+		$filepath = static::get_dir_path() . 'EditorStyle.min.css';
+		if ( ! file_exists( $filepath ) ) {
+			return;
+		}
+
 		wp_enqueue_style(
 			static::get_full_block_name() . '-editor-style',
 			static::get_url_path() . 'EditorStyle.min.css',
 			[],
-			\P4GBKS\Loader::file_ver( static::get_dir_path() . 'EditorStyle.min.css' ),
+			\P4GBKS\Loader::file_ver( $filepath ),
 		);
 	}
 
@@ -155,11 +165,16 @@ abstract class Base_Block {
 	 * Frontend script
 	 */
 	public static function enqueue_frontend_script(): void {
+		$filepath = static::get_dir_path() . 'Script.js';
+		if ( ! file_exists( $filepath ) ) {
+			return;
+		}
+
 		wp_enqueue_script(
 			static::get_full_block_name() . '-script',
 			static::get_url_path() . 'Script.js',
 			'planet4-blocks-script',
-			\P4GBKS\Loader::file_ver( static::get_dir_path() . 'Script.js' ),
+			\P4GBKS\Loader::file_ver( $filepath ),
 			true
 		);
 	}
@@ -168,11 +183,16 @@ abstract class Base_Block {
 	 * Frontend style
 	 */
 	public static function enqueue_frontend_style(): void {
+		$filepath = static::get_dir_path() . 'Style.min.css';
+		if ( ! file_exists( $filepath ) ) {
+			return;
+		}
+
 		wp_enqueue_style(
 			static::get_full_block_name() . '-style',
 			static::get_url_path() . 'Style.min.css',
 			[],
-			\P4GBKS\Loader::file_ver( static::get_dir_path() . 'Style.min.css' ),
+			\P4GBKS\Loader::file_ver( $filepath ),
 		);
 	}
 

--- a/classes/blocks/class-spreadsheet.php
+++ b/classes/blocks/class-spreadsheet.php
@@ -25,6 +25,13 @@ class Spreadsheet extends Base_Block {
 	 * SpreadsheetTable constructor.
 	 */
 	public function __construct() {
+		add_action( 'init', [ $this, 'register_spreadsheet_block' ] );
+	}
+
+	/**
+	 * Register block
+	 */
+	public function register_spreadsheet_block() {
 		register_block_type(
 			self::get_full_block_name(),
 			[
@@ -38,6 +45,9 @@ class Spreadsheet extends Base_Block {
 				],
 			]
 		);
+
+		add_action( 'enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ] );
+		add_action( 'wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ] );
 	}
 
 	/**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,7 @@ module.exports = {
     ...entryPoints('Accordion'),
     ...entryPoints('Covers'),
     ...entryPoints('CarouselHeader'),
+    ...entryPoints('Spreadsheet'),
     ...entryPoints('Timeline'),
   },
   output: {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6156

Split Spreadsheet scripts to only be loaded when a block is present on the page.

![Screenshot from 2021-05-20 16-01-49](https://user-images.githubusercontent.com/617346/118992289-c95bf280-b984-11eb-8bcc-32e5eb61cc84.png)


## Test

[Spreadsheet block](https://planet4.greenpeace.org/act/block-spreadsheet-table/#spreadsheet-block) should work as expected
- After pulling this PR, rebuild JS and CSS assets
- Add a spreadsheet to a page
- Use this doc for test https://docs.google.com/spreadsheets/d/e/2PACX-1vQz5nftk5gXiehFtdxLokvInQ4au5vAMdslL--x6RMawo8Y4NgXBOlx26PzWy9heM4hytv67FkkKg4T/pubhtml
- Spreadsheet should appear on frontend and in editor as usual, with proper styling
- You can see scripts being loaded independently for Spreadsheet in you console network tab, in the editor and on the frontend

## Common functions imported

For this split I checked bits webpack imported in the compiled file that are used elsewhere and that we could load globally once instead:
```
// only used in Spreadsheet
blocks/HighlightMatches.js
blocks/toDeclarations.js
// used elsewhere, could be exported to external dep
functions/addQueryArgs.js
functions/fetchJson.js
```
We could create a ticket to import all functions in our namespace in one go, `p4.fetchJson()`, etc. and declare it as `externals` for webpack ?

<a id="genericmethod" name="genericmethod"></a>
## Generic method for following tickets

Replacing `{Blockname}` by PascalCase block name, and `{blockname}` by lowercase block name.

#### Styles

In `assets/src/styles/blocks`:
- Create styles directory
  `mkdir {Blockname}`
- Move existing styles
  `git mv {Blockname}.scss {Blockname}/{Blockname}Style.scss`
  `git mv {Blockname}Editor.scss {Blockname}/{Blockname}EditorStyle.scss`
  If no style file exists, you don't have to create an empty one.
- Import missing styles in style files, eg:
```scss
    /* {Blockname}/{Blockname}Style.scss */
    @import "../../master-theme/assets/src/scss/base/variables";
    @import "../../master-theme/assets/src/scss/base/colors";
    @import "../../master-theme/assets/src/scss/base/mixins";
```

#### Scripts

In `assets/src/blocks`:
- Create script file and include render code
  `touch {Blockname}/{Blockname}Script.js`
``` js
import { {Blockname}Frontend } from './{Blockname}Frontend';

document.addEventListener( 'DOMContentLoaded', () => {
  const {blockname}Blocks = [...document.querySelectorAll('[data-render="planet4-blocks/{blockname}"]')];

  {blockname}Blocks.forEach(blockNode => {
    const attributes = JSON.parse( blockNode.dataset.attributes );
    wp.element.render( <{Blockname}Frontend { ...attributes.attributes } />, blockNode );
  });
});
```   
- Remove import from `assets/src/frontendIndex.js`
- Rename editor script
  `git mv {Blockname}/{Blockname}Editor.js {Blockname}/{Blockname}EditorScript.js`
- Modify references to this file accordingly
- If necessary, edit {Blockname}/{Blockname}Block.js to export a register function instead of a class
- Modify `assets/src/editorIndex.js` accordingly

#### PHP class

- Enqueue scripts in `classes/blocks/class-{blockname}.php`, extract register function from constructor
``` php
	/**
	 * Constructor.
	 */
	public function __construct() {
		add_action( 'init', [ $this, 'register_{blockname}_block' ] );
	}

	/**
	 * Register block
	 */
	public function register_{blockname}_block() {
		register_block_type(
			self::get_full_block_name(),
			[...]
		);

		add_action( 'enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ] );
		add_action( 'wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ] );
	}
```
- If a script does not exist, explicitly declare it in the class, eg:
```php
	/**
	 * Spreadsheet has no editor style.
	 */
	public static function enqueue_editor_style(): void {
	}
```