### PR TITLE
PLANET-4814: Move ENForm to "old"

### DIFF
--- a/assets/src/blocks/OldENForm/ENForm.js
+++ b/assets/src/blocks/OldENForm/ENForm.js
@@ -1,0 +1,369 @@
+import {Component} from '@wordpress/element';
+import {Preview} from '../../components/enform/Preview';
+import {LayoutSelector} from '../../components/enform/LayoutSelector/LayoutSelector';
+import {FormSectionTitle} from '../../components/enform/FormSectionTitle/FormSectionTitle';
+import {FormHelp} from '../../components/enform/FormHelp/FormHelp';
+import {InlineFormFeedback} from '../../components/enform/InlineFormFeedback/InlineFormFeedback';
+import {
+  TextControl,
+  TextareaControl,
+  ToggleControl,
+  SelectControl,
+  ServerSideRender
+} from '@wordpress/components';
+import {MediaPlaceholder} from "@wordpress/editor";
+import {ValidationMessage} from "../../components/enform/ValidationMessage/ValidationMessage";
+
+const {__} = wp.i18n;
+
+export class ENForm extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  isURLValid( url ) {
+    return !!url ? url.substr(0, 8).toLowerCase() === 'https://' : true;
+  }
+
+  renderEdit() {
+    const {getCurrentPostType} = wp.data.select("core/editor");
+    const currentPostType      = getCurrentPostType();
+
+    let flattenedPages = [];
+    let pagesByType;
+
+    for (var i in window.p4en_vars.pages) {
+      pagesByType = window.p4en_vars.pages[i].map(page => {
+        return { label: page.name, value: page.id };
+      });
+      flattenedPages = flattenedPages.concat(
+        { label: '-- ' + i, value: i }, // Page type label
+        ...pagesByType
+      );
+    }
+
+    const en_forms = window.p4en_vars.forms.map(form => {
+      return { label: form.post_title, value: form.ID };
+    });
+
+    return (
+      <div>
+        <div>
+          <FormSectionTitle>{__(
+            'EN Form options',
+            'planet4-engagingnetworks-backend'
+          )}</FormSectionTitle>
+
+          <FormHelp>{__(
+            'Display options for EN Forms',
+            'planet4-engagingnetworks-backend'
+          )}</FormHelp>
+
+          <SelectControl
+            label={__( 'Engaging Network Live Pages', 'planet4-engagingnetworks-backend' )}
+            value={this.props.en_page_id}
+            options={[
+              { label: 'No pages', value: 0 },
+              ...flattenedPages
+            ]}
+            disabled={!flattenedPages.length}
+            onChange={this.props.onPageChange}
+          />
+
+          { flattenedPages.length
+            ? <FormHelp>
+                { __( 'Select the Live EN page that this form will be submitted to.', 'planet4-engagingnetworks-backend' ) }
+              </FormHelp>
+            : <InlineFormFeedback>
+                { __( 'Check your EngagingNetworks settings!', 'planet4-engagingnetworks-backend' ) }
+              </InlineFormFeedback>
+          }
+          <br />
+          <SelectControl
+            label={__( '- Select Goal -', 'planet4-engagingnetworks-backend' )}
+            value={this.props.enform_goal}
+            options={[
+              { label: __( '--- Select Goal ---', 'planet4-engagingnetworks-backend' ), value: 'not set' },
+              { label: 'Petition Signup', value: 'Petition Signup' },
+              { label: 'Action Alert', value: 'Action Alert' },
+              { label: 'Contact Form', value: 'Contact Form' },
+              { label: 'Other', value: 'Other' },
+            ]}
+            onChange={this.props.onGoalChange}
+          />
+
+          <div>
+            <LayoutSelector
+              selectedOption={this.props.en_form_style}
+              onSelectedLayoutChange={this.props.onSelectedLayoutChange}
+              options={[
+                {
+                  label: __( 'Page body / text size width. No background.', 'planet4-engagingnetworks-backend' ),
+                  image: window.p4en_vars.home + 'images/enfullwidth.png',
+                  value: 'full-width',
+                  help: __( 'Use: on long pages (more than 5 screens) when list items are long (+ 10 words)<br>No max items<br>recommended.', 'planet4-engagingnetworks-backend' ),
+                }, {
+                  label: __( 'Full page width. With background image.', 'planet4-engagingnetworks-backend' ),
+                  image: window.p4en_vars.home + 'images/enfullwidthbg.png',
+                  value: 'full-width-bg',
+                  help: __( 'This form has a background image that expands the full width of the browser (aka "Happy Point").', 'planet4-engagingnetworks-backend' ),
+                },
+                {
+                  label: __( 'Form on the side.', 'planet4-engagingnetworks-backend' ),
+                  image: window.p4en_vars.home + 'images/submenu-sidebar.jpg',
+                  value: 'side-style',
+                  help: __( 'Form will be added to the top of the page, on the right side for most languages and on the left side for Right-to-left(RTL) languages.', 'planet4-engagingnetworks-backend' ),
+                },
+              ]}
+            />
+          </div>
+
+          <div>
+            <TextControl
+              label={ __( 'Form Title', 'planet4-engagingnetworks-backend' ) }
+              placeholder={ __( 'Enter title', 'planet4-engagingnetworks-backend' ) }
+              value={this.props.title}
+              onChange={this.props.onTitleChange}
+            />
+          </div>
+
+          <div>
+            <TextareaControl
+              label={ __( 'Form Description', 'planet4-engagingnetworks-backend' ) }
+              placeholder={ __( 'Enter description', 'planet4-engagingnetworks-backend' ) }
+              value={this.props.description}
+              onChange={this.props.onDescriptionChange}
+            />
+          </div>
+
+          { "side-style" === this.props.en_form_style &&
+          (<div>
+
+              { "campaign" === currentPostType && (
+                <div>
+                  <ToggleControl
+                    label={__( 'Use Campaign Logo?', 'planet4-engagingnetworks-backend' )}
+                    value={this.props.campaign_logo}
+                    checked={this.props.campaign_logo}
+                    onChange={this.props.onCampaignLogoChange}
+                  />
+                </div>
+              )}
+
+              <div>
+                <TextControl
+                  label={ __( 'Content Title', 'planet4-engagingnetworks-backend' ) }
+                  placeholder={ __( 'Enter content title', 'planet4-engagingnetworks-backend' ) }
+                  value={this.props.content_title}
+                  onChange={this.props.onContentTitleChange}
+                />
+              </div>
+
+              <div>
+                <SelectControl
+                  label={ __( 'Content Title text size', 'planet4-engagingnetworks-backend' ) }
+                  value={this.props.content_title_size}
+                  options={ [
+                    { label: __( 'Select title size', 'planet4-engagingnetworks-backend' ), value: '' },
+                    { label: 'h1', value: 'h1' },
+                    { label: 'h2', value: 'h2' },
+                    { label: 'h3', value: 'h3' },
+                  ] }
+                  onChange={this.props.onContentTitleSizeChange}
+                />
+              </div>
+
+              <div>
+                <TextareaControl
+                  label={ __( 'Content Description', 'planet4-engagingnetworks-backend' ) }
+                  placeholder={ __( 'Enter content description', 'planet4-engagingnetworks-backend' ) }
+                  value={this.props.content_description}
+                  onChange={this.props.onContentDescriptionChange}
+                />
+              </div>
+            </div>)
+          }
+
+          <div>
+            <TextControl
+              label={ __( 'Call to Action button (e.g. "Sign up now!")', 'planet4-engagingnetworks-backend' ) }
+              placeholder={ __( 'Enter the "Call to Action" button text', 'planet4-engagingnetworks-backend' ) }
+              value={this.props.button_text}
+              onChange={this.props.onCTAButtonTextChange}
+            />
+          </div>
+
+          <div>
+            <TextareaControl
+              label={ __( 'Text below Call to Action button', 'planet4-engagingnetworks-backend' ) }
+              placeholder={ __( 'Enter text to go below the button', 'planet4-engagingnetworks-backend' ) }
+              value={this.props.text_below_button}
+              onChange={this.props.onCTATextBelowButtonChange}
+            />
+          </div>
+
+          <FormSectionTitle>{__(
+            '"Thank You" message settings',
+            'planet4-engagingnetworks-backend'
+          )}</FormSectionTitle>
+
+          <div>
+            <TextControl
+              label={ __( 'Main text / Title', 'planet4-engagingnetworks-backend' ) }
+              placeholder={ __( 'e.g. "Thank you for signing!"', 'planet4-engagingnetworks-backend' ) }
+              value={this.props.thankyou_title}
+              onChange={this.props.onMainThankYouTextChange}
+            />
+          </div>
+
+          <div>
+            <TextControl
+              label={ __( 'Secondary message / Subtitle', 'planet4-engagingnetworks-backend' ) }
+              placeholder={ __( 'e.g. "Your support means world"', 'planet4-engagingnetworks-backend' ) }
+              value={this.props.thankyou_subtitle}
+              onChange={this.props.onSecondaryThankYouMessageChange}
+            />
+          </div>
+
+          <div>
+            <TextControl
+              label={ __( 'Social media message', 'planet4-engagingnetworks-backend' ) }
+              placeholder={ __( 'e.g. "Can you share it with your family and friends?"', 'planet4-engagingnetworks-backend' ) }
+              value={this.props.thankyou_social_media_message}
+              onChange={this.props.onThankYouTakeActionMessageChange}
+            />
+          </div>
+
+          <br/>
+
+          <ToggleControl
+            label={__( 'Hide "DONATE" button in Thank You message', 'planet4-engagingnetworks-backend' )}
+            value={this.props.donate_button_checkbox}
+            checked={this.props.donate_button_checkbox}
+            onChange={this.props.onDonateButtonCheckboxChange}
+            className="hide-donate-toggle-field"
+          />
+          { true !== this.props.donate_button_checkbox && (
+            <div>
+              <TextControl
+                label={ __( 'Donate message', 'planet4-engagingnetworks-backend' ) }
+                placeholder={ __( 'e.g. "or make a donation"', 'planet4-engagingnetworks-backend' ) }
+                value={this.props.thankyou_donate_message}
+                onChange={this.props.onThankYouDonateMessageChange}
+              />
+              <TextControl
+                label={ __( 'Custom DONATE url', 'planet4-engagingnetworks-backend' ) }
+                placeholder={ __( 'If empty, the default "DONATE" P4 Button link will be used', 'planet4-engagingnetworks-backend' ) }
+                value={this.props.custom_donate_url}
+                onChange={this.props.onCustomDonateUrlChange}
+              />
+              {!this.isURLValid( this.props.custom_donate_url ) &&
+              <span className='input_error'>{ __('The URL must start with "HTTPS://"', 'planet4-engagingnetworks-backend') }</span>}
+            </div> )
+          }
+          <br></br>
+          <div>
+            <TextControl
+              label={ __( 'Thank you page URL (Title, Subtitle, Social media message / icons and DONATE will not be shown)', 'planet4-engagingnetworks-backend' ) }
+              placeholder={ __( 'Enter "Thank you page" url', 'planet4-engagingnetworks-backend' ) }
+              value={this.props.thankyou_url}
+              onChange={this.props.onThankYouURLChange}
+            />
+            {!this.isURLValid( this.props.thankyou_url ) &&
+            <span className='input_error'>{ __('The URL must start with "HTTPS://"', 'planet4-engagingnetworks-backend') }</span>}
+          </div>
+
+          { "full-width" !== this.props.en_form_style &&
+            <div>
+              <MediaPlaceholder
+                labels={{ title: __( 'Background', 'planet4-engagingnetworks-backend' ), instructions: __( 'Select an image.', 'planet4-engagingnetworks-backend' )}}
+                icon="format-image"
+                onSelect={ this.props.onSelectImage }
+                onError={this.props.onUploadError}
+                accept="image/*"
+                allowedTypes={["image"]}
+              />
+            </div>
+          }
+
+          <div>
+            <SelectControl
+              label={__( 'Planet 4 Engaging Networks form', 'planet4-engagingnetworks-backend' )}
+              value={this.props.en_form_id}
+              options={[
+                { label: 'No forms', value: 0 },
+                ...en_forms
+              ]}
+              onChange={this.props.onFormChange}
+            />
+            <FormHelp>{ this.props.forms
+              ? __( 'Select the P4EN Form that will be displayed.', 'planet4-engagingnetworks-backend' )
+              : __( 'Create an EN Form', 'planet4-engagingnetworks-backend' )
+            }</FormHelp>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    let validationMessage = [];
+
+    if ( false === this.props.isSelected ) {
+      if ( undefined === this.props.en_page_id || 0 === this.props.en_page_id ) {
+        validationMessage.push( __( '"Engaging Network Live Pages" field is required!', 'planet4-engagingnetworks-backend' ));
+      }
+      if ( undefined === this.props.enform_goal || 'not set' === this.props.enform_goal || '' === this.props.enform_goal ) {
+        validationMessage.push( __( '"Select Goal" field is required!', 'planet4-engagingnetworks-backend' ));
+      }
+      if ( undefined === this.props.button_text || '' === this.props.button_text ) {
+        validationMessage.push( __( '"Call to Action button" field is required!', 'planet4-engagingnetworks-backend' ));
+      }
+      if ( undefined === this.props.en_form_id || 0 === this.props.en_form_id ) {
+        validationMessage.push( __( '"Planet 4 Engaging Networks form" field is required!', 'planet4-engagingnetworks-backend' ));
+      }
+    }
+
+    return (
+      <div>
+        {
+          this.props.isSelected
+            ? this.renderEdit()
+            : null
+        }
+        <Preview showBar={this.props.isSelected} isSelected={this.props.isSelected}>
+
+          { validationMessage.length ?
+              <ValidationMessage
+                message={validationMessage}
+              />
+            :
+              <ServerSideRender
+                block={'planet4-blocks/enform'}
+                attributes={{
+                  en_page_id: this.props.en_page_id,
+                  en_form_id: this.props.en_form_id,
+                  en_form_style: this.props.en_form_style,
+                  title: this.props.title,
+                  description: this.props.description,
+                  campaign_logo: this.props.campaign_logo,
+                  content_title: this.props.content_title,
+                  content_title_size: this.props.content_title_size,
+                  content_description: this.props.content_description,
+                  button_text: this.props.button_text,
+                  thankyou_title: this.props.thankyou_title,
+                  thankyou_subtitle: this.props.thankyou_subtitle,
+                  thankyou_donate_message: this.props.thankyou_donate_message,
+                  thankyou_social_media_message: this.props.thankyou_social_media_message,
+                  donate_button_checkbox: this.props.donate_button_checkbox,
+                  thankyou_url: this.props.thankyou_url,
+                  background: this.props.background,
+                }}
+              >
+              </ServerSideRender>
+          }
+        </Preview>
+      </div>
+    );
+  };
+}

--- a/assets/src/blocks/OldENForm/ENFormBlock.js
+++ b/assets/src/blocks/OldENForm/ENFormBlock.js
@@ -1,0 +1,332 @@
+import {ENForm} from './ENForm.js';
+
+export class ENFormBlock {
+  constructor() {
+    if (!window.p4ge_vars.features.feature_engaging_networks) {
+      return;
+    }
+    const {registerBlockType} = wp.blocks;
+
+    registerBlockType('planet4-blocks/enform', {
+      title: 'EN Form',
+      icon: 'feedback',
+      category: 'planet4-blocks',
+
+      // Transform the shortcode into a Gutenberg block
+      // this is used when a user clicks "Convert to blocks"
+      // on the "Classic Editor" block
+      transforms: {
+        from: [
+          {
+            type: 'shortcode',
+            // Shortcode tag can also be an array of shortcode aliases
+            tag: 'shortcake_enblock',
+            attributes: {
+              en_page_id: {
+                type: 'integer',
+                shortcode: function (attributes) {
+                  return Number(attributes.named.en_page_id);
+                }
+              },
+              enform_goal: {
+                type: 'string',
+                shortcode: function (attributes) {
+                  return attributes.named.enform_goal;
+                }
+              },
+              en_form_style: {
+                type: 'string',
+                shortcode: function (attributes) {
+                  return attributes.named.en_form_style;
+                }
+              },
+              title: {
+                type: 'string',
+                shortcode: function (attributes) {
+                  return attributes.named.title;
+                }
+              },
+              description: {
+                type: 'string',
+                shortcode: function (attributes) {
+                  return attributes.named.description;
+                }
+              },
+              campaign_logo: {
+                type: 'boolean',
+                shortcode: function (attributes) {
+                  return boolean(attributes.named.campaign_logo);
+                }
+              },
+              content_title: {
+                type: 'string',
+                shortcode: function (attributes) {
+                  return attributes.named.content_title;
+                }
+              },
+              content_title_size: {
+                type: 'string',
+                shortcode: function (attributes) {
+                  return attributes.named.content_title_size;
+                }
+              },
+              content_description: {
+                type: 'string',
+                shortcode: function (attributes) {
+                  return attributes.named.content_description;
+                }
+              },
+              button_text: {
+                type: 'string',
+                shortcode: function (attributes) {
+                  return attributes.named.button_text;
+                }
+              },
+              text_below_button: {
+                type: 'string',
+                shortcode: function (attributes) {
+                  return attributes.named.text_below_button;
+                }
+              },
+              thankyou_title: {
+                type: 'string',
+                shortcode: function (attributes) {
+                  return attributes.named.thankyou_title;
+                }
+              },
+              thankyou_subtitle: {
+                type: 'string',
+                shortcode: function (attributes) {
+                  return attributes.named.thankyou_subtitle;
+                }
+              },
+              thankyou_donate_message: {
+                type: 'string',
+                shortcode: function (attributes) {
+                  return attributes.named.thankyou_donate_message;
+                }
+              },
+              thankyou_social_media_message: {
+                type: 'string',
+                shortcode: function (attributes) {
+                  return attributes.named.thankyou_social_media_message;
+                }
+              },
+              donate_button_checkbox: {
+                type: 'boolean',
+                shortcode: function (attributes) {
+                  return boolean(attributes.named.donate_button_checkbox);
+                }
+              },
+              custom_donate_url: {
+                type: 'string',
+                shortcode: function (attributes) {
+                  return attributes.named.custom_donate_url;
+                }
+              },
+              thankyou_url: {
+                type: 'string',
+                shortcode: function (attributes) {
+                  return attributes.named.thankyou_url;
+                }
+              },
+              background: {
+                type: 'integer',
+                shortcode: function (attributes) {
+                  return attributes.named.background;
+                }
+              },
+              en_form_id: {
+                type: 'integer',
+                shortcode: function (attributes) {
+                  return Number(attributes.named.en_form_id);
+                }
+              },
+            },
+          },
+        ]
+      },
+      attributes: {
+        en_page_id: {
+          type: 'integer',
+        },
+        enform_goal: {
+          type: 'string',
+        },
+        en_form_style: {
+          type: 'string',
+        },
+        title: {
+          type: 'string',
+        },
+        description: {
+          type: 'string',
+        },
+        campaign_logo: {
+          type: 'boolean',
+        },
+        content_title: {
+          type: 'string',
+        },
+        content_title_size: {
+          type: 'string',
+        },
+        content_description: {
+          type: 'string',
+        },
+        button_text: {
+          type: 'string',
+        },
+        text_below_button: {
+          type: 'string',
+        },
+        thankyou_title: {
+          type: 'string',
+        },
+        thankyou_subtitle: {
+          type: 'string',
+        },
+        thankyou_donate_message: {
+          type: 'string',
+        },
+        thankyou_social_media_message: {
+          type: 'string',
+        },
+        donate_button_checkbox: {
+          type: 'boolean',
+        },
+        custom_donate_url: {
+          type: 'string',
+        },
+        thankyou_url: {
+          type: 'string',
+        },
+        background: {
+          type: 'integer',
+        },
+        en_form_id: {
+          type: 'integer',
+        },
+      },
+      edit: ({attributes, isSelected, setAttributes}) => {
+        function onPageChange(value) {
+          setAttributes({en_page_id: parseInt(value)});
+        }
+
+        function onGoalChange(value) {
+          setAttributes({enform_goal: value});
+        }
+
+        function onTitleChange(value) {
+          setAttributes({title: value});
+        }
+
+        function onDescriptionChange(value) {
+          setAttributes({description: value});
+        }
+
+        function onCampaignLogoChange(value) {
+          setAttributes({campaign_logo: value});
+        }
+
+        function onContentTitleChange(value) {
+          setAttributes({content_title: value});
+        }
+
+        function onContentTitleSizeChange(value) {
+          setAttributes({content_title_size: value});
+        }
+
+        function onContentDescriptionChange(value) {
+          setAttributes({content_description: value});
+        }
+
+        function onCTAButtonTextChange(value) {
+          setAttributes({button_text: value});
+        }
+
+        function onCTATextBelowButtonChange(value) {
+          setAttributes({text_below_button: value});
+        }
+
+        function onSelectedLayoutChange(value) {
+          setAttributes({en_form_style: value});
+        }
+
+        function onSelectImage(imageData) {
+          setAttributes({background: Number(imageData.id)});
+        }
+
+        function onSelectURL({url}) {
+          setAttributes({id: null});
+        }
+
+        function onMainThankYouTextChange(value) {
+          setAttributes({thankyou_title: value});
+        }
+
+        function onSecondaryThankYouMessageChange(value) {
+          setAttributes({thankyou_subtitle: value});
+        }
+
+        function onThankYouTakeActionMessageChange(value) {
+          setAttributes({thankyou_social_media_message: value});
+        }
+
+        function onDonateButtonCheckboxChange(value) {
+          setAttributes({donate_button_checkbox: value});
+        }
+
+        function onThankYouDonateMessageChange(value) {
+          setAttributes({thankyou_donate_message: value});
+        }
+
+        function onCustomDonateUrlChange(value) {
+          setAttributes({custom_donate_url: value});
+        }
+
+        function onThankYouURLChange(value) {
+          setAttributes({thankyou_url: value});
+        }
+
+        function onFormChange(value) {
+          setAttributes({en_form_id: Number(value)});
+        }
+
+        function onUploadError({message}) {
+          console.log(message);
+        }
+
+        return <ENForm
+          {...attributes}
+          isSelected={isSelected}
+          onPageChange={onPageChange}
+          onGoalChange={onGoalChange}
+          onTitleChange={onTitleChange}
+          onDescriptionChange={onDescriptionChange}
+          onCampaignLogoChange={onCampaignLogoChange}
+          onContentTitleChange={onContentTitleChange}
+          onContentTitleSizeChange={onContentTitleSizeChange}
+          onContentDescriptionChange={onContentDescriptionChange}
+          onCTAButtonTextChange={onCTAButtonTextChange}
+          onCTATextBelowButtonChange={onCTATextBelowButtonChange}
+          onSelectedLayoutChange={onSelectedLayoutChange}
+          onSelectImage={onSelectImage}
+          onSelectURL={onSelectURL}
+          onMainThankYouTextChange={onMainThankYouTextChange}
+          onSecondaryThankYouMessageChange={onSecondaryThankYouMessageChange}
+          onThankYouTakeActionMessageChange={onThankYouTakeActionMessageChange}
+          onDonateButtonCheckboxChange={onDonateButtonCheckboxChange}
+          onThankYouURLChange={onThankYouURLChange}
+          onThankYouDonateMessageChange={onThankYouDonateMessageChange}
+          onCustomDonateUrlChange={onCustomDonateUrlChange}
+          onFormChange={onFormChange}
+          onUploadError={onUploadError}
+        />
+      },
+      save() {
+        return null;
+      }
+    });
+  };
+}

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -22,7 +22,7 @@ import { setupCustomSidebar } from './setupCustomSidebar';
 import { setUpCssVariables } from './connectCssVariables';
 import { SubPagesBlock } from './blocks/SubPages/SubPagesBlock';
 import { blockEditorValidation } from './BlockEditorValidation';
-import { ENFormBlock } from './blocks/ENForm/ENFormBlock';
+import { ENFormBlock } from './blocks/OldENForm/ENFormBlock';
 import { registerGuestBookBlock } from './blocks/GuestBook/GuestBookBlock';
 
 blockEditorValidation();

--- a/assets/src/styles/blocks.scss
+++ b/assets/src/styles/blocks.scss
@@ -24,15 +24,15 @@
 @import "blocks/Covers/TakeActionBoxoutBottom";
 
 // EN Blocks
-@import "blocks/ENForm/components/enform";
-@import "blocks/ENForm/components/enform-full-width-bg";
-@import "blocks/ENForm/components/enform-full-width";
-@import "blocks/ENForm/components/enform-side-style";
+@import "blocks/OldENForm/components/enform";
+@import "blocks/OldENForm/components/enform-full-width-bg";
+@import "blocks/OldENForm/components/enform-full-width";
+@import "blocks/OldENForm/components/enform-side-style";
 // Campaigns - mixins
-@import "blocks/ENForm/campaigns/mixins";
+@import "blocks/OldENForm/campaigns/mixins";
 // Campaigns - themes
-@import "blocks/ENForm/campaigns/campaign_enform";
-@import "blocks/ENForm/campaigns/themes/theme_climate";
+@import "blocks/OldENForm/campaigns/campaign_enform";
+@import "blocks/OldENForm/campaigns/themes/theme_climate";
 
 // Native Blocks
 @import "blocks/core-overrides/Image";

--- a/assets/src/styles/blocks/OldENForm/campaigns/_campaign_enform.scss
+++ b/assets/src/styles/blocks/OldENForm/campaigns/_campaign_enform.scss
@@ -1,0 +1,3 @@
+.enform-wrap {
+  @include campaign-en-block();
+}

--- a/assets/src/styles/blocks/OldENForm/campaigns/_mixins.scss
+++ b/assets/src/styles/blocks/OldENForm/campaigns/_mixins.scss
@@ -1,0 +1,55 @@
+@mixin campaign-en-block($form-caption-transform: false) {
+  .form-caption {
+    padding-bottom: $space-xxl;
+
+    h1, h2, h3 {
+      @if $form-caption-transform {
+        text-transform: $form-caption-transform;
+      }
+    }
+
+    p {
+      font-size: $font-size-sm;
+      line-height: 1.875rem;
+    }
+
+    h1 {
+      font-size: 3.62rem;
+      color: white !important;
+      margin-bottom: 16px;
+      line-height: 1.225;
+    }
+
+    h2 {
+      margin-bottom: 18px;
+    }
+
+    h3 {
+      margin-bottom: 16px;
+    }
+
+    .campaign-logo {
+      width: 380px;
+      max-width: 100%;
+      padding-bottom: 30px;
+      padding-top: 10px;
+      display: block;
+    }
+  }
+
+  .enform {
+    .submit button {
+      margin-bottom: 0;
+      box-sizing: border-box;
+      width: 100%;
+    }
+
+    #enform-content {
+      .title-and-description {
+        h2 {
+          font-family: var(--headings--font-family, var(--header-primary-font)) !important;
+        }
+      }
+    }
+  }
+}

--- a/assets/src/styles/blocks/OldENForm/campaigns/themes/_theme_climate.scss
+++ b/assets/src/styles/blocks/OldENForm/campaigns/themes/_theme_climate.scss
@@ -1,0 +1,37 @@
+body.theme-climate {
+  $form-caption-transform: uppercase;
+
+  .enform-wrap {
+    @include campaign-en-block($form-caption-transform);
+
+    &.enform-side-style {
+      .form-caption {
+        padding-top: 33px;
+
+        @include large-and-up {
+          padding-top: 117px;
+        }
+      }
+
+      .enform {
+        @include large-and-up {
+          padding: $space-lg;
+        }
+
+        .form-description {
+          font-family: var(--headings--font-family, var(--header-primary-font));
+          margin-bottom: $space-md;
+
+          p:first-child {
+            font-weight: bold;
+            font-size: 1.2rem;
+            text-transform: uppercase;
+            font-family: var(--headings--font-family, var(--header-primary-font));
+            margin-bottom: 4px;
+            display: inline-block;
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/src/styles/blocks/OldENForm/components/_enform-full-width-bg.scss
+++ b/assets/src/styles/blocks/OldENForm/components/_enform-full-width-bg.scss
@@ -1,0 +1,80 @@
+.enform-full-width-bg {
+  @include background-before-opacity($light-blue-bg);
+  width: 100vw;
+  min-height: 444px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+
+  picture {
+    align-self: start;
+
+    img {
+      position: absolute;
+      height: auto;
+      width: 100%;
+      object-fit: cover;
+      object-position: center center;
+      opacity: 0.3;
+
+      @supports (object-fit: cover) {
+        & {
+          height: 100%;
+        }
+      }
+    }
+  }
+
+  .enform {
+    background: none;
+
+    .form-description {
+      margin-bottom: 16px;
+    }
+
+    .title-and-description {
+      h2 {
+        margin-bottom: $space-lg;
+      }
+
+      p {
+        margin-bottom: $space-lg;
+      }
+    }
+
+    form {
+      .submit {
+        @include medium-and-up {
+          margin-top: 0;
+        }
+
+        @include large-and-up {
+          padding-left: 0;
+          margin-top: 0;
+        }
+
+        @include medium-and-up {
+          flex-direction: unset;
+        }
+
+        button {
+          min-width: 100%;
+          padding: 0;
+          margin-top: 0;
+        }
+
+        .enform-legal {
+          min-width: 100%;
+        }
+      }
+
+      .formblock-flex {
+        .en__field {
+          @include large-and-up {
+            width: 49%;
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/src/styles/blocks/OldENForm/components/_enform-full-width.scss
+++ b/assets/src/styles/blocks/OldENForm/components/_enform-full-width.scss
@@ -1,0 +1,82 @@
+.enform-full-width {
+  .enform {
+    color: white;
+    padding: $space-lg;
+    padding-bottom: 42px;
+
+    .title-and-description {
+      h2 {
+        margin-bottom: 16px;
+      }
+
+      .form-description {
+        margin-bottom: 32px;
+      }
+    }
+
+    form {
+      .custom-control .custom-control-description {
+        color: $white;
+
+        a {
+          color: $white;
+        }
+      }
+
+      .en__field--check {
+        margin-top: 16px;
+
+        @include medium-and-up {
+          width: 100%;
+        }
+
+        label {
+          margin-bottom: 0;
+        }
+
+        .form-group {
+          margin-bottom: 0;
+        }
+      }
+
+      .form-check-label-block {
+        padding: 0;
+      }
+
+      .submit {
+        display: flex;
+        margin-top: 0;
+
+        @include medium-and-up {
+          justify-content: center;
+        }
+
+        @include large-and-up {
+          justify-content: left;
+        }
+
+        button {
+          padding: 0;
+          margin-bottom: 0;
+
+          @include medium-and-up {
+            width: 380px !important;
+          }
+
+          @include large-and-up {
+            width: 32% !important;
+          }
+        }
+      }
+
+      .enform-legal {
+        margin-top: 24px;
+
+        @include large-and-up {
+          margin-top: 16px;
+          width: 66%;
+        }
+      }
+    }
+  }
+}

--- a/assets/src/styles/blocks/OldENForm/components/_enform-side-style.scss
+++ b/assets/src/styles/blocks/OldENForm/components/_enform-side-style.scss
@@ -1,0 +1,166 @@
+.enform-side-style {
+  width: 100vw;
+  min-height: 444px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+
+  &:only-child {
+    margin-bottom: 0;
+  }
+
+  .caption-overlay {
+    display: block;
+    background: url("../../public/images/carousel-blurred-overlay.png");
+    background-position: bottom right;
+    background-size: cover;
+    height: 100%;
+    width: 90%;
+    position: absolute;
+    margin-left: 0;
+    z-index: 1;
+
+    html[dir="rtl"] & {
+      background-position: bottom left;
+    }
+
+    @include medium-and-up {
+      width: 50%;
+    }
+  }
+
+  // Darken background
+  &::after {
+    @include fill-container;
+    content: "";
+    background: rgba(30, 30, 30, 0.45);
+  }
+
+  picture {
+    align-self: start;
+
+    @include large-and-up {
+      display: block;
+    }
+
+    img {
+      position: absolute;
+      height: auto;
+      width: 100%;
+      object-fit: cover;
+      object-position: center center;
+      opacity: 1;
+
+      @supports (object-fit: cover) {
+        & {
+          height: 100%;
+        }
+      }
+    }
+  }
+
+  .enform {
+    overflow: hidden;
+    align-items: center;
+    min-height: 444px;
+    background: white;
+    padding-top: 28px;
+    float: none;
+    width: 100vw;
+    margin-top: 0;
+    margin-bottom: 0;
+
+    @include large-and-up {
+      margin-top: 96px;
+      margin-bottom: 60px;
+      float: right;
+
+      html[dir="rtl"] & {
+        float: left;
+      }
+
+      width: 40%;
+      max-width: 444px;
+      box-sizing: content-box;
+      box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
+      padding: $space-xl 30px 34px 30px;
+    }
+
+    .en__field--check {
+      margin-top: $space-md;
+
+      .form-group {
+        padding-top: 0;
+        margin-bottom: 0;
+      }
+
+      label {
+        margin-bottom: 0;
+      }
+
+      p {
+        html[dir="rtl"] & {
+          display: inline;
+        }
+      }
+    }
+  }
+
+  .title-and-description {
+    color: $grey-80;
+    padding: $n15;
+
+    @include large-and-up {
+      padding: 0;
+    }
+
+    .enform-extra-header-placeholder {
+      .container {
+        padding-top: 0;
+      }
+
+      .counter-block {
+        margin-bottom: 0;
+        margin-top: 32px;
+      }
+
+      .progress-container {
+        margin-bottom: $space-md;
+        height: $space-sm;
+
+        html[dir="rtl"] & {
+          margin-bottom: $space-lg;
+        }
+      }
+
+      .counter-text {
+        margin-bottom: 0;
+
+        html[dir="rtl"] & {
+          text-align: right;
+        }
+      }
+    }
+
+    .form-description {
+      margin-bottom: $space-lg;
+
+      html[dir="rtl"] & {
+        font-size: 0.75rem;
+      }
+    }
+  }
+
+  .form-container {
+    background: $white;
+    padding: $n15;
+
+    @include large-and-up {
+      padding: 0;
+    }
+
+    .formblock-flex .en__field {
+      width: 100%;
+    }
+  }
+}

--- a/assets/src/styles/blocks/OldENForm/components/_enform.scss
+++ b/assets/src/styles/blocks/OldENForm/components/_enform.scss
@@ -1,0 +1,328 @@
+.form-caption {
+  float: none;
+  width: 100%;
+
+  --block-enform--caption-- {
+    padding-top: 53px;
+    padding-bottom: 53px;
+    padding-left: 15px;
+    padding-right: 15px;
+
+    @include medium-and-up {
+      padding-top: 106px;
+      padding-bottom: 106px;
+    }
+
+    @include large-and-up {
+      padding-top: 117px;
+      padding-left: 0;
+      padding-right: 0;
+      width: 50%;
+    }
+  }
+  @include large-and-up {
+    float: left;
+
+    html[dir="rtl"] & {
+      float: right;
+    }
+
+    .form-caption-background {
+      display: none;
+    }
+  }
+
+  h1, h2, h3 {
+    --block-enform--caption-heading-- {
+      color: white;
+    }
+
+    font-family: var(--headings--font-family, var(--header-primary-font)) !important;
+  }
+
+  h1 {
+    margin-bottom: 24px;
+    line-height: 1.1;
+
+    @include large-and-up {
+      margin-bottom: $space-lg;
+    }
+  }
+
+  h2 {
+    margin-bottom: 18px;
+    line-height: 1.2;
+
+    @include large-and-up {
+      margin-bottom: 24px;
+    }
+  }
+
+  h3 {
+    margin-bottom: 8px;
+    font-size: 1.25rem;
+
+    @include medium-and-up {
+      font-size: 1.675rem;
+    }
+
+    @include large-and-up {
+      font-size: 1.75rem;
+    }
+  }
+
+  p {
+    --block-enform--caption--paragraph-- {
+      color: white;
+      font-family: $roboto;
+      font-size: 1rem;
+      line-height: 1.37rem;
+    }
+
+    html[dir="rtl"] & {
+      font-size: 1rem;
+    }
+  }
+
+  .campaign-logo {
+    max-height: 17.5rem;
+    margin-bottom: 2rem;
+  }
+}
+
+.form-description p:first-child --block-enform--caption--paragraph--first-- {
+  font-weight: inherit;
+  font-size: 1rem;
+  text-transform: none;
+  font-family: $roboto;
+  margin-bottom: auto;
+}
+
+.enform {
+  margin-top: 36px;
+  font-family: $roboto;
+  height: inherit;
+  padding: $n20;
+  background: $dark-blue;
+  width: 100%;
+
+  form {
+    margin: 0;
+
+    input,
+    select.form-control.en__field__input--select,
+    button {
+      min-width: 200px;
+
+      @include  large-and-up {
+        width: 100% !important;
+      }
+    }
+
+    .disable-checkbox {
+      opacity: 0.5;
+    }
+
+    .formblock-flex {
+      display: flex;
+      flex-wrap: wrap;
+      width: 100%;
+
+      @include medium-and-up {
+        justify-content: space-between;
+      }
+
+      .en__field {
+        width: 100%;
+
+        @include large-and-up {
+          width: 32%;
+        }
+      }
+    }
+
+    .submit {
+      margin: 0;
+      margin-top: 19px;
+      line-height: 1;
+
+      button {
+        box-sizing: border-box;
+        width: 100% !important;
+        margin-top: $space-lg;
+      }
+    }
+
+    input[type=submit] {
+      margin-bottom: 0;
+      line-height: 1;
+    }
+
+    .enform-legal {
+      margin-top: $space-md;
+
+      html[dir="rtl"] & {
+        margin-top: $space-xl;
+
+        @include large-and-up {
+          margin-top: $space-lg;
+        }
+      }
+
+      p {
+        font-size: .75rem;
+        font-family: $roboto !important;
+        line-height: 1rem;
+        margin-bottom: 0;
+        float: none;
+      }
+    }
+  }
+
+  h2 {
+    .enform-full-width & {
+      color: white;
+
+      html[dir="rtl"] & {
+        font-size: 2rem;
+
+        @include large-and-up {
+          font-size: 1.75rem;
+        }
+      }
+    }
+
+    &.thankyou {
+      margin-bottom: 0;
+    }
+
+    @include medium-and-up {
+      font-size: 1.75rem;
+      line-height: 2.5rem;
+    }
+
+    @include large-and-up {
+      font-size: 2.125rem;
+    }
+
+    @include x-large-and-up {
+      font-size: 2.25rem;
+    }
+  }
+
+  .thankyou-subtitle {
+    font-weight: normal;
+  }
+}
+
+.en-spinner {
+  border-color: $white !important;
+  border-right-color: transparent!important;
+  display: none;
+  vertical-align: middle;
+}
+
+body.wp-admin {
+  .enform-side-style,
+  .enform-full-width-bg {
+    pointer-events: none;
+    width: 100%;
+
+    .container {
+      z-index: 1;
+    }
+  }
+
+  .enform .form-container {
+    input {
+      box-sizing: border-box;
+    }
+  }
+}
+
+.thankyou {
+  position: relative;
+  min-height: inherit;
+
+  @include mobile-only {
+    margin: 0 20px;
+  }
+
+  &.full-width {
+    max-width: 444px;
+
+    @include large-and-up {
+      left: 33%;
+
+      html[dir="rtl"] & {
+        right: 33%;
+      }
+    }
+
+    .sub-section {
+      margin-bottom: 2em;
+      width: 100%;
+
+      .form-group {
+        margin-bottom: 2em;
+      }
+    }
+  }
+
+  .page-section-header {
+    line-height: 1.2;
+  }
+
+  .page-section-description {
+    line-height: 1.4;
+  }
+
+  .btn {
+    width: 100% !important;
+    box-sizing: border-box !important;
+  }
+
+  .sub-section {
+    margin-bottom: 2em;
+    width: 100%;
+
+    .form-group {
+      margin-bottom: 2em;
+    }
+
+    .social-media {
+      .share-buttons {
+        float: none;
+        display: flex;
+      }
+
+      .share-btn {
+        flex-grow: 1;
+        box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
+
+        &:not(:last-child) {
+          margin-right: 5px;
+        }
+      }
+
+      .twitter {
+        background: #00acee none repeat scroll 0 0;
+      }
+    }
+  }
+}
+
+.en__field--select {
+  width: 100%;
+  margin-bottom: 1rem;
+
+  .en__field__element--select {
+    margin-bottom: 0;
+
+    select.form-control.en__field__input--select {
+      width: 100%;
+      display: block;
+      margin-bottom: 0;
+    }
+  }
+}

--- a/classes/blocks/class-oldenform.php
+++ b/classes/blocks/class-oldenform.php
@@ -12,11 +12,11 @@ use P4GBKS\Controllers\Ensapi_Controller as Ensapi;
 use WP_Block_Type_Registry;
 
 /**
- * Class ENForm
+ * Class OldENForm
  *
  * @package P4GBKS\Blocks
  */
-class ENForm extends Base_Block {
+class OldENForm extends Base_Block {
 
 	/** @const string BLOCK_NAME */
 	protected const BLOCK_NAME = 'enform';
@@ -34,7 +34,7 @@ class ENForm extends Base_Block {
 	private const FIELDS_META = 'p4enform_fields';
 
 	/**
-	 * ENForm constructor.
+	 * OldENForm constructor.
 	 */
 	public function __construct() {
 		if ( WP_Block_Type_Registry::get_instance()->is_registered( self::get_full_block_name() ) ) {

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -81,7 +81,7 @@ final class Loader {
 		new Blocks\TakeActionBoxout();
 		new Blocks\Timeline();
 		new Blocks\SocialMediaCards();
-		new Blocks\ENForm();
+		new Blocks\OldENForm();
 		new Blocks\GuestBook();
 	}
 
@@ -692,7 +692,7 @@ DEFERREDCSS;
 			$pages[]           = $main_settings['p4en_private_api'];
 			$ens_private_token = $main_settings['p4en_private_api'];
 			$ens_api           = new Controllers\Ensapi_Controller( $ens_private_token );
-			$pages             = $ens_api->get_pages_by_types_status( Blocks\ENForm::ENFORM_PAGE_TYPES, 'live' );
+			$pages             = $ens_api->get_pages_by_types_status( Blocks\OldENForm::ENFORM_PAGE_TYPES, 'live' );
 			uasort(
 				$pages,
 				function ( $a, $b ) {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4814

In preparation for https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/453 to move to beta, moving the current block to "old" name.

## Test 

ENForm block should work the same
- Check existing blocks in Block usage
- Add a block ENForm to a page, select Goal and Form, check that form displays as expected