### PR TITLE
PLANET-6212 Fix mandatory checkboxes in EN forms

### DIFF
--- a/public/js/enform_submit.js
+++ b/public/js/enform_submit.js
@@ -104,10 +104,10 @@ const p4_enform_frontend = (function ($) {
       const formValue = $(this).val();
 
       if ( // We only need to validate once per set of radios so we can check only the first one
-        $(this).attr('required') && 'radio' === $(this).attr('type') && $(this).attr('id').slice(-1) === '0' && !enform.validateRadio($(this)) ||
-        $(this).attr('required') && 'checkbox' === $(this).attr('type') && !$(this)[0].checked ||
-        $(this).attr('required') && !formValue && 'radio' !== $(this).attr('type') ||
-        'email' === $(this).attr('type') && !enform.validateEmail(formValue)
+        ($(this).attr('required') && 'radio' === $(this).attr('type') && $(this).attr('id').slice(-1) === '0' && !enform.validateRadio($(this)))||
+        ($(this).attr('required') && 'checkbox' === $(this).attr('type') && !$(this)[0].checked) ||
+        ($(this).attr('required') && !['checkbox', 'radio'].includes($(this).attr('type')) && !formValue) ||
+        ('email' === $(this).attr('type') && !enform.validateEmail(formValue))
       ) {
         enform.addErrorMessage(this);
         formIsValid = false;


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-6212

Sometimes the following statement: `$(this).attr('required') && !formValue && 'radio' !== $(this).attr('type')` would still be true despite the mandatory checkbox being checked as intended, which caused the error to show and blocked the form submission. So the fix was to check there that the field was not only not a radio but also not a checkbox, by using `!['checkbox', 'radio'].includes($(this).attr('type'))` instead.
I've also added parenthesis around the different `&&` statements to make sure they are interpreted correctly and not mixed up with the `||` ones.

### Testing

You can create an EN form and with a mandatory checkbox opt-in field (on my local I used the first available opt-in in the list with id 3887, might be different for you depending on your settings though). Before the fix it shouldn't be possible to submit the form with or without selecting the checkbox, as the error never disappears, but after the fix it should validate it as intended.

**Note**: sometimes it works just fine before the fix too, I'm not sure why 😬 so you might need to try out different opt-ins before finding one that causes the issue