### PR TITLE
Un-nest SCSS of ContentCovers

### DIFF
--- a/assets/src/styles/blocks/Covers/ContentCovers.scss
+++ b/assets/src/styles/blocks/Covers/ContentCovers.scss
@@ -31,95 +31,95 @@
     }
   }
 
-  .content-covers-block-wrap {
-    margin-top: $space-lg;
-
-    .content-covers-block-symbol {
-      position: relative;
-      margin: 0 0 24px 0;
-      box-shadow: 0 5px 20px 0 rgba(114, 114, 114, 0.5);
-      height: 180px;
-
-      @include small-and-up {
-        margin: $n20 0;
-      }
-
-      @include medium-and-up {
-        margin: 0 0 $n20 0;
-        max-width: 210px;
-        height: 300px;
-      }
-
-      @include large-and-up {
-        margin: 0 0 $n20 0;
-      }
-
-      @include x-large-and-up {
-        max-width: 255px;
-        height: 360px;
-      }
-
-      img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        object-position: 50% 50%;
-      }
-
-      &.dark-img {
-        a {
-          color: $white;
-        }
-      }
-    }
-
-    .content-covers-block-info {
-      .four-column-hover {
-        text-decoration: underline;
-      }
-
-      h5 {
-        padding: 0;
-        margin: 0;
-
-        > a {
-          color: $grey-80;
-        }
-      }
-
-      p {
-        margin-bottom: 0;
-
-        @include x-large-and-up {
-          font-size: $font-size-sm;
-        }
-
-        &.publication-date {
-          font-family: $roboto;
-          font-size: $font-size-xxs;
-          line-height: 1.6;
-          font-style: italic;
-          font-weight: 300;
-          color: $grey-60;
-
-          @include large-and-up {
-            font-size: $font-size-xxs;
-          }
-
-          @include x-large-and-up {
-            font-size: $font-size-xs;
-          }
-        }
-      }
-    }
-  }
-
   .btn {
     display: none;
 
     @include small-and-up {
       display: block;
       width: 50%;
+    }
+  }
+}
+
+.content-covers-block-wrap {
+  margin-top: $space-lg;
+
+  .content-covers-block-symbol {
+    position: relative;
+    margin: 0 0 24px 0;
+    box-shadow: 0 5px 20px 0 rgba(114, 114, 114, 0.5);
+    height: 180px;
+
+    @include small-and-up {
+      margin: $n20 0;
+    }
+
+    @include medium-and-up {
+      margin: 0 0 $n20 0;
+      max-width: 210px;
+      height: 300px;
+    }
+
+    @include large-and-up {
+      margin: 0 0 $n20 0;
+    }
+
+    @include x-large-and-up {
+      max-width: 255px;
+      height: 360px;
+    }
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: 50% 50%;
+    }
+
+    &.dark-img {
+      a {
+        color: $white;
+      }
+    }
+  }
+}
+
+.content-covers-block-info {
+  .four-column-hover {
+    text-decoration: underline;
+  }
+
+  h5 {
+    padding: 0;
+    margin: 0;
+
+    > a {
+      color: $grey-80;
+    }
+  }
+
+  p {
+    margin-bottom: 0;
+
+    @include x-large-and-up {
+      font-size: $font-size-sm;
+    }
+
+    &.publication-date {
+      font-family: $roboto;
+      font-size: $font-size-xxs;
+      line-height: 1.6;
+      font-style: italic;
+      font-weight: 300;
+      color: $grey-60;
+
+      @include large-and-up {
+        font-size: $font-size-xxs;
+      }
+
+      @include x-large-and-up {
+        font-size: $font-size-xs;
+      }
     }
   }
 }


### PR DESCRIPTION
This was already using specific enough class names so that it doesn't need to also be very nested. Too deeply nested SCSS makes code very hard to read. It also increases high specificity, making it challenging to use in child themes.

Not a lot of changes if you view [with whitespace changes ignored](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/630/files?diff=split&w=1).

Ref: <!-- Please add a url to the ticket this change is addressing. -->

---

<!--
Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
