### PR TITLE
PLANET-5003: Fix spacing inconsistencies in lists

### DIFF
--- a/assets/src/styles/blocks/core-overrides/BlockSpacing.scss
+++ b/assets/src/styles/blocks/core-overrides/BlockSpacing.scss
@@ -2,12 +2,12 @@
 .wp-block-file,
 .wp-block-button,
 div.page-template > h2,
-div.page-template > ul,
+div.page-template > ul > li:last-of-type,
 div.page-template > p,
-.post-details > p,
-.post-details > p:first-of-type,
 .post-details > h2,
-.post-details > ul {
+.post-details > ul > li:last-of-type,
+.post-details > p,
+.post-details > p:first-of-type {
   margin-top: $space-xs;
   margin-bottom: $space-md;
 
@@ -17,21 +17,23 @@ div.page-template > p,
   }
 }
 
+div.page-template > ul > li,
+.post-details > ul > li {
+  margin-top: $space-xs;
+  margin-bottom: $space-xs;
+
+  @include large-and-up {
+    margin-top: $space-md;
+    margin-bottom: $space-md;
+  }
+}
+
 .wp-block-quote,
 .wp-block-file,
 .wp-block-button,
 div.page-template > h2,
-div.page-template > ul,
-.post-details > h2,
-.post-details > ul {
+.post-details > h2 {
   display: inline-block;
-  margin-top: $space-xs;
-  margin-bottom: $space-md;
-
-  @include large-and-up {
-    margin-top: $space-md;
-    margin-bottom: $space-lg;
-  }
 }
 
 div.page-template > ul,


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5003

> When using lists `<ul><ol>` in Pages, for both Default and Evergreen templates, there appears to be additional spacing below the list. Additionally, there is no spacing within the list itself. The expected behaviour would be what appears on Posts.

Margins between paragraphs collapse, but not between paragraph and list, so it looks larger.
List items only have a padding in posts, and no margin. 

![Screenshot from 2021-06-22 11-51-56](https://user-images.githubusercontent.com/617346/122904190-66c59000-d350-11eb-84ce-84722b4266f4.png)



## Fix

Diff is a bit confusing, but:

- I removed duplicated rules (on margins) between the first 2 declarations
- Removed margin associated to `ul` tag, so we can use margin collapse of `li` instead and not conflict with other blocks margins
- Removed list specific margin/padding for articles in https://github.com/greenpeace/planet4-master-theme/compare/planet-5003
- Added a declaration for the last list item to play as the bottom margin of the list
- Added a declaration for spacing in lists to be the next lowest version of spacing between blocks (ie: 16px when blocks have 32px margin, 8px when margin is 16) - I checked with Magali to see if those values were ok.

![Screenshot from 2021-06-22 11-52-27](https://user-images.githubusercontent.com/617346/122904234-71802500-d350-11eb-8baf-1d135190e4f5.png)

## Test

Test pages (including both branches):
- https://www-dev.greenpeace.org/test-telesto/story/1013/spacing-test-post/
- https://www-dev.greenpeace.org/test-telesto/spacing-test-page/
- https://www-dev.greenpeace.org/test-telesto/spacing-test-evergreen-page/
