### PR TITLE
A11y: Address accessibility of spreadsheet block

### DIFF
--- a/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
@@ -187,9 +187,13 @@ export class SpreadsheetFrontend extends Component {
                           )
                         }
                         onClick={ () => { this.onHeaderClick( index ) } }
-                        key={ index } title={ __('Sort by', 'planet4-blocks') }>
-                        { cell }
-                        <ArrowIcon />
+                        key={ index }
+                        scope='col'
+                        title={ cell }>
+                        <button>
+                          { cell }
+                          <ArrowIcon />
+                        </button>
                       </th>
                     ))
                   }

--- a/assets/src/styles/blocks/Spreadsheet/SpreadsheetStyle.scss
+++ b/assets/src/styles/blocks/Spreadsheet/SpreadsheetStyle.scss
@@ -44,6 +44,13 @@ table.spreadsheet-table {
       background-color: $table-header-grey;
       border-bottom-color: $table-header-grey;
     }
+
+    button {
+      background-color: inherit;
+      color: inherit;
+      border: none;
+    }
+
     color: $white;
     border-bottom: 1px solid;
     cursor: pointer;


### PR DESCRIPTION
- Ensure column sorting is tab-accessible by enclosing the header text
  and sort icon in a button. Note that I am keeping the rest of the
  table header clickable, since this will ensure a larger click area.
- Use the table header text as the title
- Add a scope attribute

Ref: Fixes https://github.com/greenpeace/planet4/issues/120

---

<!--
Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
