### PR TITLE
PLANET-6197: Fix width of embed block on mobile

### DIFF
--- a/assets/src/styles/blocks/Media.scss
+++ b/assets/src/styles/blocks/Media.scss
@@ -51,13 +51,8 @@
 }
 
 .wp-block-embed-twitter, .wp-block-embed-instagram, .wp-block-embed-soundcloud, .wp-block-embed-reddit, .wp-block-embed-flickr {
-  width: 330px;
   margin-top: $space-xs;
   margin-bottom: $space-md;
-
-  @include  small-and-up {
-    width: 330px;
-  }
 
   @include medium-and-up {
     width: 510px;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6197
Related to https://github.com/greenpeace/planet4-master-theme/pull/1399

Removing fixed min width for embed blocks, to allow them to adapt to smaller width.
Blocks adapt to width, as they usually include their own min-width.

See https://github.com/greenpeace/planet4-master-theme/pull/1399 for full description