### PR TITLE
Hubspot Form block base implementation

### DIFF
--- a/assets/src/blocks/HubspotForm/HubspotFormBlock.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormBlock.js
@@ -1,0 +1,110 @@
+import ReactDOMServer from 'react-dom/server';
+import { Tooltip } from '@wordpress/components';
+import { HubspotFormEditor } from './HubspotFormEditor';
+import { HubspotFormFrontend } from './HubspotFormFrontend';
+const { registerBlockType } = wp.blocks;
+const { __ } = wp.i18n;
+
+const BLOCK_NAME = 'planet4-blocks/hubspot-form';
+
+const getStyleLabel = (label, help) => (
+  (help)
+    ? <Tooltip text={help}>
+        <span>{label}</span>
+      </Tooltip>
+    : label
+);
+
+export const registerHubspotFormBlock = () => {
+  return registerBlockType(BLOCK_NAME, {
+    title: 'Hubspot Form (beta)',
+    icon: 'feedback',
+    category: 'planet4-blocks-beta',
+    supports: {
+      multiple: false,
+      html: false,
+    },
+    attributes: {
+      blockTitle: {
+        type: 'string',
+      },
+      blockText: {
+        type: 'string',
+      },
+      blockBackgroundImageId: {
+        type: 'integer',
+      },
+      blockBackgroundImageUrl: {
+        type: 'string',
+      },
+      blockStyle: {
+        type: 'string',
+        default: 'image-full-width',
+      },
+      ctaText: {
+        type: 'string',
+      },
+      ctaLink: {
+        type: 'string',
+      },
+      ctaNewTab: {
+        type: 'boolean',
+        default: false,
+      },
+      formTitle: {
+        type: 'string',
+      },
+      formText: {
+        type: 'string',
+      },
+      hubspotShortcode: {
+        type: 'string',
+        default: '',
+      },
+      hubspotThankyouMessage: {
+        type: 'string',
+      },
+      enableCustomHubspotThankyouMessage: {
+        type: 'boolean',
+        default: false,
+      },
+      version: {
+        type: 'integer',
+        default: 1,
+      },
+    },
+    styles: [
+      {
+        name: 'image-full-width',
+        label: getStyleLabel(
+          __('Image full width', 'planet4-blocks-backend'),
+          __('https://p4-designsystem.greenpeace.org/05f6e9516/p/213df0-hubspot-forms/b/99e047', 'planet4-blocks-backend'),
+        ),
+        isDefault: true,
+      },
+    ],
+    edit: HubspotFormEditor,
+    save: (props) => {
+      /**
+       * This parser is added cause the Hubspot plugin takes the shortcode, by a hook,
+       * and converts it into a <script>. In consequence, it fails when it is parsed to json through the hydration.
+       *
+       * This parser is only affected to the hydration.
+       *
+       * Ideally, we should use innerBlocks but it has various reported conflicts using SSR.
+       */
+      const attributes = {...props.attributes};
+      attributes.hubspotShortcode = props.attributes.hubspotShortcode.replace('[', '').replace(']', '');
+
+      const markup = ReactDOMServer.renderToString(
+        <div
+          data-hydrate={BLOCK_NAME}
+          data-attributes={JSON.stringify(attributes)}
+        >
+          <HubspotFormFrontend {...props} />
+        </div>
+      );
+      return <wp.element.RawHTML>{ markup }</wp.element.RawHTML>;
+    },
+  })
+}

--- a/assets/src/blocks/HubspotForm/HubspotFormEditor.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormEditor.js
@@ -1,0 +1,147 @@
+import { Fragment, useEffect } from '@wordpress/element';
+import { RichText } from '@wordpress/block-editor';
+import { Sidebar } from './HubspotFormSidebar';
+import { useToAttribute } from './hooks/useToAttribute';
+import { useBackgroundImage } from './hooks/useBackgroundImage';
+import { getStyleFromClassName } from '../getStyleFromClassName';
+
+const { __ } = wp.i18n;
+
+/**
+ * This component is created as a workaround because the <RichText> doesn't provide
+ * The functionality to set max characters like any content editable element.
+ */
+const MaxLengthHelperComponent = ({ value, maxLength, children, darkTheme = false }) => (
+  <div>
+    { children }
+    {maxLength && <span
+      className={`max-length-message ${darkTheme ? 'dark-theme' : ''} ${value.length >= maxLength ? 'max-length-error' : ''}`}>
+      {value.length >= maxLength
+        ? __('Maximum of characters', 'planet4-blocks-backend')
+        : `${value.length} / ${maxLength}`}
+    </span>}
+  </div>
+)
+
+export const HubspotFormEditor = ({
+  attributes: {
+    blockBackgroundImageId,
+    blockBackgroundImageUrl,
+    blockText = '',
+    blockTitle,
+    blockStyle,
+    ctaText,
+    ctaLink,
+    ctaNewTab,
+    formText = '',
+    formTitle,
+    hubspotShortcode,
+    hubspotThankyouMessage,
+    enableCustomHubspotThankyouMessage,
+    className,
+  },
+  setAttributes,
+}) => {
+  const backgroundImage = useBackgroundImage(blockBackgroundImageUrl);
+  const toAttribute = useToAttribute(setAttributes);
+
+  useEffect(() => {
+    if(className) {
+      setAttributes({ blockStyle: getStyleFromClassName(className) });
+    }
+  }, [ className ]);
+
+  return (
+    <Fragment>
+      <Sidebar {...{
+        ctaLink,
+        ctaNewTab,
+        blockBackgroundImageId,
+        enableCustomHubspotThankyouMessage,
+        hubspotThankyouMessage,
+        setAttributes
+      }} />
+      <section className={`hubspot-form hubspot-form-editor block-wide ${blockStyle}`} style={{...backgroundImage}}>
+        <div className='container'>
+          <div className='block-wrapper'>
+            <div className='block-wrapper-inner block-wrapper-text' style={{...backgroundImage}}>
+              <div className='container'>
+                <RichText
+                  tagName='h1'
+                  className='block-title'
+                  placeholder={__('Enter title', 'planet4-blocks-backend')}
+                  value={blockTitle}
+                  onChange={toAttribute('blockTitle')}
+                  withoutInteractiveFormatting={true}
+                  allowedFormats={[]}
+                  multiline='false'
+                />
+                <MaxLengthHelperComponent value={blockText} maxLength={600} darkTheme={true}>
+                  <RichText
+                    tagName='p'
+                    className='block-text'
+                    placeholder={__('Enter description', 'planet4-blocks-backend')}
+                    value={blockText}
+                    onChange={toAttribute('blockText', 600)}
+                    withoutInteractiveFormatting={true}
+                    allowedFormats={['core/bold', 'core/italic']}
+                  />
+                </MaxLengthHelperComponent>
+                <RichText
+                  tagName='div'
+                  className='block-button'
+                  placeholder={__('Enter CTA text', 'planet4-blocks-backend')}
+                  value={ctaText}
+                  onChange={toAttribute('ctaText')}
+                  withoutInteractiveFormatting
+                  allowedFormats={[]}
+                />
+              </div>
+            </div>
+            <div className='block-wrapper-inner block-wrapper-form'>
+              <div className='container'>
+                <header className='form-header'>
+                  <RichText
+                    tagName='h1'
+                    className='form-title'
+                    placeholder={__('Enter form title', 'planet4-blocks-backend')}
+                    value={formTitle}
+                    onChange={toAttribute('formTitle')}
+                    withoutInteractiveFormatting={true}
+                    allowedFormats={[]}
+                    multiline='false'
+                  />
+                  <MaxLengthHelperComponent value={formText} maxLength={300}>
+                    <RichText
+                      tagName='p'
+                      className='form-text'
+                      placeholder={__('Enter form description', 'planet4-blocks-backend')}
+                      value={formText}
+                      onChange={toAttribute('formText', 300)}
+                      withoutInteractiveFormatting={true}
+                      allowedFormats={['core/bold', 'core/italic']}
+                    />
+                  </MaxLengthHelperComponent>
+                </header>
+                <div className='form-wrapper-editor'>
+                  <div className='form-wrapper-field'>
+                    <label>{__('Paste the Hubspot shortcode here', 'planet4-blocks-backend')}</label>
+                    <RichText
+                      tagName='p'
+                      className='hubspot-form-shortcode-editor'
+                      placeholder={__('[hubspot type="form" portal="XXXXXX" id="XXXX-XXXX-XXXX-XXXX"]', 'planet4-blocks-backend')}
+                      value={hubspotShortcode}
+                      onChange={toAttribute('hubspotShortcode')}
+                      withoutInteractiveFormatting={true}
+                      allowedFormats={[]}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </Fragment>
+  );
+};

--- a/assets/src/blocks/HubspotForm/HubspotFormEditorScript.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormEditorScript.js
@@ -1,0 +1,3 @@
+import { registerHubspotFormBlock } from './HubspotFormBlock';
+
+registerHubspotFormBlock();

--- a/assets/src/blocks/HubspotForm/HubspotFormFrontend.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormFrontend.js
@@ -1,0 +1,70 @@
+import { useRef, useEffect, useState } from '@wordpress/element';
+import { useHubspotForm } from './hooks/useHubspotForm';
+import { useBackgroundImage } from './hooks/useBackgroundImage';
+
+const { __ } = wp.i18n;
+
+export const HubspotFormFrontend = ({
+  formTitle,
+  formText,
+  blockBackgroundImageUrl,
+  blockTitle,
+  blockText,
+  blockStyle,
+  ctaLink,
+  ctaText,
+  ctaNewTab,
+  hubspotShortcode,
+  hubspotThankyouMessage,
+  enableCustomHubspotThankyouMessage,
+}) => {
+  const hubspotFormRef = useRef(null);
+  const [ styleClass, setStyleClass ] = useState('');
+  const { submitted, submittedMessage } = useHubspotForm(hubspotShortcode, hubspotFormRef);
+  const backgroundImage = useBackgroundImage(blockBackgroundImageUrl);
+
+  useEffect(() => {
+    if(blockStyle) {
+      setStyleClass(blockStyle);
+    }
+  }, [ blockStyle ]);
+
+  return (
+    <section className={`hubspot-form block-wide ${styleClass}`} style={{...backgroundImage}}>
+      <div className='container'>
+        <div className='block-wrapper'>
+          <div className='block-wrapper-inner block-wrapper-text' style={{...backgroundImage}}>
+            <div className='container'>
+              <h1 className='block-title'>{ blockTitle }</h1>
+              {blockText && <p className='block-text' dangerouslySetInnerHTML={{ __html: blockText }} />}
+              {(ctaLink && ctaText) && <a
+                href={ctaLink}
+                className='block-button'
+                data-ga-category='Hubspot Forms Block'
+                data-ga-action='custom form'
+                data-ga-label={ctaLink}
+                { ...ctaNewTab && { target: '_blank' } }
+                >{ctaText}</a>}
+            </div>
+          </div>
+          <div className={`block-wrapper-inner block-wrapper-form ${submitted ? 'submitted-form' : ''}`}>
+            <div className='container'>
+              {!submitted && <header className='form-header'>
+                <h1 className='form-title'>{formTitle}</h1>
+                <p className='form-text'>{formText}</p>
+              </header>}
+              {!submitted ? <div className='form-wrapper'>
+                <div id='hubspot-api-form' ref={hubspotFormRef} />
+              </div> : <div className='submitted-message'>
+                <svg className='icon-tick' width="24" height="20" viewBox="0 0 24 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M2 10.4211L8.4 18L22 2" stroke="#074365" strokeWidth="4" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+                <span>{ enableCustomHubspotThankyouMessage ? hubspotThankyouMessage : submittedMessage }</span>
+              </div>}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/assets/src/blocks/HubspotForm/HubspotFormScript.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormScript.js
@@ -1,0 +1,4 @@
+import { HubspotFormFrontend } from './HubspotFormFrontend';
+import { hydrateBlock } from '../../functions/hydrateBlock';
+
+hydrateBlock('planet4-blocks/hubspot-form', HubspotFormFrontend);

--- a/assets/src/blocks/HubspotForm/HubspotFormSidebar.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormSidebar.js
@@ -1,0 +1,107 @@
+import { CheckboxControl, PanelBody, PanelRow, Button, TextControl } from '@wordpress/components';
+import { MediaUpload, MediaUploadCheck, InspectorControls } from '@wordpress/block-editor';
+import { URLInput } from '../../components/URLInput/URLInput';
+import { useToAttribute } from './hooks/useToAttribute';
+
+const { __ } = wp.i18n;
+
+const PanelRowWrapper = ({ labelText, helpText, children }) => {
+  return (
+    <div className='panel-row-wrapper'>
+      {labelText && <label className='panel-row-label-text'>{labelText}</label>}
+      {helpText && <span className='panel-row-help-text'>{helpText}</span>}
+      {children}
+    </div>
+  )
+}
+
+export const Sidebar = ({
+  ctaLink,
+  ctaNewTab,
+  blockBackgroundImageId,
+  enableCustomHubspotThankyouMessage,
+  hubspotThankyouMessage,
+  setAttributes,
+}) => {
+  const toAttribute = useToAttribute(setAttributes);
+
+  const onSelectImageHandler = ({ id, url }) => {
+    if(url && id) {
+      setAttributes({
+        blockBackgroundImageId: id,
+        blockBackgroundImageUrl: url,
+      });
+    }
+  };
+
+  const onRemoveImageHandler = () => {
+    setAttributes({
+      blockBackgroundImageId: null,
+      blockBackgroundImageUrl: null,
+    });
+  }
+
+  return <InspectorControls>
+    <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
+      <PanelRow>
+        <PanelRowWrapper labelText={__('Call to action', 'planet4-blocks-backend')}>
+          <URLInput
+            placeholder={__('Enter the button link', 'planet4-blocks-backend')}
+            value={ctaLink}
+            onChange={toAttribute('ctaLink')}
+          />
+          <CheckboxControl
+            label={__('Open in a new tab', 'planet4-blocks-backend')}
+            value={ctaNewTab}
+            checked={ctaNewTab}
+            onChange={toAttribute('ctaNewTab')}
+          />
+        </PanelRowWrapper>
+      </PanelRow>
+      <PanelRow>
+        <PanelRowWrapper labelText={__('Background image', 'planet4-blocks-backend')}>
+          <MediaUploadCheck>
+            <nav className='image-actions-nav'>
+              <MediaUpload
+                title={__('Select image', 'planet4-blocks-backend')}
+                type='image'
+                onSelect={onSelectImageHandler}
+                value={blockBackgroundImageId}
+                allowedTypes={[ 'image' ]}
+                render={({ open }) => open && (
+                  <div>
+                    <Button
+                      onClick={open}
+                      className='button'
+                    >
+                      {__('Select', 'planet4-blocks-backend')}
+                    </Button>
+                  </div>)}
+              />
+              <Button className='button-remove-image' onClick={onRemoveImageHandler}>Remove</Button>
+            </nav>
+          </MediaUploadCheck>
+        </PanelRowWrapper>
+      </PanelRow>
+      <PanelRow>
+        <PanelRowWrapper
+          labelText={__('Custom thank you message', 'planet4-blocks-backend')}
+          helpText={__('This functionality overrides the default thank you message set to the Form on Hubspot', 'planet4-blocks-backend')}
+        >
+          <CheckboxControl
+            label={__('Enable custom thank you message', 'planet4-blocks-backend')}
+            value={enableCustomHubspotThankyouMessage}
+            checked={enableCustomHubspotThankyouMessage}
+            onChange={toAttribute('enableCustomHubspotThankyouMessage')}
+          />
+          {enableCustomHubspotThankyouMessage && <TextControl
+            placeholder={__('e.g. Thanks for submitting the form.', 'planet4-blocks-backend')}
+            value={hubspotThankyouMessage}
+            onChange={toAttribute('hubspotThankyouMessage')}
+            disabled={false}
+          />}
+        </PanelRowWrapper>
+      </PanelRow>
+    </PanelBody>
+  </InspectorControls>
+};

--- a/assets/src/blocks/HubspotForm/hooks/useBackgroundImage.js
+++ b/assets/src/blocks/HubspotForm/hooks/useBackgroundImage.js
@@ -1,0 +1,11 @@
+import { useState, useEffect } from '@wordpress/element';
+
+export const useBackgroundImage = (image) => {
+  const [ backgroundImage, setBackgroundImage ] = useState();
+
+  useEffect(() => {
+    setBackgroundImage({ backgroundImage: image ? `url(${image})` : 'none' });
+  }, [ image ]);
+
+  return backgroundImage;
+};

--- a/assets/src/blocks/HubspotForm/hooks/useHubspotForm.js
+++ b/assets/src/blocks/HubspotForm/hooks/useHubspotForm.js
@@ -1,0 +1,66 @@
+import { useState, useEffect } from '@wordpress/element';
+
+export const useHubspotForm = (shortcode, targetRef) => {
+  const [ submitted, setSubmitted ] = useState(false);
+  const [ formId, setFormId ] = useState();
+  const [ portalId, setPortalId ] = useState();
+  const [ submittedMessage, setSubmittedMessage ] = useState();
+
+  const createHubspotForm = () => {
+    window.hbspt.forms.create({
+      portalId,
+      formId,
+      target: `#${targetRef.current.attributes.id.value}`,
+      region: "",
+      onFormSubmitted: ($form) => {
+        setSubmitted(true);
+        if($form.length) {
+          setSubmittedMessage($form[0].innerText);
+        }
+      }
+    });
+  }
+
+  const fetchHubspotFormsLibrary = () => {
+    const script = document.createElement('script');
+    script.src = 'https://js.hsforms.net/forms/v2.js';
+    document.body.appendChild(script);
+    script.addEventListener('load', createHubspotForm);
+  }
+
+  useEffect(() => {
+    if(formId && portalId) {
+      try {
+        createHubspotForm();
+      } catch(exception) {
+        fetchHubspotFormsLibrary();
+      }
+    }
+  }, [
+    formId,
+    portalId,
+  ]);
+
+  /**
+   * Parse the `portalId` and `formId` values from the `shortcode`.
+   */
+  useEffect(() => {
+    if(shortcode) {
+      shortcode.replace(/["'\)\(\]\[]/g,'').split(' ').forEach(value => {
+        if(/portal=/.test(value)) {
+          setPortalId(value.split('=')[1]);
+        }
+        if(/id=/.test(value)) {
+          setFormId(value.split('=')[1]);
+        }
+      });
+    }
+  }, [
+    shortcode,
+  ]);
+
+  return {
+    submitted,
+    submittedMessage,
+  };
+};

--- a/assets/src/blocks/HubspotForm/hooks/useToAttribute.js
+++ b/assets/src/blocks/HubspotForm/hooks/useToAttribute.js
@@ -1,0 +1,23 @@
+export const useToAttribute = (setAttributes) => {
+  const toAttribute = (attributeName, maxLength = -1) => value => {
+    if(setAttributes) {
+      if(maxLength > -1) {
+        if(value.length < maxLength) {
+          setAttributes({
+            [attributeName]: value,
+          });
+        } else {
+          setAttributes({
+            [attributeName]: value.slice(0, maxLength),
+          });
+        }
+      } else {
+        setAttributes({
+          [attributeName]: value,
+        });
+      }
+    }
+  };
+
+  return toAttribute;
+};

--- a/assets/src/styles/blocks/HubspotForm/HubspotFormEditorStyles.scss
+++ b/assets/src/styles/blocks/HubspotForm/HubspotFormEditorStyles.scss
@@ -1,0 +1,81 @@
+@import "../../master-theme/assets/src/scss/base/variables";
+@import "../../master-theme/assets/src/scss/base/colors";
+@import "../../master-theme/assets/src/scss/base/mixins";
+
+@import "HubspotFormSidebarStyles";
+
+.hubspot-form-editor {
+  padding-right: 32px;
+  padding-left: 32px;
+
+  & > .container {
+    @media (max-width: #{$large-width}) {
+      padding: 0;
+    }
+  }
+
+  .max-length-message {
+    color: $grey-80;
+    display: inline-block;
+    font-size: 15px;
+    margin-bottom: 20px;
+
+    &.dark-theme {
+      color: $grey-10;
+    }
+
+    &.max-length-error {
+      color: $dark-orange;
+    }
+  }
+}
+
+.block-editor-rich-text__editable.form-title {
+  color: $grey-80;
+  font-size: 20px;
+  margin: 0 0 16px 0;
+  text-align: start;
+
+  @include large-and-up {
+    font-size: 28px;
+  }
+}
+
+.block-editor-rich-text__editable.form-text {
+  color: $grey-80;
+  font-family: $roboto;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 26px;
+  text-align: start;
+}
+
+.block-editor-rich-text__editable.block-title {
+  font-size: 28px;
+  line-height: 32px;
+  text-align: start;
+  color: $white;
+  margin: 0;
+  word-break: break-word;
+
+  @include large-and-up {
+    font-size: 40px;
+    line-height: 46px;
+  }
+}
+
+.block-editor-rich-text__editable.block-text {
+  font-size: 16px;
+  font-family: $lora;
+  font-weight: 400;
+  color: $white;
+  line-height: 26px;
+  text-align: start;
+  margin-top: 24px;
+  margin-bottom: 32px;
+
+  @include large-and-up {
+    font-size: 20px;
+    line-height: 28px;
+  }
+}

--- a/assets/src/styles/blocks/HubspotForm/HubspotFormSidebarStyles.scss
+++ b/assets/src/styles/blocks/HubspotForm/HubspotFormSidebarStyles.scss
@@ -1,0 +1,47 @@
+.components-panel__row {
+  .panel-row-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    width: 100%;
+
+    .panel-row-label-text {
+      font-weight: bold;
+      margin-bottom: 8px;
+
+      & ~ div {
+        width: 100%;
+        margin-bottom: 8px;
+      }
+    }
+
+    .panel-row-help-text {
+      font-size: 12px;
+      font-style: normal;
+      color: rgb(117, 117, 117);
+      margin-bottom: 8px;
+    }
+
+    .image-actions-nav {
+      display: flex;
+      margin: 12px 0 16px;
+
+      & > * {
+        &:not(:last-child) {
+          margin-right: 8px;
+        }
+      }
+    }
+
+    .button-remove-image {
+      padding: 0;
+    }
+  }
+
+  &:not(:last-child) {
+    .panel-row-wrapper {
+      margin-bottom: 8px;
+      border-bottom: 1px solid #e0e0e0;
+    }
+  }
+}

--- a/assets/src/styles/blocks/HubspotForm/HubspotFormStyles.scss
+++ b/assets/src/styles/blocks/HubspotForm/HubspotFormStyles.scss
@@ -1,0 +1,179 @@
+@import "../../master-theme/assets/src/scss/base/variables";
+@import "../../master-theme/assets/src/scss/base/colors";
+@import "../../master-theme/assets/src/scss/base/mixins";
+@import "../../master-theme/assets/src/scss/base/fonts";
+
+/* Layouts */
+@import "layouts/ImageFullWidthStyles";
+
+.hubspot-form {
+  position: relative;
+  margin-bottom: 32px;
+  font-family: $roboto;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center center;
+  box-shadow: inset 0 0 0 100vw transparentize($grey-80, .45);
+
+  &.block-wide {
+    width: 100vw;
+    /* A better way is to add these changes into the WideBlocks stylesheet */
+    margin-inline-start: calc(((100vw - 100%) / 2) * -1);
+  }
+
+  & > .container {
+    padding-left: 0;
+    padding-right: 0;
+
+    @media (max-width: #{$large-width}) {
+      max-width: 100%;
+    }
+  }
+}
+
+.block-wrapper {
+  display: flex;
+  flex-direction: column;
+  padding-left: 0;
+  padding-right: 0;
+
+  @include large-and-up {
+    flex-direction: row;
+    padding-top: 156px;
+    padding-bottom: 156px;
+  }
+}
+
+.block-wrapper-inner {
+  padding-top: 32px;
+  padding-bottom: 32px;
+}
+
+.block-wrapper-form {
+  display: flex;
+  flex-direction: column;
+  padding-top: 32px;
+  padding-bottom: 32px;
+
+  @include large-and-up {
+    padding-top: 16px;
+    padding-bottom: 7px;
+    padding-inline-start: 32px;
+    padding-inline-end: 32px;
+  }
+
+  &.submitted-form {
+    align-items: center;
+    justify-content: center;
+    display: flex;
+
+    @include large-and-up {
+      padding-top: 30px;
+      padding-bottom: 30px;
+    }
+
+    & > .container {
+      width: auto;
+    }
+  }
+}
+
+.block-wrapper-form .form-wrapper-field {
+  padding: 10px;
+  margin-bottom: 10px;
+  border: solid 1px $grey-40;
+  background-color: $grey-10;
+
+  label {
+    font-size: 14px;
+    align-items: center;
+    font-weight: 600;
+  }
+
+  .rich-text {
+    padding: 10px;
+    margin-top: 10px;
+    border: solid 1px $grey-40;
+    font-size: 15px;
+    line-height: 1.4;
+    background-color: $white;
+  }
+}
+
+.form-title {
+  color: $grey-80;
+  font-size: 20px;
+  margin: 0 0 16px 0;
+  text-align: start;
+
+  @include large-and-up {
+    font-size: 28px;
+  }
+}
+
+.form-text {
+  color: $grey-80;
+  font-family: $roboto;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 26px;
+  text-align: start;
+}
+
+.block-title {
+  font-size: 28px;
+  line-height: 32px;
+  text-align: start;
+  color: $white;
+  margin: 0;
+  word-break: break-word;
+
+  @include large-and-up {
+    font-size: 40px;
+    line-height: 46px;
+  }
+}
+
+.block-text {
+  font-size: 16px;
+  font-family: $lora;
+  font-weight: 400;
+  color: $white;
+  line-height: 26px;
+  text-align: start;
+  margin-top: 24px;
+  margin-bottom: 32px;
+
+  @include large-and-up {
+    font-size: 20px;
+    line-height: 28px;
+  }
+}
+
+.block-button {
+  border: solid 1px $white;
+  background: transparent;
+  padding: 13px 61px;
+  border-radius: 4px;
+  color: $white !important;
+  line-height: 19px;
+  font-size: 16px;
+  font-weight: 700;
+  width: fit-content;
+
+  &.external-link {
+    &::after {
+      margin-left: 6px;
+    }
+  }
+
+  &:hover {
+    background-color: $white;
+    color: $grey-80 !important;
+    text-decoration: none;
+  }
+}
+
+#hubspot-api-form {
+  width: 100%;
+}

--- a/assets/src/styles/blocks/HubspotForm/layouts/ImageFullWidthStyles.scss
+++ b/assets/src/styles/blocks/HubspotForm/layouts/ImageFullWidthStyles.scss
@@ -1,0 +1,56 @@
+.hubspot-form.image-full-width {
+  background-color: $grey-80;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center center;
+}
+
+.block-wrapper-text {
+  background-color: $grey-80;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center center;
+  box-shadow: inset 0 0 0 100vw transparentize($grey-80, .45);
+  width: 100%;
+
+  @include large-and-up {
+    background-color: transparent;
+    background-image: none !important;
+    box-shadow: none;
+    padding: 0 !important;
+    margin-inline-end: 120px;
+    width: 100%;
+  }
+
+  & > .container {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.block-wrapper-form {
+  background-color: $white;
+  margin-inline-end: 0;
+
+  @include large-and-up {
+    flex-shrink: 0;
+    flex-basis: 450px;
+    height: fit-content;
+    border-radius: 4px;
+    /* Using REM because of the .container used units for paddings */
+    margin-inline-end: 0.75rem;
+  }
+}
+
+.block-wrapper-form .submitted-message {
+  display: flex;
+  align-items: center;
+  color: $grey-80;
+  font-family: $roboto;
+  font-size: 20px;
+  font-weight: 700;
+
+  .icon-tick {
+    margin-inline-end: 16px;
+  }
+}

--- a/classes/blocks/class-hubspotform.php
+++ b/classes/blocks/class-hubspotform.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Hubspot Forms block class
+ *
+ * @package P4GBKS
+ * @since 0.1
+ */
+
+namespace P4GBKS\Blocks;
+
+/**
+ * Class HubspotForm
+ * Registers the HubspotForm block.
+ *
+ * @package P4BKS
+ * @since 0.1
+ */
+class HubspotForm extends Base_Block {
+
+	/**
+	 * Block name.
+	 *
+	 * @const string BLOCK_NAME.
+	 */
+	const BLOCK_NAME = 'hubspot-form';
+
+	/**
+	 * HubspotForm constructor.
+	 */
+	public function __construct() {
+		add_action( 'init', [ $this, 'register_hubspotform_block' ] );
+	}
+
+	/**
+	 * Register HubspotForm block.
+	 */
+	public function register_hubspotform_block() {
+		register_block_type(
+			self::get_full_block_name(),
+			[
+				'render_callback' => [ $this, 'front_end_rendered_fallback' ],
+				'attributes'      => [
+					'blockTitle'                         => [
+						'type' => 'string',
+					],
+					'blockText'                          => [
+						'type' => 'string',
+					],
+					'blockBackgroundImageId'             => [
+						'type' => 'string',
+					],
+					'blockBackgroundImageUrl'            => [
+						'type' => 'string',
+					],
+					'blockStyle'                         => [
+						'type' => 'string',
+					],
+					'ctaText'                            => [
+						'type' => 'string',
+					],
+					'ctaLink'                            => [
+						'type' => 'string',
+					],
+					'ctaNewTab'                          => [
+						'type'    => 'boolean',
+						'default' => false,
+					],
+					'formTitle'                          => [
+						'type' => 'string',
+					],
+					'formText'                           => [
+						'type' => 'string',
+					],
+					'hubspotShortcode'                   => [
+						'type' => 'string',
+					],
+					'hubspotThankyouMessage'             => [
+						'type' => 'string',
+					],
+					'enableCustomHubspotThankyouMessage' => [
+						'type'    => 'boolean',
+						'default' => true,
+					],
+				],
+			]
+		);
+
+		add_action( 'enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ] );
+		add_action( 'wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ] );
+	}
+
+	/**
+	 * Required by the `Base_Block` class.
+	 *
+	 * @param array $fields Unused, required by the abstract function.
+	 */
+	public function prepare_data( $fields ): array {
+		return [];
+	}
+}

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -82,6 +82,7 @@ final class Loader {
 		new Blocks\OldENForm();
 		new Blocks\ENForm();
 		new Blocks\GuestBook();
+		new Blocks\HubspotForm();
 	}
 
 	/**

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -143,6 +143,7 @@ const PAGE_BLOCK_TYPES = [
 
 const BETA_PAGE_BLOCK_TYPES = [
 	'planet4-blocks/enform-beta',
+	'planet4-blocks/hubspot-form',
 ];
 
 // campaigns allow all block types.
@@ -170,6 +171,7 @@ const CAMPAIGN_BLOCK_TYPES = [
 const BETA_CAMPAIGN_BLOCK_TYPES = [
 	'planet4-blocks/enform-beta',
 	'planet4-blocks/social-media-cards',
+	'planet4-blocks/hubspot-form',
 ];
 
 /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,8 +44,10 @@ const publicJsConfig = {
     SpreadsheetScript: './assets/src/blocks/Spreadsheet/SpreadsheetScript.js',
     TimelineScript: './assets/src/blocks/Timeline/TimelineScript.js',
     GalleryScript: './assets/src/blocks/Gallery/GalleryScript.js',
+    HubspotFormScript: './assets/src/blocks/HubspotForm/HubspotFormScript.js',
   },
 };
+
 const adminJsConfig = {
   ...jsConfig,
   resolve: {
@@ -66,6 +68,7 @@ const adminJsConfig = {
     TimelineEditorScript: './assets/src/blocks/Timeline/TimelineEditorScript.js',
     SocialMediaEditorScript: './assets/src/blocks/SocialMedia/SocialMediaEditorScript.js',
     GalleryEditorScript: './assets/src/blocks/Gallery/GalleryEditorScript.js',
+    HubspotFormEditorScript: './assets/src/blocks/HubspotForm/HubspotFormEditorScript.js',
   },
 };
 const cssConfig = {
@@ -89,6 +92,8 @@ const cssConfig = {
     CoversStyle: './assets/src/styles/blocks/Covers/CoversStyle.scss',
     GalleryStyle: './assets/src/styles/blocks/Gallery/GalleryStyle.scss',
     GalleryEditorStyle: './assets/src/styles/blocks/Gallery/GalleryEditorStyle.scss',
+    HubspotFormStyle: './assets/src/styles/blocks/HubspotForm/HubspotFormStyles.scss',
+    HubspotFormEditorStyle: './assets/src/styles/blocks/HubspotForm/HubspotFormEditorStyles.scss',
   },
   output: {
     filename: '[name].js',


### PR DESCRIPTION
**Description**
---
It's about the new custom [Hubspot Form Block](https://jira.greenpeace.org/browse/PLANET-6190).

For now is only implemented as the default the [Image Full Width](https://p4-designsystem.greenpeace.org/05f6e9516/p/213df0-hubspot-forms/b/99e047) form, but easy to be scalable. 
The rest of the forms will be added once the base implementation is approved. 

-> [Demo page](https://www-dev.greenpeace.org/test-deimos/hubspot-form-block)
-> [Design](https://p4-designsystem.greenpeace.org/05f6e9516/p/213df0-hubspot-forms/b/99e047)

Ref: [Ticket](https://jira.greenpeace.org/browse/PLANET-6190)

If you want to create a new **Hubspot Form** please go [here](https://www-dev.greenpeace.org/dmptest/wp-admin/admin.php?page=leadin_forms&leadin_route%5B0%5D=type&leadin_search=businessUnitId%3D%26dateType%3DLAST_THIRTY_DAYS%26formType%3DALL%26offset%3D0%26parentId%3D0%26query%3D%26sortDirection%3DDESCENDING%26sortingColumn%3DLAST_MODIFIED)

:warning: **Things to keep in mind**
---
- The custom form design will be covered on [this](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/662) pull request.

**Testing**
---
- Make sure you already have a portal id and id related to a Hubspot from before starting.
- Enable `beta` blocks from P4 settings.

**Related PRs** (are in draft)
---
- Use with custom hubspot form styles (overriding the default ones): https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/662
- Implement the Thank you section. https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/663

**Updates**
---
- **September, 9:**
  - Implemented a custom hook to create dynamically the form instead to adding this logic inside the Compoment.
  - Enable to show a custom _Thank you message_ or show the one retrieved by the API.
  - Improve the Hubspot shortcode parser. It can parse 3 different shortcodes (with or without `' and "`)
  ```
  [hubspot type=form portal=8710305 id=85158a32-72b6-4dd7-8012-f4f4d8ef08d1]
  [hubspot type='form' portal='8710305' id='85158a32-72b6-4dd7-8012-f4f4d8ef08d1']
  [hubspot type="form" portal="8710305" id="85158a32-72b6-4dd7-8012-f4f4d8ef08d1"]
  ```
  - ~Show a preloader when the Hubspot form is fetched.~

---

<!--
Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
