### PR TITLE
PLANET-6196: Add credits to image caption in Slider Gallery

### DIFF
--- a/assets/src/blocks/Gallery/GalleryCarousel.js
+++ b/assets/src/blocks/Gallery/GalleryCarousel.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { IMAGE_SIZES } from './imageSizes';
-import { getImageTitle } from './getImageTitle.js';
+import { getCaptionWithCredits } from './getCaptionWithCredits.js';
 
 const { __ } = wp.i18n;
 
@@ -108,7 +108,7 @@ export const GalleryCarousel = ({ images, onImageClick }) => {
             {(image.caption || image.credits) && (
               <div className="carousel-caption">
                 <p>
-                  {getImageTitle(image)}
+                  {getCaptionWithCredits(image)}
                 </p>
               </div>
             )}

--- a/assets/src/blocks/Gallery/GalleryCarousel.js
+++ b/assets/src/blocks/Gallery/GalleryCarousel.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { IMAGE_SIZES } from './imageSizes';
+import { getImageTitle } from './getImageTitle.js';
 
 const { __ } = wp.i18n;
 
@@ -107,7 +108,7 @@ export const GalleryCarousel = ({ images, onImageClick }) => {
             {(image.caption || image.credits) && (
               <div className="carousel-caption">
                 <p>
-                  {image.caption || image.credits}
+                  {getImageTitle(image)}
                 </p>
               </div>
             )}

--- a/assets/src/blocks/Gallery/GalleryFrontend.js
+++ b/assets/src/blocks/Gallery/GalleryFrontend.js
@@ -2,7 +2,7 @@ import { GalleryCarousel } from './GalleryCarousel';
 import { GalleryThreeColumns } from './GalleryThreeColumns';
 import { GalleryGrid } from './GalleryGrid';
 import { getGalleryLayout, GALLERY_BLOCK_CLASSES } from './getGalleryLayout';
-import { getImageTitle } from './getImageTitle.js';
+import { getCaptionWithCredits } from './getCaptionWithCredits.js';
 import { Lightbox } from '../../components/Lightbox/Lightbox';
 import { useLightbox } from '../../components/Lightbox/useLightbox';
 
@@ -11,7 +11,7 @@ const imagesToItems = images => images.map(
     src: image.image_src,
     w: 0,
     h: 0,
-    title: getImageTitle(image)
+    title: getCaptionWithCredits(image)
   })
 );
 

--- a/assets/src/blocks/Gallery/GalleryFrontend.js
+++ b/assets/src/blocks/Gallery/GalleryFrontend.js
@@ -2,22 +2,16 @@ import { GalleryCarousel } from './GalleryCarousel';
 import { GalleryThreeColumns } from './GalleryThreeColumns';
 import { GalleryGrid } from './GalleryGrid';
 import { getGalleryLayout, GALLERY_BLOCK_CLASSES } from './getGalleryLayout';
+import { getImageTitle } from './getImageTitle.js';
 import { Lightbox } from '../../components/Lightbox/Lightbox';
 import { useLightbox } from '../../components/Lightbox/useLightbox';
-
-const getTitle = (image) => {
-  const caption = image.caption || '';
-  const credits = image.credits && !caption.includes(image.credits)
-    ? (image.credits.includes('©') ? image.credits : `© ${image.credits}`) : '';
-  return `${caption}  ${credits}`.trim();
-}
 
 const imagesToItems = images => images.map(
   image => ({
     src: image.image_src,
     w: 0,
     h: 0,
-    title: getTitle(image)
+    title: getImageTitle(image)
   })
 );
 

--- a/assets/src/blocks/Gallery/getCaptionWithCredits.js
+++ b/assets/src/blocks/Gallery/getCaptionWithCredits.js
@@ -1,0 +1,13 @@
+export const getCaptionWithCredits = (image) => {
+  const caption = image.caption || '';
+  const credits = getCredits(image, caption);
+  return `${caption}  ${credits}`.trim();
+};
+
+const getCredits = (image, caption) => {
+  if (!image.credits || caption.includes(image.credits)) {
+    return '';
+  }
+
+  return `© ${image.credits.replace(/^©\s*/, '')}`;
+}

--- a/assets/src/blocks/Gallery/getImageTitle.js
+++ b/assets/src/blocks/Gallery/getImageTitle.js
@@ -1,6 +1,0 @@
-export const getImageTitle = (image) => {
-  const caption = image.caption || '';
-  const credits = image.credits && !caption.includes(image.credits)
-    ? (image.credits.includes('©') ? image.credits : `© ${image.credits}`) : '';
-  return `${caption}  ${credits}`.trim();
-};

--- a/assets/src/blocks/Gallery/getImageTitle.js
+++ b/assets/src/blocks/Gallery/getImageTitle.js
@@ -1,0 +1,6 @@
+export const getImageTitle = (image) => {
+  const caption = image.caption || '';
+  const credits = image.credits && !caption.includes(image.credits)
+    ? (image.credits.includes('©') ? image.credits : `© ${image.credits}`) : '';
+  return `${caption}  ${credits}`.trim();
+};


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6196

Image credits are not displayed in the Gallery block for the Slider version. (other versions don't display any text)

## Fix 

Exporting `getImageTitle()` function to use for frontend/backend and Lightbox data.

## Test

- Add a gallery to a post/page
- Use images that have a completed `credits` field
- On the Slider version of the gallery, credits should appear at the end of the image caption, on backend and frontend

![Screenshot from 2021-06-16 12-06-28](https://user-images.githubusercontent.com/617346/1222.00487-61250180-ce9b-11eb-972d-d8ce078b4256.png)
