### PR TITLE
WIP Use h3 for tasks style as well

### DIFF
--- a/assets/src/blocks/Columns/ColumnsTasks.js
+++ b/assets/src/blocks/Columns/ColumnsTasks.js
@@ -27,7 +27,7 @@ export const ColumnsTasks = ({ isCampaign, columns, no_of_columns }) => (
                 </span>
               </span>
               {title &&
-                <h5>
+                <h3>
                   {cta_link ?
                     <a
                       href={cta_link}
@@ -40,7 +40,7 @@ export const ColumnsTasks = ({ isCampaign, columns, no_of_columns }) => (
                     </a> :
                     title
                   }
-                </h5>
+                </h3>
               }
               {description &&
                 <p dangerouslySetInnerHTML={{ __html: description }} />


### PR DESCRIPTION
Other styles use h3 and it's used for the same content. Probably will allow to reduce some duplication. Still need to verify the style looks ok with the designs.

Luckily it turned out not needed for the legacy conversion, as just 2 pages use this block style and they will be converted to use another style.

Ref: <!-- Please add a url to the ticket this change is addressing. -->

---

<!--
Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
