### PR TITLE
PLANET-6147: Fix missing and breaking classes on blocks

### DIFF
--- a/assets/src/blocks/Accordion/AccordionEditor.js
+++ b/assets/src/blocks/Accordion/AccordionEditor.js
@@ -36,7 +36,7 @@ const renderView = ({ title, description, tabs, className }, setAttributes, isSe
   };
 
   return (
-    <div className={`block accordion-block ${className}`}>
+    <div className={`block accordion-block ${className ?? ''}`}>
       <header>
         <RichText
           tagName="h2"

--- a/assets/src/blocks/Accordion/AccordionFrontend.js
+++ b/assets/src/blocks/Accordion/AccordionFrontend.js
@@ -1,7 +1,7 @@
 window.dataLayer = window.dataLayer || [];
 
 export const AccordionFrontend = ({ title, description, tabs, className }) => (
-  <section className={`block accordion-block ${className}`}>
+  <section className={`block accordion-block ${className ?? ''}`}>
     {title &&
       <header>
         <h2 className="page-section-header">{title}</h2>

--- a/assets/src/blocks/Articles/ArticlesFrontend.js
+++ b/assets/src/blocks/Articles/ArticlesFrontend.js
@@ -10,6 +10,7 @@ export const ArticlesFrontend = (props) => {
     read_more_text,
     read_more_link,
     button_link_new_tab,
+    className,
   } = props;
 
   const postType = document.body.getAttribute('data-post-type');
@@ -27,7 +28,7 @@ export const ArticlesFrontend = (props) => {
   }
 
   return (
-    <section className="block articles-block">
+    <section className={`block articles-block ${className ?? ''}`}>
       <div className="container">
         <header>
           <h2 className="page-section-header">{ article_heading }</h2>

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
@@ -12,7 +12,7 @@ import { EditableBackground } from './EditableBackground';
 import { useCarouselHeaderImages } from './useCarouselHeaderImages';
 
 export const CarouselHeaderEditor = ({ setAttributes, attributes }) => {
-  const { carousel_autoplay, slides } = attributes;
+  const { carousel_autoplay, slides, className } = attributes;
   const slidesRef = useRef([]);
   const slidesWithImages = useCarouselHeaderImages(slides);
 
@@ -51,7 +51,7 @@ export const CarouselHeaderEditor = ({ setAttributes, attributes }) => {
   }
 
   return (
-    <section className='block block-header block-wide carousel-header-beta'>
+    <section className={`block block-header block-wide carousel-header-beta ${className ?? ''}`}>
       <Sidebar
         carouselAutoplay={carousel_autoplay}
         slides={slidesWithImages}

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
@@ -7,7 +7,7 @@ import { StaticCaption } from './StaticCaption';
 
 const isRTL = document.querySelector('html').dir === 'rtl';
 
-export const CarouselHeaderFrontend = ({ slides, carousel_autoplay }) => {
+export const CarouselHeaderFrontend = ({ slides, carousel_autoplay, className }) => {
   const slidesRef = useRef([]);
   const containerRef = useRef(null);
   const {
@@ -73,7 +73,7 @@ export const CarouselHeaderFrontend = ({ slides, carousel_autoplay }) => {
 
   return (
     <section
-      className='block block-header block-wide carousel-header-beta'
+      className={`block block-header block-wide carousel-header-beta ${className ?? ''}`}
       ref={containerRef}
     >
       <div className='carousel-wrapper-header'>

--- a/assets/src/blocks/CarouselHeader/deprecated/carouselHeaderV1.js
+++ b/assets/src/blocks/CarouselHeader/deprecated/carouselHeaderV1.js
@@ -30,7 +30,7 @@ export const carouselHeaderV1 = {
     },
   },
   isEligible({ slides }) {
-    return !!slides.find(slide => slide.header_size !== 'undefined');
+    return !!slides?.find(slide => slide.header_size !== 'undefined');
   },
   migrate( { slides, ...attributes } ) {
     return {

--- a/assets/src/blocks/Columns/ColumnsEditor.js
+++ b/assets/src/blocks/Columns/ColumnsEditor.js
@@ -11,6 +11,8 @@ import { URLInput } from '../../components/URLInput/URLInput';
 import { EditableColumns } from './EditableColumns';
 import { Columns } from './Columns';
 import { MAX_COLUMNS_AMOUNT, MIN_COLUMNS_AMOUNT } from './ColumnConstants';
+import { getStyleFromClassName } from '../getStyleFromClassName';
+
 
 const { __ } = wp.i18n;
 const { RichText } = wp.blockEditor;
@@ -103,10 +105,10 @@ export const ColumnsEditor = ({ isSelected, attributes, setAttributes }) => {
 
   // Update column block style based on className attribute
   useEffect(() => {
-    if (className && className.includes('is-style-')) {
-      const newColumnsStyle = className.split('is-style-')[1];
+    const styleClass = getStyleFromClassName(className);
+    if (styleClass) {
       setAttributes({
-        columns_block_style: newColumnsStyle
+        columns_block_style: styleClass
       });
     }
   }, [className]);
@@ -141,7 +143,7 @@ export const ColumnsEditor = ({ isSelected, attributes, setAttributes }) => {
   }
 
   return (
-    <section className={`block columns-block block-style-${columns_block_style}`}>
+    <section className={`block columns-block block-style-${columns_block_style} ${className ?? ''}`}>
       <div className='container'>
         {renderEdit(attributes, toAttribute, setAttributes, isSelected)}
         {!isExample &&

--- a/assets/src/blocks/Columns/ColumnsFrontend.js
+++ b/assets/src/blocks/Columns/ColumnsFrontend.js
@@ -2,7 +2,7 @@ import { useEffect } from '@wordpress/element';
 import { LAYOUT_TASKS } from './ColumnConstants';
 import { Columns } from './Columns';
 
-export const ColumnsFrontend = ({ columns_block_style, columns_title, columns_description, columns }) => {
+export const ColumnsFrontend = ({ columns_block_style, columns_title, columns_description, columns, className }) => {
   const postType = document.body.getAttribute('data-post-type');
 
   // This function updates the headings' height so that they align
@@ -37,7 +37,7 @@ export const ColumnsFrontend = ({ columns_block_style, columns_title, columns_de
   }, []);
 
   return (
-    <section className={`block columns-block block-style-${columns_block_style}`}>
+    <section className={`block columns-block block-style-${columns_block_style} ${className ?? ''}`}>
       <div className='container'>
         {columns_title &&
           <header>

--- a/assets/src/blocks/Cookies/CookiesFrontend.js
+++ b/assets/src/blocks/Cookies/CookiesFrontend.js
@@ -34,6 +34,7 @@ export const CookiesFrontend = props => {
     all_cookies_name,
     all_cookies_description,
     isEditing,
+    className,
     toAttribute = () => {},
   } = props;
 
@@ -72,7 +73,7 @@ export const CookiesFrontend = props => {
   useEffect(toggleHubSpotConsent, [allCookiesChecked, userRevokedAllCookies])
 
   return <Fragment>
-    <section className="block cookies-block">
+    <section className={`block cookies-block ${className ?? ''}`}>
       {(isEditing || title) &&
       <header>
         <FrontendRichText

--- a/assets/src/blocks/Counter/CounterFrontend.js
+++ b/assets/src/blocks/Counter/CounterFrontend.js
@@ -1,4 +1,5 @@
 import { Component, Fragment } from '@wordpress/element';
+import { getStyleFromClassName } from '../getStyleFromClassName';
 
 export class CounterFrontend extends Component {
   constructor(props) {
@@ -26,7 +27,7 @@ export class CounterFrontend extends Component {
     var enFormHeader = document.querySelector('.enform-extra-header-placeholder');
     if ( counterBar !== null && enFormHeader !== null ) {
       enFormHeader.append(counterBar);
-    } 
+    }
   }
 
   componentWillUnmount() {
@@ -95,14 +96,15 @@ export class CounterFrontend extends Component {
     const { completed } = this.state;
 
     let style = this.props.style || 'plain'; // Needed to convert existing blocks
-    if (className) {
-      style = className.split('is-style-')[1];
+    const styleClass = getStyleFromClassName(className);
+    if (styleClass) {
+      style = styleClass;
     }
     const arcLength = 31.5;
 
     const percent = Math.min(target > 0 ? Math.round(completed / target * 100) : 0, 100);
 
-    let counterClassName = `block container counter-block counter-style-${style}`;
+    let counterClassName = `block container counter-block counter-style-${style} ${className ?? ''}`;
     if (isEditing) counterClassName += ` editing`;
 
     return (

--- a/assets/src/blocks/Covers/CoversEditor.js
+++ b/assets/src/blocks/Covers/CoversEditor.js
@@ -10,6 +10,7 @@ import PostSelector from '../../components/PostSelector/PostSelector';
 import PostTypeSelector from '../../components/PostTypeSelector/PostTypeSelector';
 import { Covers, COVER_TYPES } from './Covers';
 import { useCovers } from './useCovers';
+import { getStyleFromClassName } from '../getStyleFromClassName';
 
 const { RichText } = wp.blockEditor;
 const { __ } = wp.i18n;
@@ -69,7 +70,7 @@ const renderEdit = (attributes, toAttribute) => {
 }
 
 const renderView = (attributes, toAttribute) => {
-  const { initialRowsLimit, cover_type, title, description } = attributes;
+  const { initialRowsLimit, cover_type, title, description, className } = attributes;
 
   const { covers, loading, row } = useCovers(attributes);
 
@@ -82,7 +83,7 @@ const renderView = (attributes, toAttribute) => {
   };
 
   return (
-    <section className={`block covers-block ${cover_type}-covers-block`}>
+    <section className={`block covers-block ${cover_type}-covers-block ${className ?? ''}`}>
       <header>
         <RichText
           tagName='h2'
@@ -122,10 +123,10 @@ export const CoversEditor = ({ attributes, setAttributes, isSelected }) => {
   const { className, post_types } = attributes;
 
   useEffect(() => {
-    if (className && className.includes('is-style-')) {
-      const newCoverType = className.split('is-style-')[1];
+    const styleClass = getStyleFromClassName(className);
+    if (styleClass) {
       setAttributes({
-        cover_type: newCoverType,
+        cover_type: styleClass,
         posts: [],
         post_types: className.includes('content') ? post_types : [],
       });

--- a/assets/src/blocks/Covers/CoversFrontend.js
+++ b/assets/src/blocks/Covers/CoversFrontend.js
@@ -2,7 +2,7 @@ import { Covers } from './Covers';
 import { useCovers } from './useCovers';
 
 export const CoversFrontend = attributes => {
-  const { initialRowsLimit, cover_type, title, description, covers } = attributes;
+  const { initialRowsLimit, cover_type, title, description, covers, className } = attributes;
 
   const { loadMoreCovers, row } = useCovers(attributes, true);
 
@@ -19,7 +19,7 @@ export const CoversFrontend = attributes => {
   }
 
   return (
-    <section className={`block covers-block ${cover_type}-covers-block`}>
+    <section className={`block covers-block ${cover_type}-covers-block ${className ?? ''}`}>
       {title &&
         <h2 className='page-section-header' dangerouslySetInnerHTML={{ __html: title }} />
       }

--- a/assets/src/blocks/Gallery/GalleryEditor.js
+++ b/assets/src/blocks/Gallery/GalleryEditor.js
@@ -123,7 +123,7 @@ const renderView = (attributes, setAttributes) => {
   const { images } = useGalleryImages({ multiple_image, gallery_block_focus_points }, layout);
 
   return (
-    <section className={`block ${GALLERY_BLOCK_CLASSES[layout]}`}>
+    <section className={`block ${GALLERY_BLOCK_CLASSES[layout]} ${className ?? ''}`}>
       <header className="articles-title-container">
         <RichText
           tagName="h2"

--- a/assets/src/blocks/Gallery/GalleryFrontend.js
+++ b/assets/src/blocks/Gallery/GalleryFrontend.js
@@ -30,7 +30,7 @@ export const GalleryFrontend = ({
   const items = imagesToItems(images);
 
   return (
-    <section className={`block ${GALLERY_BLOCK_CLASSES[layout]}`}>
+    <section className={`block ${GALLERY_BLOCK_CLASSES[layout]} ${className ?? ''}`}>
       {gallery_block_title &&
         <header>
           <h2 className="page-section-header" dangerouslySetInnerHTML={{ __html: gallery_block_title }} />

--- a/assets/src/blocks/Gallery/getGalleryLayout.js
+++ b/assets/src/blocks/Gallery/getGalleryLayout.js
@@ -1,3 +1,5 @@
+import { getStyleFromClassName } from '../getStyleFromClassName'
+
 const GALLERY_LAYOUTS = ['slider', 'three-columns', 'grid'];
 
 export const GALLERY_BLOCK_CLASSES = {
@@ -8,8 +10,9 @@ export const GALLERY_BLOCK_CLASSES = {
 
 export const getGalleryLayout = (className, style) => {
   let layout = style > 0 ? GALLERY_LAYOUTS[style - 1] : 'slider';
-  if (className && className.includes('is-style-')) {
-    layout = className.replace('is-style-', '');
+  const styleClass = getStyleFromClassName(className);
+  if (styleClass) {
+    layout = styleClass;
   }
   return layout;
 };

--- a/assets/src/blocks/Happypoint/HappypointFrontend.js
+++ b/assets/src/blocks/Happypoint/HappypointFrontend.js
@@ -5,7 +5,8 @@ export const HappypointFrontend = ({
   opacity,
   mailing_list_iframe,
   iframe_url,
-  id
+  id,
+  className,
 }) => {
   const { imageData } = useHappypointImageData(id);
 
@@ -35,7 +36,7 @@ export const HappypointFrontend = ({
   const url = iframe_url || engaging_network_id;
 
   return (
-    <section className="block block-footer block-wide happy-point-block-wrap">
+    <section className={`block block-footer block-wide happy-point-block-wrap ${className ?? ''}`}>
       <picture>
         <img {...imgProps} loading="lazy" />
       </picture>

--- a/assets/src/blocks/Media/MediaFrontend.js
+++ b/assets/src/blocks/Media/MediaFrontend.js
@@ -24,6 +24,7 @@ export const MediaFrontend = ( attributes ) => {
     embed_html,
     poster_url,
     media_url,
+    className,
   } = attributes;
 
   if ( !media_url ) {
@@ -31,7 +32,7 @@ export const MediaFrontend = ( attributes ) => {
   }
 
   return (
-    <section className="block media-block">
+    <section className={`block media-block ${className ?? ''}`}>
       <div className="container">
         {
           video_title &&

--- a/assets/src/blocks/Splittwocolumns/SplittwocolumnsFrontend.js
+++ b/assets/src/blocks/Splittwocolumns/SplittwocolumnsFrontend.js
@@ -17,7 +17,8 @@ export const SplittwocolumnsFrontend = ({
   tag_image_src,
   tag_image_srcset,
   tag_image_title,
-  focus_tag_image
+  focus_tag_image,
+  className,
 }) => {
 
   const analytics = (action) => {
@@ -29,7 +30,7 @@ export const SplittwocolumnsFrontend = ({
   }
 
   return (
-    <section className="block-wide split-two-column">
+    <section className={`block-wide split-two-column ${className ?? ''}`}>
       <div className="split-two-column-item item--left">
         {issue_image_src &&
           <div className="split-two-column-item-image">

--- a/assets/src/blocks/Splittwocolumns/SplittwocolumnsInPlaceEdit.js
+++ b/assets/src/blocks/Splittwocolumns/SplittwocolumnsInPlaceEdit.js
@@ -22,7 +22,8 @@ export const SplittwocolumnsInPlaceEdit = ({attributes, charLimit, setAttributes
     tag_image_src,
     tag_image_title,
     focus_tag_image,
-    edited
+    edited,
+    className,
   } = attributes;
 
   const onTextChange = (field_name) => debounce(content => {
@@ -36,7 +37,7 @@ export const SplittwocolumnsInPlaceEdit = ({attributes, charLimit, setAttributes
   }, 400);
 
   return (
-    <section className="block-wide split-two-column">
+    <section className={`block-wide split-two-column ${className ?? ''}`}>
       <div className="split-two-column-item item--left">
         {issue_image_src &&
           <div className="split-two-column-item-image">

--- a/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
@@ -165,7 +165,7 @@ export class SpreadsheetFrontend extends Component {
 
     return (
       <Fragment>
-        <section className="block block-spreadsheet" style={{ cssText: toDeclarations( this.props.css_variables ) }}>
+        <section className={`block block-spreadsheet ${this.props.className ?? ''}`} style={{ cssText: toDeclarations( this.props.css_variables ) }}>
           <input className="spreadsheet-search form-control"
             type="text"
             value={ this.state.searchText }

--- a/assets/src/blocks/Submenu/SubmenuEditor.js
+++ b/assets/src/blocks/Submenu/SubmenuEditor.js
@@ -101,7 +101,7 @@ const renderView = (attributes, setAttributes, className) => {
   const style = getSubmenuStyle(className, submenu_style);
 
   return (
-    <section className={`block submenu-block submenu-${style}`}>
+    <section className={`block submenu-block submenu-${style} ${className ?? ''}`}>
       <RichText
         tagName="h2"
         placeholder={__('Enter title', 'planet4-blocks-backend')}

--- a/assets/src/blocks/Submenu/SubmenuFrontend.js
+++ b/assets/src/blocks/Submenu/SubmenuFrontend.js
@@ -10,7 +10,7 @@ export const SubmenuFrontend = ({ title, className, levels, submenu_style }) => 
   const style = getSubmenuStyle(className, submenu_style);
 
   return (
-    <section className={ `block submenu-block submenu-${ style }` }>
+    <section className={ `block submenu-block submenu-${style} ${className ?? ''}` }>
       { !!title && (
         <h2>{ title }</h2>
       ) }

--- a/assets/src/blocks/Submenu/getSubmenuStyle.js
+++ b/assets/src/blocks/Submenu/getSubmenuStyle.js
@@ -1,3 +1,5 @@
+import { getStyleFromClassName } from '../getStyleFromClassName';
+
 // Map for old attribute 'submenu_style'
 const SUBMENU_STYLES = {
   1: 'long',
@@ -6,8 +8,10 @@ const SUBMENU_STYLES = {
 };
 
 export const getSubmenuStyle = (className, submenu_style) => {
-  if (className && className.includes('is-style-')) {
-    return className.split('is-style-')[1];
+  const styleClass = getStyleFromClassName(className);
+  if (styleClass) {
+    return styleClass;
   }
+
   return submenu_style ? SUBMENU_STYLES[submenu_style] : 'long';
 };

--- a/assets/src/blocks/Timeline/TimelineEditorScript.js
+++ b/assets/src/blocks/Timeline/TimelineEditorScript.js
@@ -96,7 +96,7 @@ const renderEdit = (
 
 const renderView = (attributes, toAttribute, scriptLoaded, stylesLoaded) => {
   return (
-    <section className="block timeline-block">
+    <section className={`block timeline-block ${attributes.className ?? ''}`}>
       <Tooltip text={__('Edit text', 'planet4-blocks-backend')}>
         <header className="articles-title-container">
           <RichText

--- a/assets/src/blocks/Timeline/TimelineFrontend.js
+++ b/assets/src/blocks/Timeline/TimelineFrontend.js
@@ -5,11 +5,12 @@ export const TimelineFrontend = (props) => {
     timeline_title,
     description,
     isSelected,
+    className,
     ...nodeProps
   } = props;
 
   return (
-    <section className="block timeline-block">
+    <section className={`block timeline-block ${className ?? ''}`}>
       {!!timeline_title &&
         <header>
           <h2 className="page-section-header">{ timeline_title }</h2>

--- a/assets/src/blocks/getStyleFromClassName.js
+++ b/assets/src/blocks/getStyleFromClassName.js
@@ -1,0 +1,24 @@
+/**
+ * Get the name of the block style used from the classname string
+ * given by Gutenberg
+ *
+ * @example
+ * getStyleFromClassName('is-style-foo') => 'foo'
+ * getStyleFromClassName('bar is-style-foo baz') => 'foo'
+ * getStyleFromClassName('bar baz') => null
+ *
+ * @param {string} className
+ * @returns string|null
+ */
+export const getStyleFromClassName = className => {
+  if (!className || className.trim().length <= 9) {
+    return null;
+  }
+
+  const styleClass = className.split(' ').filter((c) => c.startsWith('is-style-'))[0];
+  if (!styleClass) {
+    return null;
+  }
+
+  return styleClass.replace(/^is-style-/, '');
+}

--- a/classes/blocks/class-splittwocolumns.php
+++ b/classes/blocks/class-splittwocolumns.php
@@ -160,7 +160,7 @@ class SplitTwoColumns extends Base_Block {
 		$updated = array_filter(
 			$fields,
 			static function ( $key ) {
-				return isset( self::ATTRIBUTES[ $key ] );
+				return isset( self::ATTRIBUTES[ $key ] ) || 'className' === $key;
 			},
 			\ARRAY_FILTER_USE_KEY
 		);


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6147

The style name extraction method generates issues with the "additional classes" field.
Additional classes are also not included in the resulting blocks, except when the current bug extracts a style and if those additional classes are placed after the style class name.

Currently, for a Columns block with style `tasks`, an additional class `is-style-tasks` is included. If we edit the additional class to `foo is-style-tasks bar`, the column will end up with classes `block-style-tasks bar`. This is because the code splits the classname string on `is-style-`, keeps everything that is after it (so `tasks bar`) and concatenate to `block-style-`. 
Other blocks simply don't have these additional CSS classes included on their container section.

## Example

You should look at the `class` attribute of the `section` tag (usually).
**Config**:
`foobar is-style-no_image foobaz`
![Screenshot from 2021-06-17 18-22-17](https://user-images.githubusercontent.com/617346/122436298-ff4ac180-cf98-11eb-8943-1ff0514dfc87.png)
**Before fix**:
`block columns-block block-style-no_image foobaz`
![Screenshot from 2021-06-17 18-24-25](https://user-images.githubusercontent.com/617346/122436648-489b1100-cf99-11eb-9c9a-fa8d6ac08fab.png)
**After fix**:
`block columns-block block-style-no_image foobar is-style-no_image foobaz`
![Screenshot from 2021-06-17 18-28-30](https://user-images.githubusercontent.com/617346/122437267-d8d95600-cf99-11eb-9ccf-d72693372e74.png)


## Fix 

- Adding a function `getStyleFromClassName` to use in relevant blocks
- Adding className string to generated blocks containers that are missing it

This PR does not fix
- ServerSideRendered blocks : OldENForm, OldCarouselHeader, SocialMedia, TakeActionBoxout
- SplitTwoColumns (not sure I understand where `className` is) 

## Test

Here is the boring part:
- Add one of every Planet4 block in a page
- Add additional classes in the "Additional CSS class(es)" field everywhere you can
- Check that it appears in the source inspector on backend and frontend 

The less boring way:
I've edited a page on Sinope (https://www-dev.greenpeace.org/test-sinope/?page_id=47006&preview=true), adding classes `foobar` to blocks, and `foobaz` when a class `is-style-*` is involved (to check that classes included before and after this string are properly added). So you can also:
- Go there and open the inspector
- Search (ctrl+f) for classes `.foobar`, `.foobaz`
- Check that they are in there, and that classes `is-style-*` are also included 