### PR TITLE
PLANET-4460 Set Social media block min and max width to Facebook Page

### DIFF
--- a/assets/src/styles/blocks/Socialmedia.scss
+++ b/assets/src/styles/blocks/Socialmedia.scss
@@ -10,5 +10,29 @@
         margin-right: auto !important;
       }
     }
+
+    &-facebook {
+      border: none;
+      overflow: hidden;
+      height: 500px;
+
+      &--small {
+        width: 240px;
+        display: block;
+
+        @include medium-and-up {
+          display: none;
+        }
+      }
+
+      &--large {
+        width: 500px;
+        display: none;
+
+        @include medium-and-up {
+          display: block;
+        }
+      }
+    }
   }
 }

--- a/templates/blocks/social-media.twig
+++ b/templates/blocks/social-media.twig
@@ -13,14 +13,18 @@
 			{% if ( embed_code ) %}
 				{{ embed_code|raw }}
 			{% elseif ( facebook_page_url ) %}
-				<iframe src="https://www.facebook.com/plugins/page.php?href={{ facebook_page_url|url_encode }}&tabs={{ facebook_page_tab }}&width=340&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true"
-						width="340"
-						height="500"
-						style="border:none;overflow:hidden"
-						scrolling="no"
-						frameborder="0"
-						allowTransparency="true"
-						allow="encrypted-media"></iframe>
+				<iframe class="social-media-embed-facebook social-media-embed-facebook--small" src="https://www.facebook.com/plugins/page.php?href={{ facebook_page_url|url_encode }}&tabs={{ facebook_page_tab }}&width=240&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true"
+					scrolling="no"
+					frameborder="0"
+					allowTransparency="true"
+					allow="encrypted-media"
+				></iframe>
+				<iframe class="social-media-embed-facebook social-media-embed-facebook--large" src="https://www.facebook.com/plugins/page.php?href={{ facebook_page_url|url_encode }}&tabs={{ facebook_page_tab }}&width=500&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true"
+					scrolling="no"
+					frameborder="0"
+					allowTransparency="true"
+					allow="encrypted-media"
+				></iframe>
 			{% endif %}
 		</div>
 	</section>


### PR DESCRIPTION
**Description**

PLANET-4460: Set Social media block min and max width to Facebook Page

Ref: https://jira.greenpeace.org/browse/PLANET-4460

If you think this issue as an easy fix, my answer is yes! I completely agree with you. 
However, I was leading a lot to this issue finding the best solution but I'm sure that what I've done is not the best approach, but honestly, I don't think we could do more than this.

**Why?**
- Because the plugin neither allow resizing the `iframe` and nor div's width. [Check it out this](https://developers.facebook.com/support/bugs/2203165469736837/)
- Because it's a SSR Component and you cannot change it's render logic at runtime and its fully logic comes from the server. It doesn't have any lifecycle methods (to re-render). 
- Using this plugin as a SSR disallow to change the `queryString width` (width=240 or width=500) parameter from its `src` string since the server doesn't know the viewport width where the plugin is going to be rendered. This is another big thing that you should take care of this fix, and understand this current approach

i.e. 
```
https://www.facebook.com/plugins/page.php
?href=https://www.facebook.com/greenpeace.international
&tabs=timeline
&width=240
&height=500
&small_header=false
&adapt_container_width=true
&hide_cover=fals
e&show_facepile=true
```

- FYI and according to the Facebook Documentation, you can set the width of its parent and then the content should adapt to it but it only works for `div`s. See adapt width section [here](https://developers.facebook.com/support/bugs/2203165469736837/). As you see it doesn't work with `iframes` :/ 

The umbral of the plugin `width` is greather equal than `180px` and lower equal than `500px`. For example.. (see how it works for a -CSR- behaviour if you use the Javascript SDK, using `div` instead of `iframe`)

```
<div style="width: 400px;">
  <div
    class="fb-page"
    data-href="https://www.facebook.com/greenpeace.international"
    data-tabs="timeline,events"
    data-hide-cover="false"
    data-show-facepile="false"
    data-width="500"
    data-adapt-container-width="true"
  ></div>
</div>
```
If the parent width (400px) is lower than `data-width` and `data-adapt-container-width` is set to `true`, `.fb-page` should be `400px`
If the parent width (400px) is lower than `data-width` and `data-adapt-container-width` is set to `false`, `.fb-page` should be `500px`
If the parent width (180px) is lower than `data-width` and `data-adapt-container-width` is set to `false`, `.fb-page` should be `180px`


And finally..
**PROS ands CONS of this approach**

PROS
- You get a smaller layout rendered correctly in small devices and viceversa (min-width 240px and max-width 500px). So, this is what we need!

CONS
- Still using `iframe`
- Doesn't keep the scroll position when resizing
- Duplicated code :(
- SSR (I'm referring on only for this plugin and not of the rest of blocks) 

