### PR TITLE
Remove large-and-up media query of Columns tasks

### DIFF
--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -177,7 +177,6 @@
   // Columns block, layout tasks.
   &.block-style-tasks {
     .can-do-steps {
-      cursor: default;
       position: relative;
 
       @include x-large-and-up {
@@ -186,58 +185,39 @@
 
       .step-number {
         --block-columns--step-number-- {
-          background: $grey;
+          background: $dark-blue;
           color: $white;
         }
-        float: left;
+        position: relative;
         display: block;
         margin-right: 20px;
         margin-bottom: $space-xl;
-        width: 74px;
-        height: 74px;
-        line-height: 74px;
+        width: 126px;
+        height: 126px;
+        line-height: 114px;
         text-align: center;
-        font-size: 2.75rem;
+        font-size: 4.375rem;
         border-radius: 50%;
-        opacity: 0.7;
-        text-transform: uppercase;
         font-weight: 500;
 
         html[dir="rtl"] & {
           margin-right: 0;
         }
 
-        @include large-and-up {
-          --block-columns--step-number-- {
-            background: $dark-blue;
-          }
-          float: none;
-          width: 126px;
-          height: 126px;
-          vertical-align: middle;
-          line-height: 114px;
-          font-size: 4.375rem;
-          position: relative;
-          opacity: 1;
-        }
-
         .step-number-inner {
-          font-family: $roboto;
-
-          @include large-and-up {
-            --block-columns--step-number--inner-- {
-              background: $dark-blue;
-              border-color: $white;
-              border-width: 2px;
-            }
-            position: absolute;
-            border-style: solid;
-            border-radius: 50%;
-            right: 5px;
-            left: 5px;
-            top: 5px;
-            bottom: 5px;
+          --block-columns--step-number--inner-- {
+            background: $dark-blue;
+            border-color: $white;
+            border-width: 2px;
+            font-family: $roboto;
           }
+          position: absolute;
+          border-style: solid;
+          border-radius: 50%;
+          right: 5px;
+          left: 5px;
+          top: 5px;
+          bottom: 5px;
         }
       }
 


### PR DESCRIPTION
* As the markup is always matching this query. At smaller sizes the whole thing is hidden and other markup is shown.
* This in turn allows to substitute any declaration that was overridden by the large-and-up media query.
* Also remove some things that didn't do anything.

https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/640/files?diff=split&w=1

For now I didn't add any new variables. However because the media query was removed, and some variables were in it, it changes the names (to not include the media query).

Example page on test instance with Columns tasks style: https://www-dev.greenpeace.org/test-uranus/act/plastic-free-nz-2/plastic-free-nz/isthisyours/

Ref: <!-- Please add a url to the ticket this change is addressing. -->


