### PR TITLE
PLANET-6151 Add RTL to CarouselHeader WYSIWYG

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
@@ -2,6 +2,8 @@ import { useRef, useEffect } from '@wordpress/element';
 import { useSlides } from './useSlides';
 import { CarouselHeaderStaticContent } from './CarouselHeaderStaticContent';
 
+const isRTL = document.querySelector('html').dir === 'rtl';
+
 const { __ } = wp.i18n;
 
 export const CarouselHeaderFrontend = ({ slides, carousel_autoplay }) => {
@@ -17,6 +19,15 @@ export const CarouselHeaderFrontend = ({ slides, carousel_autoplay }) => {
     autoplayCancelled
   } = useSlides(slidesRef, slides.length - 1, containerRef);
 
+  const changeSlideHandlers = [
+    () => goToNextSlide(),
+    () => goToPrevSlide(),
+  ];
+
+  if (isRTL) {
+    changeSlideHandlers.reverse();
+  }
+
   useEffect(() => {
     if (!containerRef.current) {
       return;
@@ -30,21 +41,12 @@ export const CarouselHeaderFrontend = ({ slides, carousel_autoplay }) => {
     swipe.set({ direction: Hammer.DIRECTION_HORIZONTAL });
     hammer.add(swipe);
 
-    const swipeListeners = [
-      goToNextSlide,
-      goToPrevSlide
-    ];
-
-    // if (isRTL) {
-    //   swipeListeners.reverse();
-    // }
-
-    hammer.on('swipeleft', swipeListeners[0]);
-    hammer.on('swiperight', swipeListeners[1]);
+    hammer.on('swipeleft', changeSlideHandlers[0]);
+    hammer.on('swiperight', changeSlideHandlers[1]);
 
     return () => {
-      hammer.off('swipeleft', swipeListeners[0]);
-      hammer.off('swiperight', swipeListeners[1]);
+      hammer.off('swipeleft', changeSlideHandlers[0]);
+      hammer.off('swiperight', changeSlideHandlers[1]);
     }
   }, [currentSlide]);
 
@@ -70,7 +72,7 @@ export const CarouselHeaderFrontend = ({ slides, carousel_autoplay }) => {
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }
-      timerRef.current = setTimeout(() => goToNextSlide(true), 10000);
+      timerRef.current = setTimeout(() => changeSlideHandlers[0](true), 10000);
       return () => clearTimeout(timerRef.current);
     } else if (timerRef.current) {
       clearTimeout(timerRef.current);
@@ -82,8 +84,8 @@ export const CarouselHeaderFrontend = ({ slides, carousel_autoplay }) => {
       slides={slides}
       slidesRef={slidesRef}
       containerRef={containerRef}
-      goToNextSlide={goToNextSlide}
-      goToPrevSlide={goToPrevSlide}
+      goToNextSlide={changeSlideHandlers[0]}
+      goToPrevSlide={changeSlideHandlers[1]}
       goToSlide={goToSlide}
       currentSlide={currentSlide}
     />

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -18,15 +18,13 @@ export const EditableBackground = ({
     value={image_id}
     render={mediaUploadInstance => (
       <>
-        <div className='background-holder'>
-          {!image_url ?
-            <ImagePlaceholder /> :
-            <img
-              src={image_url}
-              style={{ objectPosition: `${focalPoints?.x * 100}% ${focalPoints?.y * 100}%` }}
-            />
-          }
-        </div>
+        {!image_url ?
+          <ImagePlaceholder /> :
+          <img
+            src={image_url}
+            style={{ objectPosition: `${focalPoints?.x * 100}% ${focalPoints?.y * 100}%` }}
+          />
+        }
 
         <EditorControls
           image_url={image_url}

--- a/assets/src/blocks/CarouselHeader/Slide.js
+++ b/assets/src/blocks/CarouselHeader/Slide.js
@@ -10,9 +10,7 @@ export const SlideWithRef = ({
     className={`carousel-item ${active ? 'active' : ''}`}
     ref={ref}
   >
-    <div className='carousel-item-mask'>
-      {children}
-    </div>
+    {children}
   </div>
 );
 

--- a/assets/src/blocks/CarouselHeader/SlideBackground.js
+++ b/assets/src/blocks/CarouselHeader/SlideBackground.js
@@ -1,13 +1,11 @@
 export const SlideBackground = ({ slide }) => {
   const { image_url, image_sizes, image_srcset, focal_points } = slide;
   return (
-    <div className='background-holder'>
-      <img
-        src={image_url}
-        style={{ objectPosition: `${focal_points?.x * 100}% ${focal_points?.y * 100}%` }}
-        srcSet={image_srcset}
-        sizes={image_sizes || 'false'}
-      />
-    </div>
+    <img
+      src={image_url}
+      style={{ objectPosition: `${focal_points?.x * 100}% ${focal_points?.y * 100}%` }}
+      srcSet={image_srcset}
+      sizes={image_sizes || 'false'}
+    />
   );
 }

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -11,24 +11,21 @@ import { useState, useEffect } from '@wordpress/element';
  * @param {Array} slidesRef
  * @param {Object} options
  */
-export const useSlides = (slidesRef, lastSlide, containerRef, options = {
-  // Following Bootstrap's approach for RTL:
-  // https://getbootstrap.com/docs/5.0/getting-started/rtl/#approach
-  // Note: in non-directional transitions (e.g.: fade out),
-  // these could have the same class for both directions.
-  enterTransitionClasses: {
-    next: 'enter-from-end',
-    prev: 'enter-from-start'
-  },
-  exitTransitionClasses: {
-    next: 'exit-to-start',
-    prev: 'exit-to-end'
-  }
-}) => {
+export const useSlides = (slidesRef, lastSlide, containerRef) => {
   const [currentSlide, setCurrentSlide] = useState(0);
   const [autoplayPaused, setAutoplayPaused] = useState(false);
   const [autoplayCancelled, setAutoplayCancelled] = useState(false);
   const [sliding, setSliding] = useState(false);
+  const [options, setOptions] = useState({
+    enterTransitionClasses: {
+      next: 'enter-from-end',
+      prev: 'enter-from-start'
+    },
+    exitTransitionClasses: {
+      next: 'exit-to-start',
+      prev: 'exit-to-end'
+    }
+  });
 
   const goToNextSlide = (autoplay = false) => {
     goToSlide(currentSlide === lastSlide ? 0 : currentSlide + 1);
@@ -37,9 +34,11 @@ export const useSlides = (slidesRef, lastSlide, containerRef, options = {
     }
   };
 
-  const goToPrevSlide = () => {
+  const goToPrevSlide = (autoplay = false) => {
     goToSlide(currentSlide === 0 ? lastSlide : currentSlide - 1);
-    setAutoplayCancelled(true);
+    if (!autoplay) {
+      setAutoplayCancelled(true);
+    }
   };
 
   const getOrder = (currentSlide, newSlide, lastSlide) => {
@@ -84,7 +83,6 @@ export const useSlides = (slidesRef, lastSlide, containerRef, options = {
     if (newSlide !== currentSlide && nextElement && activeElement && !sliding) {
       setSliding(true);
 
-      const isRTL = false;
       const order = getOrder(currentSlide, newSlide, lastSlide);
       const enterTransitionClass = options.enterTransitionClasses[order];
       const exitTransitionClass = options.exitTransitionClasses[order];
@@ -116,6 +114,20 @@ export const useSlides = (slidesRef, lastSlide, containerRef, options = {
   useEffect(() => {
     if (!containerRef || !containerRef.current) {
       return;
+    }
+
+    const isRTL = document.querySelector('html').dir === 'rtl';
+    if (isRTL) {
+      setOptions({
+        enterTransitionClasses: {
+          prev: 'enter-from-end',
+          next: 'enter-from-start'
+        },
+        exitTransitionClasses: {
+          prev: 'exit-to-start',
+          next: 'exit-to-end'
+        }
+      });
     }
 
     containerRef.current.addEventListener('mouseenter', () => setAutoplayPaused(true));

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -1,5 +1,7 @@
 import { useState, useEffect } from '@wordpress/element';
 
+const SLIDE_TRANSITION_SPEED = 200;
+
 /**
  * Takes an array of refs to the slides
  * and performs the following transition:
@@ -52,7 +54,7 @@ export const useSlides = (slidesRef, lastSlide, containerRef) => {
   };
 
   const getSlideHeight = slideRef => {
-    return `${slideRef.querySelector('.carousel-item-mask .background-holder').offsetHeight + slideRef.querySelector('.carousel-caption').offsetHeight}px`;
+    return `${slideRef.querySelector('img').offsetHeight + slideRef.querySelector('.carousel-caption').offsetHeight}px`;
   };
 
   const setCarouselHeight = slideRef => {
@@ -62,11 +64,11 @@ export const useSlides = (slidesRef, lastSlide, containerRef) => {
 
     const carouselElement = containerRef.current;
     if (window.matchMedia('(max-width: 991px)').matches) {
-      carouselElement.querySelectorAll('.carousel-inner, .carousel-item-mask').forEach(container =>
+      carouselElement.querySelectorAll('.carousel-inner').forEach(container =>
         container.style.height = getSlideHeight(slideRef)
       );
     } else {
-      carouselElement.querySelectorAll('.carousel-inner, .carousel-item-mask').forEach(container =>
+      carouselElement.querySelectorAll('.carousel-inner').forEach(container =>
         container.style.height = null
       );
     }
@@ -95,12 +97,11 @@ export const useSlides = (slidesRef, lastSlide, containerRef) => {
       const unsetTransitionClasses = () => {
         activeElement.classList.remove(exitTransitionClass);
         nextElement.classList.remove(enterTransitionClass);
-        activeElement.removeEventListener('transitionend', unsetTransitionClasses);
         setSliding(false);
         setCurrentSlide(newSlide);
       };
 
-      activeElement.addEventListener('transitionend', unsetTransitionClasses);
+      setTimeout(unsetTransitionClasses, SLIDE_TRANSITION_SPEED);
 
       // This hack is used to force what happens
       // on transitionEnd when the active slide was removed in the editor

--- a/assets/src/styles/blocks/CarouselHeader/CarouselHeaderEditorStyle.scss
+++ b/assets/src/styles/blocks/CarouselHeader/CarouselHeaderEditorStyle.scss
@@ -1,4 +1,6 @@
 @import "../../master-theme/assets/src/scss/base/colors";
+@import "../../master-theme/assets/src/scss/base/mixins";
+@import "../../master-theme/assets/src/scss/base/variables";
 
 .visually-hidden {
   display: none;
@@ -50,12 +52,24 @@
   right: 20px;
   z-index: 1;
 
+  html[dir="rtl"] & {
+    left: 20px;
+    right: auto;
+  }
+
   .carousel-header-editor-controls-menu {
     position: relative;
 
     ul {
       position: absolute;
       right: 0;
+      margin: 0;
+      padding: 0;
+
+      html[dir="rtl"] & {
+        left: 0;
+        right: auto;
+      }
 
       li {
         color: $grey-80;
@@ -97,5 +111,11 @@
 
   p {
     margin: 0 !important;
+  }
+}
+
+@include x-large-and-up {
+  .carousel-header-beta .carousel-item .carousel-caption .main-header .row {
+    padding-inline-start: 110px;
   }
 }

--- a/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
+++ b/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
@@ -312,6 +312,7 @@ $medium-image-height: 600px;
       position: relative;
       top: 0;
       left: 0;
+      right: 0;
       padding-top: 24px;
       padding-bottom: 24px;
       padding-left: 24px;
@@ -384,7 +385,7 @@ $medium-image-height: 600px;
 
         @include x-large-and-up {
           padding-bottom: 54px;
-          padding-inline-start: 110px;
+          padding-inline-start: 0;
         }
 
         h1 {
@@ -607,7 +608,7 @@ $medium-image-height: 600px;
         width: auto;
 
         html[dir="rtl"] & {
-          right: auto;
+          text-align: right;
         }
       }
 
@@ -617,6 +618,7 @@ $medium-image-height: 600px;
         padding-right: 0;
         width: auto;
         display: block;
+        padding-inline-start: 80px;
       }
 
       @include x-large-and-up {

--- a/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
+++ b/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
@@ -3,7 +3,7 @@
 @import "../../master-theme/assets/src/scss/base/colors";
 @import "../../master-theme/assets/src/scss/base/fonts";
 
-// $slide-transition-speed should match SLIDE_TRANSITION_SPEED in carousel-header.js
+// $slide-transition-speed should match SLIDE_TRANSITION_SPEED in useSlides.js
 $slide-transition-speed: .2s;
 $text-slide-offset: 50px;
 
@@ -81,7 +81,7 @@ $medium-image-height: 600px;
 
   .carousel-inner {
     position: relative;
-    overflow: visible;
+    overflow: hidden;
     height: 580px;
     padding-bottom: 0;
 
@@ -111,7 +111,6 @@ $medium-image-height: 600px;
     position: absolute;
     top: 0;
     opacity: 0;
-    z-index: 3500;
 
     @include medium-and-up {
       height: $medium-image-height;
@@ -127,10 +126,6 @@ $medium-image-height: 600px;
       z-index: 1;
       opacity: 1;
       transition: unset;
-
-      .carousel-item-mask {
-        width: 100%;
-      }
 
       .carousel-caption .main-header {
         h1 {
@@ -156,25 +151,11 @@ $medium-image-height: 600px;
       }
     }
 
-    .carousel-item-mask {
-      position: relative;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      overflow: hidden;
-    }
-
-    .background-holder {
+    img {
+      object-fit: cover;
       width: 100vw;
       height: $mobile-image-height;
       z-index: -1;
-
-      img {
-        height: 100%;
-        object-fit: cover;
-        width: 100vw;
-      }
 
       @include medium-and-up {
         height: $medium-image-height;
@@ -182,17 +163,6 @@ $medium-image-height: 600px;
 
       @include large-and-up {
         height: 100%;
-      }
-
-      // Darken background
-      &::after {
-        @include fill-container;
-        content: "";
-        background: none;
-
-        @include large-and-up {
-          background: rgba(30, 30, 30, 0.45);
-        }
       }
     }
 
@@ -204,10 +174,6 @@ $medium-image-height: 600px;
       transition: unset;
       pointer-events: all;
 
-      .carousel-item-mask {
-        width: 100%;
-      }
-
       .carousel-caption .main-header {
         h1, p {
           transform: translateX(0);
@@ -216,52 +182,6 @@ $medium-image-height: 600px;
 
         .action-button {
           opacity: 1;
-        }
-      }
-    }
-
-    &.exit-to-start {
-      .carousel-item-mask {
-        width: 0;
-        transition: width $slide-transition-speed;
-
-        html[dir="rtl"] & {
-          direction: ltr;
-
-          .background-holder {
-            direction: rtl;
-          }
-        }
-      }
-
-      html[dir="rtl"] & {
-        direction: ltr;
-      }
-    }
-
-    &.exit-to-end {
-      .carousel-item-mask {
-        width: 0;
-        margin-left: auto;
-        right: 0;
-
-        transition: width $slide-transition-speed;
-
-        // This "width + overflow: hidden" reveal trick depends on
-        // the direction property to allow masking content from the left, see:
-        // https://stackoverflow.com/questions/22126759/how-to-cut-off-overflow-on-the-left-side?rq=1
-        //
-        // It exists as a workaround for `clip-path` which is not yet well supported on Safari & Firefox.
-        // TODO: Remove in favor of `clip-path` when supported in all major browsers
-        // Check for compatibility: https://caniuse.com/#feat=css-clip-path
-        direction: rtl;
-
-        .background-holder {
-          direction: ltr;
-
-          html[dir="rtl"] & {
-            direction: rtl;
-          }
         }
       }
     }


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-6151

- Added some RTL-specific CSS styles both for the frontend (indicators position, caption alignment, etc) and the backend ("Edit" button + menu)
- Updated swipe on mobile
- Updated arrows behaviour
- Made some small CSS fixes

### Testing

You can add a "CarouselHeader (beta)" block to the MENA [dev site](https://www-dev.greenpeace.org/mena/ar/) in Arabic and compare it to the "normal" block in the corresponding [production site](https://www.greenpeace.org/mena/ar/) to test the changes. The behaviour should be the same in all screen sizes 🙂 