### PR TITLE
Remove h1 styles in Gallery block

### DIFF
--- a/assets/src/styles/blocks/Gallery_carousel.scss
+++ b/assets/src/styles/blocks/Gallery_carousel.scss
@@ -1,29 +1,7 @@
 .carousel-wrap {
   overflow: hidden;
 
-  h1 {
-    font-size: $font-size-lg;
-    color: $grey-80;
-    margin-bottom: 22px;
-    margin-left: 0;
-
-    html[dir="rtl"] & {
-      text-align: right;
-    }
-
-    @include large-and-up {
-      font-size: $font-size-xl;
-      margin-bottom: 20px;
-    }
-
-    @include x-large-and-up {
-      font-size: 1.875rem;
-      margin-bottom: 22px;
-    }
-  }
-
   .carousel-item {
-
     @include mobile-only {
       height: 265px;
     }


### PR DESCRIPTION
* It looks like the current code doesn't put an h1 inside of
.carousel-wrap, so this CSS is unused.

I'll check if any more things can be removed before submitting for review.

Ref: <!-- Please add a url to the ticket this change is addressing. -->