### PR TITLE
PLANET-6155 Convert cookies block to hooks part I

### DIFF
--- a/assets/src/blocks/Cookies/CookiesFrontend.js
+++ b/assets/src/blocks/Cookies/CookiesFrontend.js
@@ -60,23 +60,24 @@ export class CookiesFrontend extends Component {
   }
 
   onNecessaryCookiesClick() {
-    const isChecked = !this.state.necessaryCookiesChecked;
-    let { allCookiesChecked } = this.state;
+    const {allCookiesChecked, necessaryCookiesChecked} = this.state;
 
-    if (isChecked) {
+    // Flip previous value.
+    const allowNecessary = !necessaryCookiesChecked;
+
+    if (allowNecessary) {
       createCookie('greenpeace', '1', 365);
       hideCookieNotice();
     } else {
-      allCookiesChecked = false;
       createCookie('greenpeace', '0', -1);
       showCookieNotice();
     }
 
     this.setState({
-      necessaryCookiesChecked: isChecked,
+      necessaryCookiesChecked: allowNecessary,
       // if Necessary Cookies is not checked,
       // All Cookies should be unchecked too
-      allCookiesChecked,
+      allCookiesChecked: allCookiesChecked && allowNecessary,
     }, this.setNoTrackCookie);
   }
 

--- a/assets/src/blocks/Cookies/CookiesFrontend.js
+++ b/assets/src/blocks/Cookies/CookiesFrontend.js
@@ -4,19 +4,15 @@ import { FrontendRichText } from '../../components/FrontendRichText/FrontendRich
 const { __ } = wp.i18n;
 
 const readCookie = (name) => {
-  const nameEQ = name + '=';
-  const ca = document.cookie.split(';');
-  let c;
-  for (let i = 0; i < ca.length; i++) {
-    c = ca[i];
-    while (c.charAt(0) === ' ') {
-      c = c.substring(1, c.length);
+  const declarations = document.cookie.split(';');
+  let match = null;
+  declarations.forEach(part => {
+    const [key, value] = part.split('=');
+    if (key.trim() === name) {
+      match = value;
     }
-    if (c.indexOf(nameEQ) === 0) {
-      return c.substring(nameEQ.length, c.length);
-    }
-  }
-  return null;
+  })
+  return match;
 };
 
 const showCookieNotice = () => {

--- a/assets/src/blocks/Cookies/CookiesFrontend.js
+++ b/assets/src/blocks/Cookies/CookiesFrontend.js
@@ -3,10 +3,51 @@ import { FrontendRichText } from '../../components/FrontendRichText/FrontendRich
 
 const { __ } = wp.i18n;
 
+const readCookie = (name) => {
+  const nameEQ = name + '=';
+  const ca = document.cookie.split(';');
+  let c;
+  for (let i = 0; i < ca.length; i++) {
+    c = ca[i];
+    while (c.charAt(0) === ' ') {
+      c = c.substring(1, c.length);
+    }
+    if (c.indexOf(nameEQ) === 0) {
+      return c.substring(nameEQ.length, c.length);
+    }
+  }
+  return null;
+};
+
+const showCookieNotice = () => {
+  // the .cookie-notice element belongs to the P4 Master Theme
+  const cookieElement = document.querySelector('#set-cookie');
+  if (cookieElement) {
+    cookieElement.classList.add('shown');
+  }
+}
+
+const createCookie = (name, value, days) => {
+  let date = new Date();
+  date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+  let secureMode = document.location.protocol === 'http:'
+    ? ';SameSite=Lax'
+    : ';SameSite=None;Secure';
+  document.cookie = encodeURI(name) + '=' + encodeURI(value) + ';domain=.' + document.domain + ';path=/;' + '; expires=' + date.toGMTString() + secureMode;
+}
+
+const hideCookieNotice = () => {
+  // the .cookie-notice element belongs to the P4 Master Theme
+  const cookieElement = document.querySelector('#set-cookie');
+  if (cookieElement) {
+    cookieElement.classList.remove('shown');
+  }
+}
+
 export class CookiesFrontend extends Component {
   constructor(props) {
     super(props);
-    const cookie = this.readCookie('greenpeace');
+    const cookie = readCookie('greenpeace');
 
     this.state = {
       necessaryCookiesChecked: ['1', '2'].includes(cookie),
@@ -18,33 +59,17 @@ export class CookiesFrontend extends Component {
     this.setNoTrackCookie = this.setNoTrackCookie.bind(this);
   }
 
-  showCookieNotice() {
-    // the .cookie-notice element belongs to the P4 Master Theme
-    const cookieElement = document.querySelector('#set-cookie');
-    if (cookieElement) {
-      cookieElement.classList.add('shown');
-    }
-  }
-
-  hideCookieNotice() {
-    // the .cookie-notice element belongs to the P4 Master Theme
-    const cookieElement = document.querySelector('#set-cookie');
-    if (cookieElement) {
-      cookieElement.classList.remove('shown');
-    }
-  }
-
   onNecessaryCookiesClick() {
     const isChecked = !this.state.necessaryCookiesChecked;
     let { allCookiesChecked } = this.state;
 
     if (isChecked) {
-      this.createCookie('greenpeace', '1', 365);
-      this.hideCookieNotice();
+      createCookie('greenpeace', '1', 365);
+      hideCookieNotice();
     } else {
       allCookiesChecked = false;
-      this.createCookie('greenpeace', '0', -1);
-      this.showCookieNotice();
+      createCookie('greenpeace', '0', -1);
+      showCookieNotice();
     }
 
     this.setState({
@@ -59,48 +84,23 @@ export class CookiesFrontend extends Component {
     const isChecked = !this.state.allCookiesChecked;
 
     if (isChecked) {
-      this.createCookie('greenpeace', '2', 365);
-      this.hideCookieNotice();
+      createCookie('greenpeace', '2', 365);
+      hideCookieNotice();
     } else {
       if (this.state.necessaryCookiesChecked) {
-        this.createCookie('greenpeace', '1', 365);
+        createCookie('greenpeace', '1', 365);
       } else {
-        this.createCookie('greenpeace', '0', -1);
-        this.showCookieNotice();
+        createCookie('greenpeace', '0', -1);
+        showCookieNotice();
       }
     }
 
-    const cookie = this.readCookie('greenpeace');
+    const cookie = readCookie('greenpeace');
 
     this.setState({
       necessaryCookiesChecked: ['1', '2'].includes(cookie),
       allCookiesChecked: isChecked,
     }, this.setNoTrackCookie);
-  }
-
-  createCookie(name, value, days) {
-    let date = new Date();
-    date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-    let secureMode = document.location.protocol === 'http:'
-      ? ';SameSite=Lax'
-      : ';SameSite=None;Secure';
-    document.cookie = encodeURI(name) + '=' + encodeURI(value) + ';domain=.' + document.domain + ';path=/;' + '; expires=' + date.toGMTString() + secureMode;
-  }
-
-  readCookie(name) {
-    const nameEQ = name + '=';
-    const ca = document.cookie.split(';');
-    let c;
-    for (let i = 0; i < ca.length; i++) {
-      c = ca[i];
-      while (c.charAt(0) === ' ') {
-        c = c.substring(1, c.length);
-      }
-      if (c.indexOf(nameEQ) === 0) {
-        return c.substring(nameEQ.length, c.length);
-      }
-    }
-    return null;
   }
 
   setNoTrackCookie() {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6155

---

As a preparation step for adding HubSpot support to the cookies block, this converts the block from class components to function components and hooks.

The block currently uses a less known feature of classes (adding a callback function to `this.setState`) to set certain cookies as an "effect" when the state changes. This effect will need to be expanded to also trigger HubSpot cookie consent, which is much easier to achieve with `useEffect`.

I probably will also split the hooks conversion in 2 PRs. Currently on this branch I have a few commits that simplify the class which could already be merged, after which the rest should be easier to review.