### PR TITLE
PLANET-6124: Fix the "open in a new tab" functionality through from settings

### DIFF
--- a/assets/src/blocks/Columns/Columns.js
+++ b/assets/src/blocks/Columns/Columns.js
@@ -42,10 +42,10 @@ export const Columns = ({ columns, columns_block_style, isCampaign, isExample = 
                 : cta_link ?
                   <a
                     href={cta_link}
-                    target={link_new_tab && link_new_tab !== 'false' ? '_blank' : ''}
                     data-ga-category='Columns Block'
                     data-ga-action={columns_block_style === LAYOUT_ICONS ? 'Icon' : 'Image'}
                     data-ga-label={cta_link}
+                    { ...link_new_tab && { target: '_blank' } }
                   >
                     <img src={attachment} alt={title} title={title} loading='lazy' />
                   </a> :
@@ -60,6 +60,7 @@ export const Columns = ({ columns, columns_block_style, isCampaign, isExample = 
                   data-ga-category='Columns Block'
                   data-ga-action='Title'
                   data-ga-label={cta_link}
+                  { ...link_new_tab && { target: '_blank' } }
                 >
                   {title}
                 </a> :
@@ -72,7 +73,6 @@ export const Columns = ({ columns, columns_block_style, isCampaign, isExample = 
             {cta_text && cta_link &&
               <a
                 href={cta_link}
-                target={link_new_tab ? '_blank' : ''}
                 className={isCampaign || columns_block_style === LAYOUT_NO_IMAGE ?
                   `btn btn-${isCampaign ? 'primary' : 'secondary'}` :
                   'call-to-action-link'
@@ -80,6 +80,7 @@ export const Columns = ({ columns, columns_block_style, isCampaign, isExample = 
                 data-ga-category='Columns Block'
                 data-ga-action='Call to Action'
                 data-ga-label={cta_link}
+                { ...link_new_tab && { target: '_blank' } }
               >
                 {cta_text}
               </a>

--- a/assets/src/blocks/Columns/ColumnsEditor.js
+++ b/assets/src/blocks/Columns/ColumnsEditor.js
@@ -30,7 +30,7 @@ const renderEdit = (attributes, toAttribute, setAttributes, isSelected) => {
           attachment: 0,
           cta_link: '',
           cta_text: '',
-          link_new_tab: '',
+          link_new_tab: false,
         }
       ]
     });


### PR DESCRIPTION
Fix the "open in a new tab" functionality for external domains on <a> selectors.
Also fixed this functionality on `headings` and `images`

Issue found [here](https://www-dev.greenpeace.org/test-sinope/columns-with-links/)
Issue replicated and solved [here](https://www-dev.greenpeace.org/test-titan/columns-with-links/)
Issue replicated and solved (with images) [here](https://www-dev.greenpeace.org/test-titan/29060-2/)

Linked PR https://github.com/greenpeace/planet4-master-theme/pull/1411


Ref: https://jira.greenpeace.org/browse/PLANET-6124
