### PR TITLE
PLANET-6009 Media Block: Add mandatory field validation on media_url …

### DIFF
--- a/assets/src/blocks/Media/MediaBlock.js
+++ b/assets/src/blocks/Media/MediaBlock.js
@@ -38,7 +38,13 @@ export const registerMediaBlock = () => {
         default: ''
       },
       media_url: {
-        type: 'string'
+        type: 'string',
+        validation: media_url => {
+          const isValid  = media_url ? 1 : 0;
+          const messages = media_url ? [] : [ __('The Media Block video URL could not be empty.', 'planet4-blocks-backend') ];
+
+          return { isValid, messages };
+        }
       },
       poster_url: {
         type: 'string',

--- a/assets/src/blocks/Media/MediaFrontend.js
+++ b/assets/src/blocks/Media/MediaFrontend.js
@@ -26,6 +26,10 @@ export const MediaFrontend = ( attributes ) => {
     media_url,
   } = attributes;
 
+  if ( !media_url ) {
+    return '';
+  }
+
   return (
     <section className="block media-block">
       <div className="container">

--- a/classes/blocks/class-media.php
+++ b/classes/blocks/class-media.php
@@ -85,7 +85,7 @@ class Media extends Base_Block {
 	 * @return array The data to be passed to the frontend block.
 	 */
 	public static function get_media_data( $fields ): array {
-		$media_url        = $fields['media_url'] ?? $fields['youtube_id'];
+		$media_url        = $fields['media_url'] ?? $fields['youtube_id'] ?? '';
 		$url_path_segment = wp_parse_url( $media_url, PHP_URL_PATH );
 		$poster_url       = '';
 


### PR DESCRIPTION
…field

- Fix Undefined index: youtube_id error for old content

- If media_url field is empty hide Media block on frontend

Ref: [JIRA 6009](https://jira.greenpeace.org/browse/PLANET-6009)

---

**Testing:**
- Add a media block without media url, on post publish the publish checklist through's error
- Test old media block without media url, it will not visible on frontend

eg. https://www-dev.greenpeace.org/sagardev/test-media-block/