### PR TITLE
Add CSS variables to Articles, Columns and Covers

### DIFF
--- a/assets/src/styles/blocks/Articles.scss
+++ b/assets/src/styles/blocks/Articles.scss
@@ -2,9 +2,9 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  margin-top: $space-lg;
 
   --block-articles--article-- {
+    margin-top: $space-lg;
     background-color: transparentize($white, .2);
     box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
 
@@ -95,20 +95,22 @@
   margin: 4px 0;
 }
 
-.article-list-item-meta {
-  --block-articles--article--meta-- {
-    color: $grey-60;
-    font-family: $roboto;
-    font-style: italic;
-    font-size: 0.875rem;
-    font-weight: 300;
-
-    @include large-and-up {
-      font-size: 0.9375rem;
-      width: 80%;
-    }
-  }
+.article-list-item-meta --block-articles--article--meta-- {
+  color: $grey-60;
+  font-family: $roboto;
+  font-style: italic;
+  font-size: 0.875rem;
+  font-weight: 300;
   margin: 0;
+
+  &:hover {
+    color: $grey-60;
+  }
+
+  @include large-and-up {
+    font-size: 0.9375rem;
+    width: 80%;
+  }
 }
 
 .article-list-item-bullet {
@@ -119,10 +121,10 @@
 .article-list-item-content {
   --block-articles--article--content-- {
     font-size: inherit;
+    width: 80%;
   }
   display: none;
   margin: $space-xs 0 0;
-  width: 80%;
 
   @include large-and-up {
     display: block;
@@ -164,4 +166,8 @@
 
 .article-load-more {
   margin-top: $space-lg;
+}
+
+.article-list-item-tags .tag-wrap --block-articles--article--tags-- {
+  display: inline-block;
 }

--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -134,13 +134,15 @@
           margin-bottom: 0;
         }
 
-        a {
+        a --block-columns--paragraph-- {
           font-family: $lora;
         }
       }
 
       a {
-        font-family: $roboto;
+        --block-columns--link-- {
+          font-family: $roboto;
+        }
 
         &.call-to-action-link {
           position: relative;
@@ -183,6 +185,10 @@
       }
 
       .step-number {
+        --block-columns--step-number-- {
+          background: $grey;
+          color: $white;
+        }
         float: left;
         display: block;
         margin-right: 20px;
@@ -192,9 +198,7 @@
         line-height: 74px;
         text-align: center;
         font-size: 2.75rem;
-        background: $grey;
         border-radius: 50%;
-        color: $white;
         opacity: 0.7;
         text-transform: uppercase;
         font-weight: 500;
@@ -204,6 +208,9 @@
         }
 
         @include large-and-up {
+          --block-columns--step-number-- {
+            background: $dark-blue;
+          }
           float: none;
           width: 126px;
           height: 126px;
@@ -211,7 +218,6 @@
           line-height: 114px;
           font-size: 4.375rem;
           position: relative;
-          background-color: $dark-blue;
           opacity: 1;
         }
 
@@ -219,11 +225,13 @@
           font-family: $roboto;
 
           @include large-and-up {
+            --block-columns--step-number--inner-- {
+              background: $dark-blue;
+              border-color: $white;
+              border-width: 2px;
+            }
             position: absolute;
-            background-color: $dark-blue;
-            border-color: $white;
             border-style: solid;
-            border-width: 2px;
             border-radius: 50%;
             right: 5px;
             left: 5px;
@@ -234,7 +242,7 @@
       }
 
       .step-info {
-        h5 > a {
+        h5 > a _-- {
           color: $grey-80;
         }
 
@@ -271,17 +279,19 @@
         box-shadow: none;
 
         .card-header {
+          --block-columns--card-header-- {
+            font-weight: 400;
+            font-size: $font-size-xs;
+            font-family: $roboto;
+            background: $dark-blue;
+            color: $white;
+          }
           display: block;
           cursor: pointer;
-          font-weight: 400;
-          font-size: $font-size-xs;
-          font-family: $roboto;
           text-decoration: none;
           padding: $n10 $n10 $n5 $n10;
           margin-bottom: $space-sm;
-          background: $dark-blue;
           border: none;
-          color: $white;
 
           &:hover {
             text-decoration: none;

--- a/assets/src/styles/blocks/Covers/ContentCovers.scss
+++ b/assets/src/styles/blocks/Covers/ContentCovers.scss
@@ -1,6 +1,4 @@
 .content-covers-block {
-  color: $grey-80;
-
   .limit-visibility {
     margin-top: -$space-lg;
   }
@@ -94,7 +92,7 @@
           font-size: $font-size-sm;
         }
 
-        &.publication-date {
+        &.publication-date --block-covers--publication-date-- {
           font-family: $roboto;
           font-size: $font-size-xxs;
           line-height: 1.6;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5983

---

Some variables that are needed to reproduce the themes. CSS structure is still the same, so these changes should be safe. Except for a redundant color rule on ContentCovers which was removed.

It would be better if we clean up the block styles, currently they're very nested. But I added the variables to this structure anyway, since it's the only thing blocking us from removing the legacy.

Somewhat easier [without whitespace changes](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/628/files?diff=split&w=1)