### PR TITLE
PLANET-6155 Convert cookies block to hooks part II

### DIFF
--- a/assets/src/blocks/Cookies/CookiesFrontend.js
+++ b/assets/src/blocks/Cookies/CookiesFrontend.js
@@ -23,7 +23,7 @@ const showCookieNotice = () => {
   }
 }
 
-const createCookie = (name, value, days) => {
+const setCookie = (name, value, days) => {
   let date = new Date();
   date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
   let secureMode = document.location.protocol === 'http:'
@@ -62,10 +62,10 @@ export class CookiesFrontend extends Component {
     const allowNecessary = !necessaryCookiesChecked;
 
     if (allowNecessary) {
-      createCookie('greenpeace', '1', 365);
+      setCookie('greenpeace', '1', 365);
       hideCookieNotice();
     } else {
-      createCookie('greenpeace', '0', -1);
+      setCookie('greenpeace', '0', -1);
       showCookieNotice();
     }
 
@@ -81,13 +81,13 @@ export class CookiesFrontend extends Component {
     const isChecked = !this.state.allCookiesChecked;
 
     if (isChecked) {
-      createCookie('greenpeace', '2', 365);
+      setCookie('greenpeace', '2', 365);
       hideCookieNotice();
     } else {
       if (this.state.necessaryCookiesChecked) {
-        createCookie('greenpeace', '1', 365);
+        setCookie('greenpeace', '1', 365);
       } else {
-        createCookie('greenpeace', '0', -1);
+        setCookie('greenpeace', '0', -1);
         showCookieNotice();
       }
     }
@@ -104,10 +104,10 @@ export class CookiesFrontend extends Component {
     const { necessaryCookiesChecked, allCookiesChecked } = this.state;
     if (!necessaryCookiesChecked && !allCookiesChecked) {
       // If user manually disables all trackings, set a 'no_track' cookie.
-      createCookie('no_track', 'true', 20 * 365);
+      setCookie('no_track', 'true', 20 * 365);
     } else {
       // Remove the 'no_track' cookie, if user accept the cookies consent.
-      createCookie('no_track', 'true', -1);
+      setCookie('no_track', 'true', -1);
     }
   }
 

--- a/assets/src/blocks/Cookies/CookiesFrontend.js
+++ b/assets/src/blocks/Cookies/CookiesFrontend.js
@@ -1,19 +1,12 @@
-import { Component, Fragment } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import { FrontendRichText } from '../../components/FrontendRichText/FrontendRichText';
+import { removeCookie, useCookie, writeCookie } from './useCookie';
+import { useState, useEffect } from 'react';
 
 const { __ } = wp.i18n;
-
-const readCookie = (name) => {
-  const declarations = document.cookie.split(';');
-  let match = null;
-  declarations.forEach(part => {
-    const [key, value] = part.split('=');
-    if (key.trim() === name) {
-      match = value;
-    }
-  })
-  return match;
-};
+const CONSENT_COOKIE = 'greenpeace';
+const ONLY_NECESSARY = '1';
+const ALL_COOKIES = '2';
 
 const showCookieNotice = () => {
   // the .cookie-notice element belongs to the P4 Master Theme
@@ -21,15 +14,6 @@ const showCookieNotice = () => {
   if (cookieElement) {
     cookieElement.classList.add('shown');
   }
-}
-
-const setCookie = (name, value, days) => {
-  let date = new Date();
-  date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-  let secureMode = document.location.protocol === 'http:'
-    ? ';SameSite=Lax'
-    : ';SameSite=None;Secure';
-  document.cookie = encodeURI(name) + '=' + encodeURI(value) + ';domain=.' + document.domain + ';path=/;' + '; expires=' + date.toGMTString() + secureMode;
 }
 
 const hideCookieNotice = () => {
@@ -40,202 +24,164 @@ const hideCookieNotice = () => {
   }
 }
 
-export class CookiesFrontend extends Component {
-  constructor(props) {
-    super(props);
-    const cookie = readCookie('greenpeace');
+export const CookiesFrontend = props => {
+  const {
+    isSelected,
+    title,
+    description,
+    necessary_cookies_name,
+    necessary_cookies_description,
+    all_cookies_name,
+    all_cookies_description,
+    isEditing,
+    toAttribute = () => {},
+  } = props;
 
-    this.state = {
-      necessaryCookiesChecked: ['1', '2'].includes(cookie),
-      allCookiesChecked: '2' === cookie,
+  // Whether consent was revoked by the user since current page load.
+  const [userRevokedConsent, setUserRevokedConsent] = useState(false);
+  const [consentCookie, setConsentCookie, removeConsentCookie] = useCookie(CONSENT_COOKIE);
+  const necessaryCookiesChecked = [ONLY_NECESSARY, ALL_COOKIES].includes(consentCookie);
+  const allCookiesChecked = ALL_COOKIES === consentCookie;
+  const hasConsent = allCookiesChecked || necessaryCookiesChecked;
+
+  const updateNoTrackCookie = () => {
+    if (hasConsent) {
+      removeCookie('no_track');
+    } else if (userRevokedConsent) {
+      writeCookie('no_track', 'true');
     }
+  };
+  useEffect(updateNoTrackCookie, [hasConsent, userRevokedConsent]);
 
-    this.onNecessaryCookiesClick = this.onNecessaryCookiesClick.bind(this);
-    this.onAllCookiesClick = this.onAllCookiesClick.bind(this);
-    this.setNoTrackCookie = this.setNoTrackCookie.bind(this);
-  }
-
-  onNecessaryCookiesClick() {
-    const {allCookiesChecked, necessaryCookiesChecked} = this.state;
-
-    // Flip previous value.
-    const allowNecessary = !necessaryCookiesChecked;
-
-    if (allowNecessary) {
-      setCookie('greenpeace', '1', 365);
+  const toggleCookieNotice = () => {
+    if (hasConsent) {
       hideCookieNotice();
     } else {
-      setCookie('greenpeace', '0', -1);
       showCookieNotice();
     }
+  };
+  useEffect(toggleCookieNotice, [hasConsent]);
 
-    this.setState({
-      necessaryCookiesChecked: allowNecessary,
-      // if Necessary Cookies is not checked,
-      // All Cookies should be unchecked too
-      allCookiesChecked: allCookiesChecked && allowNecessary,
-    }, this.setNoTrackCookie);
-  }
-
-  onAllCookiesClick() {
-    const isChecked = !this.state.allCookiesChecked;
-
-    if (isChecked) {
-      setCookie('greenpeace', '2', 365);
-      hideCookieNotice();
-    } else {
-      if (this.state.necessaryCookiesChecked) {
-        setCookie('greenpeace', '1', 365);
-      } else {
-        setCookie('greenpeace', '0', -1);
-        showCookieNotice();
+  return <Fragment>
+    <section className="block cookies-block">
+      {(isEditing || title) &&
+      <header>
+        <FrontendRichText
+          tagName="h2"
+          className="page-section-header"
+          placeholder={__('Enter title', 'planet4-blocks-backend')}
+          value={title}
+          onChange={toAttribute('title')}
+          keepPlaceholderOnFocus={true}
+          withoutInteractiveFormatting
+          characterLimit={40}
+          multiline="false"
+          editable={isEditing}
+        />
+      </header>
       }
-    }
-
-    const cookie = readCookie('greenpeace');
-
-    this.setState({
-      necessaryCookiesChecked: ['1', '2'].includes(cookie),
-      allCookiesChecked: isChecked,
-    }, this.setNoTrackCookie);
-  }
-
-  setNoTrackCookie() {
-    const { necessaryCookiesChecked, allCookiesChecked } = this.state;
-    if (!necessaryCookiesChecked && !allCookiesChecked) {
-      // If user manually disables all trackings, set a 'no_track' cookie.
-      setCookie('no_track', 'true', 20 * 365);
-    } else {
-      // Remove the 'no_track' cookie, if user accept the cookies consent.
-      setCookie('no_track', 'true', -1);
-    }
-  }
-
-  render() {
-    const {
-      isSelected,
-      title,
-      description,
-      necessary_cookies_name,
-      necessary_cookies_description,
-      all_cookies_name,
-      all_cookies_description,
-      isEditing,
-      toAttribute
-    } = this.props;
-
-    const { necessaryCookiesChecked, allCookiesChecked } = this.state;
-
-    return (
+      {(isEditing || description) &&
+      <FrontendRichText
+        tagName="p"
+        className="page-section-description"
+        placeholder={__('Enter description', 'planet4-blocks-backend')}
+        value={description}
+        onChange={toAttribute('description')}
+        keepPlaceholderOnFocus={true}
+        withoutInteractiveFormatting
+        characterLimit={300}
+        editable={isEditing}
+      />
+      }
+      {(isEditing || (necessary_cookies_name && necessary_cookies_description)) &&
       <Fragment>
-        <section className="block cookies-block">
-          {(isEditing || title) &&
-            <header>
-              <FrontendRichText
-                tagName="h2"
-                className="page-section-header"
-                placeholder={__('Enter title', 'planet4-blocks-backend')}
-                value={title}
-                onChange={toAttribute && toAttribute('title')}
-                keepPlaceholderOnFocus={true}
-                withoutInteractiveFormatting
-                characterLimit={40}
-                multiline="false"
-                editable={isEditing}
-              />
-            </header>
-          }
-          {(isEditing || description) &&
-            <FrontendRichText
-              tagName="p"
-              className="page-section-description"
-              placeholder={__('Enter description', 'planet4-blocks-backend')}
-              value={description}
-              onChange={toAttribute && toAttribute('description')}
-              keepPlaceholderOnFocus={true}
-              withoutInteractiveFormatting
-              characterLimit={300}
-              editable={isEditing}
-            />
-          }
-          {(isEditing || (necessary_cookies_name && necessary_cookies_description)) &&
-            <Fragment>
-              <label className="custom-control"
-                style={isSelected ? { pointerEvents: 'none' } : null}>
-                <input
-                  type="checkbox"
-                  tabIndex={isSelected ? '-1' : null}
-                  name="necessary_cookies"
-                  onChange={this.onNecessaryCookiesClick}
-                  checked={necessaryCookiesChecked}
-                  className="p4-custom-control-input"
-                />
-                <FrontendRichText
-                  tagName="span"
-                  className="custom-control-description"
-                  placeholder={__('Enter necessary cookies name', 'planet4-blocks-backend')}
-                  value={necessary_cookies_name}
-                  onChange={toAttribute && toAttribute('necessary_cookies_name')}
-                  keepPlaceholderOnFocus={true}
-                  withoutInteractiveFormatting
-                  characterLimit={40}
-                  multiline="false"
-                  editable={isEditing}
-                />
-              </label>
-              <FrontendRichText
-                tagName="p"
-                className="cookies-checkbox-description"
-                placeholder={__('Enter necessary cookies description', 'planet4-blocks-backend')}
-                value={necessary_cookies_description}
-                onChange={toAttribute && toAttribute('necessary_cookies_description')}
-                keepPlaceholderOnFocus={true}
-                withoutInteractiveFormatting
-                characterLimit={300}
-                editable={isEditing}
-              />
-            </Fragment>
-          }
-          {(isEditing || (all_cookies_name && all_cookies_description)) &&
-            <Fragment>
-              <label className="custom-control"
-                style={isSelected ? { pointerEvents: 'none' } : null}>
-                <input
-                  type="checkbox"
-                  tabIndex={isSelected ? '-1' : null}
-                  onChange={this.onAllCookiesClick}
-                  name="all_cookies"
-                  checked={allCookiesChecked}
-                  className="p4-custom-control-input"
-                />
-                <FrontendRichText
-                  tagName="span"
-                  className="custom-control-description"
-                  placeholder={__('Enter all cookies name', 'planet4-blocks-backend')}
-                  value={all_cookies_name}
-                  onChange={toAttribute && toAttribute('all_cookies_name')}
-                  keepPlaceholderOnFocus={true}
-                  withoutInteractiveFormatting
-                  characterLimit={40}
-                  multiline="false"
-                  editable={isEditing}
-                />
-              </label>
-              <FrontendRichText
-                tagName="p"
-                className="cookies-checkbox-description"
-                placeholder={__('Enter all cookies description', 'planet4-blocks-backend')}
-                value={all_cookies_description}
-                onChange={toAttribute && toAttribute('all_cookies_description')}
-                keepPlaceholderOnFocus={true}
-                withoutInteractiveFormatting
-                characterLimit={300}
-                editable={isEditing}
-              />
-            </Fragment>
-          }
-        </section>
+        <label className="custom-control"
+               style={isSelected ? { pointerEvents: 'none' } : null}>
+          <input
+            type="checkbox"
+            tabIndex={isSelected ? '-1' : null}
+            name="necessary_cookies"
+            onChange={ () => {
+              if (necessaryCookiesChecked) {
+                setUserRevokedConsent(true);
+                removeConsentCookie();
+              } else {
+                setConsentCookie(ONLY_NECESSARY);
+              }
+            } }
+            checked={necessaryCookiesChecked}
+            className="p4-custom-control-input"
+          />
+          <FrontendRichText
+            tagName="span"
+            className="custom-control-description"
+            placeholder={__('Enter necessary cookies name', 'planet4-blocks-backend')}
+            value={necessary_cookies_name}
+            onChange={toAttribute('necessary_cookies_name')}
+            keepPlaceholderOnFocus={true}
+            withoutInteractiveFormatting
+            characterLimit={40}
+            multiline="false"
+            editable={isEditing}
+          />
+        </label>
+        <FrontendRichText
+          tagName="p"
+          className="cookies-checkbox-description"
+          placeholder={__('Enter necessary cookies description', 'planet4-blocks-backend')}
+          value={necessary_cookies_description}
+          onChange={toAttribute('necessary_cookies_description')}
+          keepPlaceholderOnFocus={true}
+          withoutInteractiveFormatting
+          characterLimit={300}
+          editable={isEditing}
+        />
       </Fragment>
-    );
-  }
+      }
+      {(isEditing || (all_cookies_name && all_cookies_description)) &&
+      <Fragment>
+        <label className="custom-control"
+               style={isSelected ? { pointerEvents: 'none' } : null}>
+          <input
+            type="checkbox"
+            tabIndex={isSelected ? '-1' : null}
+            onChange={ () => {
+              if (allCookiesChecked) {
+                setConsentCookie(ONLY_NECESSARY);
+              } else {
+                setConsentCookie(ALL_COOKIES);
+              }
+            } }
+            name="all_cookies"
+            checked={allCookiesChecked}
+            className="p4-custom-control-input"
+          />
+          <FrontendRichText
+            tagName="span"
+            className="custom-control-description"
+            placeholder={__('Enter all cookies name', 'planet4-blocks-backend')}
+            value={all_cookies_name}
+            onChange={toAttribute('all_cookies_name')}
+            keepPlaceholderOnFocus={true}
+            withoutInteractiveFormatting
+            characterLimit={40}
+            multiline="false"
+            editable={isEditing}
+          />
+        </label>
+        <FrontendRichText
+          tagName="p"
+          className="cookies-checkbox-description"
+          placeholder={__('Enter all cookies description', 'planet4-blocks-backend')}
+          value={all_cookies_description}
+          onChange={toAttribute('all_cookies_description')}
+          keepPlaceholderOnFocus={true}
+          withoutInteractiveFormatting
+          characterLimit={300}
+          editable={isEditing}
+        />
+      </Fragment>
+      }
+    </section>
+  </Fragment>;
 }

--- a/assets/src/blocks/Cookies/useCookie.js
+++ b/assets/src/blocks/Cookies/useCookie.js
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react';
+
+export const readCookie = (name) => {
+  const declarations = document.cookie.split(';');
+  let match = null;
+  declarations.forEach(part => {
+    const [key, value] = part.split('=');
+    if (key.trim() === name) {
+      match = value;
+    }
+  });
+  return match;
+};
+
+export const writeCookie = (name, value, days = 365) => {
+  let date = new Date();
+  date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+  let secureMode = document.location.protocol === 'http:'
+    ? ';SameSite=Lax'
+    : ';SameSite=None;Secure';
+  document.cookie = encodeURI(name) + '=' + encodeURI(value) + ';domain=.' + document.domain + ';path=/;' + '; expires=' + date.toGMTString() + secureMode;
+};
+
+// Value should not matter as cookie is expired.
+export const removeCookie = name => writeCookie(name, '0', -1);
+
+export const useCookie = name => {
+  const [value, setValue] = useState(() => readCookie(name));
+
+  const saveCookie = () => {
+    if (value === null) {
+      removeCookie(name);
+      return;
+    }
+    writeCookie(name, value);
+  };
+  useEffect(saveCookie, [value]);
+
+  return [
+    value,
+    setValue,
+    () => {
+      setValue(null);
+    }
+  ];
+};
+


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6155

---

**Easier to review [with hidden whitespace changes](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/601/files?diff=split&w=1)**

The actual conversion. I added a `useCookie` hook to encapsulate reading and writing the cookie. `no_track` cookie doesn't use it because we only ever need to write it.

Also renamed `setCookie` to `writeCookie`, because of a naming collision. Though after doing so the colliding other function was moved, so it could theoretically stay `setCookie`. But we can keep `writeCookie` to avoid confusion with setter methods returned by `useState`.