### PR TITLE
PLANET-6172 Allow basic rich text formatting on blocks description fields

### DIFF
--- a/assets/src/blocks/Accordion/AccordionEditor.js
+++ b/assets/src/blocks/Accordion/AccordionEditor.js
@@ -48,7 +48,7 @@ const renderView = ({ title, description, tabs, className }, setAttributes, isSe
           withoutInteractiveFormatting
           characterLimit={60}
           multiline="false"
-          formattingControls={[]}
+          allowedFormats={[]}
         />
       </header>
       <RichText
@@ -60,7 +60,7 @@ const renderView = ({ title, description, tabs, className }, setAttributes, isSe
         keepPlaceholderOnFocus={true}
         withoutInteractiveFormatting
         characterLimit={200}
-        formattingControls={[]}
+        allowedFormats={['core/bold', 'core/italic']}
       />
       {tabs.map((tab, index) => (
         <div key={`accordion-content-${index}`} className='accordion-content'>
@@ -73,7 +73,7 @@ const renderView = ({ title, description, tabs, className }, setAttributes, isSe
             keepPlaceholderOnFocus={true}
             withoutInteractiveFormatting
             multiline="false"
-            formattingControls={[]}
+            allowedFormats={[]}
           />
           <div className={`panel ${isSelected ? '' : 'panel-hidden'}`}>
             <RichText
@@ -83,7 +83,7 @@ const renderView = ({ title, description, tabs, className }, setAttributes, isSe
               value={tab.text}
               onChange={updateTabAttribute('text', index)}
               keepPlaceholderOnFocus={true}
-              formattingControls={[]}
+              allowedFormats={['core/bold', 'core/italic']}
             />
             {tab.button ?
               <div className="button-container">
@@ -96,7 +96,7 @@ const renderView = ({ title, description, tabs, className }, setAttributes, isSe
                   keepPlaceholderOnFocus={true}
                   withoutInteractiveFormatting
                   multiline="false"
-                  formattingControls={[]}
+                  allowedFormats={[]}
                 />
                 <Button
                   className='remove-btn'

--- a/assets/src/blocks/Articles/ArticlesEditor.js
+++ b/assets/src/blocks/Articles/ArticlesEditor.js
@@ -116,6 +116,7 @@ const renderView = ({ attributes, postType, posts, totalPosts }, toAttribute) =>
             withoutInteractiveFormatting
             characterLimit={40}
             multiline="false"
+            allowedFormats={[]}
           />
         </header>
       </Tooltip>
@@ -128,6 +129,7 @@ const renderView = ({ attributes, postType, posts, totalPosts }, toAttribute) =>
         keepPlaceholderOnFocus={true}
         withoutInteractiveFormatting
         characterLimit={200}
+        allowedFormats={['core/bold', 'core/italic']}
       />
       <ArticlesList posts={posts} postType={postType} />
       {attributes.posts.length === 0 && hasMultiplePages && (
@@ -141,6 +143,7 @@ const renderView = ({ attributes, postType, posts, totalPosts }, toAttribute) =>
               keepPlaceholderOnFocus={true}
               withoutInteractiveFormatting
               multiline="false"
+              allowedFormats={[]}
             />
           </div>
         </Tooltip>

--- a/assets/src/blocks/Columns/ColumnsEditor.js
+++ b/assets/src/blocks/Columns/ColumnsEditor.js
@@ -154,9 +154,9 @@ export const ColumnsEditor = ({ isSelected, attributes, setAttributes }) => {
               onChange={toAttribute('columns_title')}
               keepPlaceholderOnFocus={true}
               withoutInteractiveFormatting
-              allowedFormats={[]}
               characterLimit={40}
               multiline='false'
+              allowedFormats={[]}
             />
           </header>
         }
@@ -170,7 +170,7 @@ export const ColumnsEditor = ({ isSelected, attributes, setAttributes }) => {
             keepPlaceholderOnFocus={true}
             withoutInteractiveFormatting
             characterLimit={200}
-            allowedFormats={[]}
+            allowedFormats={['core/bold', 'core/italic']}
           />
         }
         {isExample ?

--- a/assets/src/blocks/Columns/EditableColumns.js
+++ b/assets/src/blocks/Columns/EditableColumns.js
@@ -122,7 +122,7 @@ export const EditableColumns = ({
               keepPlaceholderOnFocus={true}
               withoutInteractiveFormatting
               characterLimit={400}
-              allowedFormats={[]}
+              allowedFormats={['core/bold', 'core/italic']}
             />
             {columns_block_style === LAYOUT_TASKS && (
               <MediaUploadCheck>

--- a/assets/src/blocks/Cookies/CookiesFrontend.js
+++ b/assets/src/blocks/Cookies/CookiesFrontend.js
@@ -86,6 +86,7 @@ export const CookiesFrontend = props => {
           characterLimit={40}
           multiline="false"
           editable={isEditing}
+          allowedFormats={[]}
         />
       </header>
       }
@@ -100,6 +101,7 @@ export const CookiesFrontend = props => {
         withoutInteractiveFormatting
         characterLimit={300}
         editable={isEditing}
+        allowedFormats={['core/bold', 'core/italic']}
       />
       }
       {(isEditing || (necessary_cookies_name && necessary_cookies_description)) &&
@@ -133,6 +135,7 @@ export const CookiesFrontend = props => {
             characterLimit={40}
             multiline="false"
             editable={isEditing}
+            allowedFormats={[]}
           />
         </label>
         <FrontendRichText
@@ -145,6 +148,7 @@ export const CookiesFrontend = props => {
           withoutInteractiveFormatting
           characterLimit={300}
           editable={isEditing}
+          allowedFormats={['core/bold', 'core/italic']}
         />
       </Fragment>
       }
@@ -178,6 +182,7 @@ export const CookiesFrontend = props => {
             characterLimit={40}
             multiline="false"
             editable={isEditing}
+            allowedFormats={[]}
           />
         </label>
         <FrontendRichText
@@ -190,6 +195,7 @@ export const CookiesFrontend = props => {
           withoutInteractiveFormatting
           characterLimit={300}
           editable={isEditing}
+          allowedFormats={['core/bold', 'core/italic']}
         />
       </Fragment>
       }

--- a/assets/src/blocks/Counter/CounterEditor.js
+++ b/assets/src/blocks/Counter/CounterEditor.js
@@ -98,6 +98,7 @@ export class CounterEditor extends Component {
             withoutInteractiveFormatting
             characterLimit={60}
             multiline="false"
+            allowedFormats={[]}
           />
         </header>
         <RichText
@@ -109,6 +110,7 @@ export class CounterEditor extends Component {
           keepPlaceholderOnFocus={true}
           withoutInteractiveFormatting
           characterLimit={400}
+          allowedFormats={['core/bold', 'core/italic']}
         />
       </div>
       <CounterFrontend isEditing {...attributes} />

--- a/assets/src/blocks/Covers/CoversEditor.js
+++ b/assets/src/blocks/Covers/CoversEditor.js
@@ -106,7 +106,7 @@ const renderView = (attributes, toAttribute) => {
         keepPlaceholderOnFocus={true}
         withoutInteractiveFormatting
         characterLimit={400}
-        allowedFormats={[]}
+        allowedFormats={['core/bold', 'core/italic']}
       />
       {!loading && !covers.length ?
         <div className='EmptyMessage'>

--- a/assets/src/blocks/Gallery/GalleryEditor.js
+++ b/assets/src/blocks/Gallery/GalleryEditor.js
@@ -135,6 +135,7 @@ const renderView = (attributes, setAttributes) => {
           withoutInteractiveFormatting
           characterLimit={40}
           multiline="false"
+          allowedFormats={[]}
         />
       </header>
       <RichText
@@ -146,6 +147,7 @@ const renderView = (attributes, setAttributes) => {
         keepPlaceholderOnFocus={true}
         withoutInteractiveFormatting
         characterLimit={400}
+        allowedFormats={['core/bold', 'core/italic']}
       />
       {layout === 'slider' && <GalleryCarousel images={images || []} />}
       {layout === 'three-columns' && <GalleryThreeColumns images={images || []} postType={postType} />}

--- a/assets/src/blocks/Media/MediaEditor.js
+++ b/assets/src/blocks/Media/MediaEditor.js
@@ -90,6 +90,7 @@ const renderView = (attributes, toAttribute) => {
           withoutInteractiveFormatting
           characterLimit={40}
           multiline="false"
+          allowedFormats={[]}
         />
       </header>
       <RichText
@@ -101,6 +102,7 @@ const renderView = (attributes, toAttribute) => {
         keepPlaceholderOnFocus={true}
         withoutInteractiveFormatting
         characterLimit={200}
+        allowedFormats={['core/bold', 'core/italic']}
       />
       {
         media_url && !media_url?.endsWith('.mp4') && !embed_html

--- a/assets/src/blocks/Submenu/SubmenuEditor.js
+++ b/assets/src/blocks/Submenu/SubmenuEditor.js
@@ -111,6 +111,7 @@ const renderView = (attributes, setAttributes, className) => {
         withoutInteractiveFormatting
         characterLimit={60}
         multiline="false"
+        allowedFormats={[]}
       />
       {menuItems.length > 0 ?
         <SubmenuItems menuItems={menuItems} /> :

--- a/assets/src/blocks/Timeline/TimelineEditorScript.js
+++ b/assets/src/blocks/Timeline/TimelineEditorScript.js
@@ -109,6 +109,7 @@ const renderView = (attributes, toAttribute, scriptLoaded, stylesLoaded) => {
             withoutInteractiveFormatting
             maxLength={40}
             multiline="false"
+            allowedFormats={[]}
           />
         </header>
       </Tooltip>
@@ -121,6 +122,7 @@ const renderView = (attributes, toAttribute, scriptLoaded, stylesLoaded) => {
         keepPlaceholderOnFocus={true}
         withoutInteractiveFormatting
         maxLength={200}
+        allowedFormats={['core/bold', 'core/italic']}
       />
       {!attributes.google_sheets_url &&
         <div className="block-edit-mode-warning components-notice is-warning">


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6172

---

Most of the blocks have a title and a description. This changes removes formatting options from title and adds them on description. For now this is just bold and italic. Links are still [not supported properly from WP](https://github.com/WordPress/gutenberg/issues/11599).

Used `allowedFormats` everywhere, instead of `formattingControls`, for consistency but also because `formattingControls` is [being deprecated](https://github.com/WordPress/gutenberg/blob/641f1c70af8ffd466b4adf20b29e7a4a839fc1e8/packages/block-editor/CHANGELOG.md#new-features-2).

Additionally we add these rules on specific blocks:

**Accordion**

Headline: Disallow
Text: Allow

**Carousel Header**

Disallow everywhere

**Columns**

Column Header: Disallow
Column Description: Allow

**Cookies**

Cookie name: Disallow
Cookie description: Allow