### PR TITLE
PLANET-5662 Split webpack into multiple configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15369,12 +15369,6 @@
       "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ==",
       "dev": true
     },
-    "remove-files-webpack-plugin": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/remove-files-webpack-plugin/-/remove-files-webpack-plugin-1.1.3.tgz",
-      "integrity": "sha512-r53wQ/IlTkmcv11wri71CZ27S+GhFI5SjHbTbaAJbisPC3qGwg87vlA2C5Z1PuVA+aMI8SgimnE4SqI+ZYzu6Q==",
-      "dev": true
-    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "node-sass": "^4.14.1",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "postcss-loader": "^3.0.0",
-    "remove-files-webpack-plugin": "^1.1.3",
     "sass-loader": "^7.3.1",
     "terser-webpack-plugin": "^1.4.1",
     "webpack-fix-style-only-entries": "^0.3.1"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,9 +3,7 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const TerserJSPlugin = require('terser-webpack-plugin');
 const FixStyleOnlyEntriesPlugin = require("webpack-fix-style-only-entries");
-const RemovePlugin = require('remove-files-webpack-plugin');
 const dashDash = require('@greenpeace/dashdash');
-const fs = require('fs');
 
 const mediaQueryAliases = {
   '(max-width: 576px)': 'mobile-only',
@@ -15,27 +13,49 @@ const mediaQueryAliases = {
   '(min-width: 1200px)': 'x-large-and-up',
 };
 
-const entryPoints = blockName => {
-  const tpl = {
-    [`${blockName}EditorScript`]: `./assets/src/blocks/${blockName}/${blockName}EditorScript.js`,
-    [`${blockName}EditorStyle`]: `./assets/src/styles/blocks/${blockName}/${blockName}EditorStyle.scss`,
-    [`${blockName}Script`]: `./assets/src/blocks/${blockName}/${blockName}Script.js`,
-    [`${blockName}Style`]: `./assets/src/styles/blocks/${blockName}/${blockName}Style.scss`,
-  };
-  const pathExists = ([,path]) => fs.existsSync(path);
-  return Object.fromEntries(Object.entries(tpl).filter(pathExists));
+const jsConfig = {
+  ...defaultConfig,
+  output: {
+    filename: '[name].js',
+    path: __dirname + '/assets/build'
+  },
+  optimization: {
+    minimizer: [
+      new TerserJSPlugin({}),
+    ]
+  },
 };
 
-module.exports = {
-  ...defaultConfig,
+const publicJsConfig = {
+  ...jsConfig,
   entry: {
-    editorIndex: './assets/src/editorIndex.js',
     frontendIndex: './assets/src/frontendIndex.js',
     carouselHeaderFrontIndex: './assets/src/carouselHeaderFrontIndex.js',
+    AccordionScript: './assets/src/blocks/Accordion/AccordionScript.js',
+    CoversScript: './assets/src/blocks/Covers/CoversScript.js',
+    CarouselHeaderScript: './assets/src/blocks/CarouselHeader/CarouselHeaderScript.js',
+    SpreadsheetScript: './assets/src/blocks/Spreadsheet/SpreadsheetScript.js',
+    TimelineScript: './assets/src/blocks/Timeline/TimelineScript.js',
+  },
+};
+const adminJsConfig = {
+  ...jsConfig,
+  entry: {
+    editorIndex: './assets/src/editorIndex.js',
+    themeEditor: './assets/src/themeEditorIndex.js',
+    AccordionEditorScript: './assets/src/blocks/Accordion/AccordionEditorScript.js',
+    CoversEditorScript: './assets/src/blocks/Covers/CoversEditorScript.js',
+    CarouselHeaderEditorScript: './assets/src/blocks/CarouselHeader/CarouselHeaderEditorScript.js',
+    SpreadsheetEditorScript: './assets/src/blocks/Spreadsheet/SpreadsheetEditorScript.js',
+    TimelineEditorScript: './assets/src/blocks/Timeline/TimelineEditorScript.js',
+  },
+};
+const cssConfig = {
+  ...defaultConfig,
+  entry: {
     style: './assets/src/styles/style.scss',
     editorStyle: './assets/src/styles/editorStyle.scss',
     lightbox: './assets/src/styles/lightbox.scss',
-    themeEditor: './assets/src/themeEditorIndex.js',
     themeEditorStyle: './assets/src/styles/themeEditor.scss',
     theme_antarctic: './assets/src/styles/theme_antarctic.scss',
     theme_arctic: './assets/src/styles/theme_arctic.scss',
@@ -44,20 +64,20 @@ module.exports = {
     theme_oceans: './assets/src/styles/theme_oceans.scss',
     theme_oil: './assets/src/styles/theme_oil.scss',
     theme_plastic: './assets/src/styles/theme_plastic.scss',
-    ...entryPoints('Accordion'),
-    ...entryPoints('Covers'),
-    ...entryPoints('CarouselHeader'),
-    ...entryPoints('Spreadsheet'),
-    ...entryPoints('Timeline'),
+    AccordionStyle: './assets/src/styles/blocks/Accordion/AccordionStyle.scss',
+    AccordionEditorStyle: './assets/src/styles/blocks/Accordion/AccordionEditorStyle.scss',
+    CarouselHeaderStyle: './assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss',
+    CarouselHeaderEditorStyle: './assets/src/styles/blocks/CarouselHeader/CarouselHeaderEditorStyle.scss',
+    SpreadsheetStyle: './assets/src/styles/blocks/Spreadsheet/SpreadsheetStyle.scss',
+    TimelineStyle: './assets/src/styles/blocks/Timeline/TimelineStyle.scss',
+    TimelineEditorStyle: './assets/src/styles/blocks/Timeline/TimelineEditorStyle.scss',
   },
   output: {
     filename: '[name].js',
     path: __dirname + '/assets/build'
   },
   module: {
-    ...defaultConfig.module,
     rules: [
-      ...defaultConfig.module.rules,
       {
         test: /\.(sass|scss)$/,
         use: [
@@ -111,36 +131,10 @@ module.exports = {
       ignoreOrder: false, // Enable to remove warnings about conflicting order
       filename: './[name].min.css'
     }),
-    new RemovePlugin({
-      after: {
-        test: [
-          {
-            folder: 'assets/build/',
-            method: (filePath) => {
-              return [
-                'editorStyle.deps.json',
-                'style.deps.json',
-                'theme_antarctic.deps.json',
-                'theme_arctic.deps.json',
-                'theme_climate.deps.json',
-                'theme_forest.deps.json',
-                'theme_oceans.deps.json',
-                'theme_oil.deps.json',
-                'theme_plastic.deps.json'
-              ].filter(item => {
-                return new RegExp(item, 'm').test(filePath);
-              }).length > 0;
-            }
-          }
-        ]
-      }
-    }),
   ],
   optimization: {
-    ...defaultConfig.optimization,
     minimizer: [
       // enable the css minification plugin
-      new TerserJSPlugin({}),
       new OptimizeCSSAssetsPlugin({
         cssProcessorOptions: {
           sourceMap: true,
@@ -151,5 +145,6 @@ module.exports = {
         }
       })
     ]
-  }
+  },
 };
+module.exports = [publicJsConfig, adminJsConfig, cssConfig];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,13 @@ const jsConfig = {
 
 const publicJsConfig = {
   ...jsConfig,
+  resolve: {
+    alias: {
+      '@hooks': 'preact/hooks',
+      '@render': 'preact',
+      '@compat': 'preact/compat',
+    }
+  },
   entry: {
     frontendIndex: './assets/src/frontendIndex.js',
     carouselHeaderFrontIndex: './assets/src/carouselHeaderFrontIndex.js',
@@ -40,6 +47,13 @@ const publicJsConfig = {
 };
 const adminJsConfig = {
   ...jsConfig,
+  resolve: {
+    alias: {
+      '@hooks': '@wordpress/element',
+      '@render': '@wordpress/element',
+      '@compat': '@wordpress/element',
+    }
+  },
   entry: {
     editorIndex: './assets/src/editorIndex.js',
     themeEditor: './assets/src/themeEditorIndex.js',


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5662

We can merge this before https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/603, then we should be able to remove the webpack changes from that PR and rebase. After that it should be mergeable :crossed_fingers: But before we proceed with that PR, we need to sync with @oekeur to see if this requires changes from their part. Probably they will have to mimic our alias config in both webpack and imports.

* This is needed because we want to have separate aliases for public and
admin JS, so that we can use Preact for the former and WP's bundled
React for the latter.
* Also split off the CSS config, because we can. All config in the
previous mixed object was either applying to JS or to CSS, never to
both.
* Include blocks' entries one by one instead of using the template. This
wouldn't work for the split config, and there were already cases where
not all files were needed for a block. This was previously caught with a
file system check, which can make it hard to figure out what's
happening, and impossible to both have the file local and not build it.
* Remove the plugins that remove certain build artifacts. This was
probably added when the built files were checked into Git. Now that we
build these in CI this shouldn't be needed anymore. These are all small
files.
