### PR TITLE
PLANET-5868: Make table caption styles same as image caption

### DIFF
--- a/assets/src/styles/blocks/core-overrides/Table.scss
+++ b/assets/src/styles/blocks/core-overrides/Table.scss
@@ -46,6 +46,15 @@
     }
   }
 
+  // Table caption
+  figcaption {
+    text-align: center;
+    font-size: $font-size-xxs;
+    font-family: $roboto;
+    color: $grey-60;
+    line-height: 1.4;
+  }
+
   &.is-style-stripes table {
     // Grey background (defaut)
     tr:nth-child(odd) {


### PR DESCRIPTION
Ref: <!-- Please add a url to the ticket this change is addressing. -->

Fixes https://github.com/greenpeace/planet4/issues/136

The change makes the table caption style same as the image caption style. Please review
