### PR TITLE
Some more blocks variables (ENForm and Counter), bump theme editor

### DIFF
--- a/assets/src/styles/blocks/Counter.scss
+++ b/assets/src/styles/blocks/Counter.scss
@@ -1,6 +1,8 @@
 .counter-block {
+  _-- {
+    font-family: $roboto;
+  }
   text-align: center;
-  font-family: $roboto;
   margin-top: $space-xl;
   margin-bottom: $space-xl;
 
@@ -30,16 +32,18 @@
   }
 
   .counter-target {
+    _-- {
+      color: inherit;
+      font-size: 2rem;
+      font-weight: bold;
+      margin-bottom: $space-lg;
+    }
     display: inline-block;
-
     line-height: 1;
-    font-size: 2rem;
-    font-weight: bold;
-    margin-bottom: $space-lg;
   }
 
   &.counter-style-1 {
-    .counter-target {
+    .counter-target _-- {
       font-size: 3rem;
       font-weight: bold;
       margin-bottom: $space-lg;
@@ -47,42 +51,50 @@
   }
 
   .progress-container {
-    background-color: $grey-20;
-    height: 30px;
-    margin-bottom: $space-lg;
+    _-- {
+      background: $grey-20;
+      height: 30px;
+      margin-bottom: $space-lg;
+    }
     overflow: hidden;
   }
 
   .progress-bar {
-    background-color: $dark-blue;
+    _-- {
+      background: $dark-blue;
+      transform: skewX(-30deg);
+    }
     height: 100%;
-    transform: skew(-30deg, 0deg);
     margin-left: -10px;
   }
 
-  .enform-progress-bar {
-    background-color: $orange;
+  .enform-progress-bar _-- {
+    background: $orange;
   }
 
   .progress-arc {
-    max-width: 225px;
+    _-- {
+      max-width: 225px;
+      stroke-width: 3;
+    }
     margin-bottom: -20px;
 
     fill: none;
-    stroke-width: 3;
 
-    .background {
+    .background _-- {
       stroke: $grey-20;
     }
 
-    .foreground {
+    .foreground _-- {
       stroke: $dark-blue;
     }
   }
 
   .counter-text {
+    _-- {
+      font-size: 1rem;
+    }
     margin-bottom: 0;
-    font-size: 1rem;
   }
 
   .counter-text-goal_reached {

--- a/assets/src/styles/blocks/OldENForm/components/_enform.scss
+++ b/assets/src/styles/blocks/OldENForm/components/_enform.scss
@@ -90,7 +90,7 @@
   }
 }
 
-.form-description p:first-child --block-enform--caption--paragraph--first-- {
+.form-description p:first-child _-- {
   font-weight: inherit;
   font-size: 1rem;
   text-transform: none;
@@ -99,11 +99,13 @@
 }
 
 .enform {
+  _-- {
+    font-family: $roboto;
+    background: $dark-blue;
+  }
   margin-top: 36px;
-  font-family: $roboto;
   height: inherit;
   padding: $n20;
-  background: $dark-blue;
   width: 100%;
 
   form {
@@ -171,7 +173,6 @@
 
       p {
         font-size: .75rem;
-        font-family: $roboto !important;
         line-height: 1rem;
         margin-bottom: 0;
         float: none;
@@ -180,8 +181,25 @@
   }
 
   h2 {
+    _-- {
+      @include medium-and-up {
+        font-size: 1.75rem;
+        line-height: 2.5rem;
+      }
+
+      @include large-and-up {
+        font-size: 2.125rem;
+      }
+
+      @include x-large-and-up {
+        font-size: 2.25rem;
+      }
+    }
+
     .enform-full-width & {
-      color: white;
+      _-- {
+        color: white;
+      }
 
       html[dir="rtl"] & {
         font-size: 2rem;
@@ -194,19 +212,6 @@
 
     &.thankyou {
       margin-bottom: 0;
-    }
-
-    @include medium-and-up {
-      font-size: 1.75rem;
-      line-height: 2.5rem;
-    }
-
-    @include large-and-up {
-      font-size: 2.125rem;
-    }
-
-    @include x-large-and-up {
-      font-size: 2.25rem;
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -220,7 +220,6 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
       "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.4.4",
         "jsesc": "^2.5.1",
@@ -233,7 +232,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -294,7 +292,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-      "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.0.0",
         "@babel/template": "^7.1.0",
@@ -305,7 +302,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -332,7 +328,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -442,7 +437,6 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
       "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.4.4"
       }
@@ -597,8 +591,7 @@
     "@babel/parser": {
       "version": "7.4.5",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-      "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
-      "dev": true
+      "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.2.0",
@@ -1202,7 +1195,6 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
       "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.4.4",
@@ -1213,7 +1205,6 @@
       "version": "7.4.5",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
       "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/generator": "^7.4.4",
@@ -1230,7 +1221,6 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
       "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
-      "dev": true,
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.11",
@@ -1818,6 +1808,29 @@
         }
       }
     },
+    "@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "requires": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
     "@greenpeace/dashdash": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@greenpeace/dashdash/-/dashdash-1.1.1.tgz",
@@ -2306,17 +2319,17 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
-          "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
+          "version": "7.15.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
+          "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
         },
         "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
         }
       }
     },
@@ -4624,6 +4637,22 @@
         "@types/babel__traverse": "^7.0.6"
       }
     },
+    "babel-plugin-styled-components": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.13.2.tgz",
+      "integrity": "sha512-Vb1R3d4g+MUfPQPVDMCGjm3cDocJEUTR7Xq7QS95JWWeksN1wdFRYpD2kulDgI3Huuaf1CZd+NK4KQmqUFh5dA==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-module-imports": "^7.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "lodash": "^4.17.11"
+      }
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+    },
     "babel-preset-jest": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
@@ -5216,6 +5245,11 @@
         "camelcase": "^2.0.0",
         "map-obj": "^1.0.0"
       }
+    },
+    "camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -6274,6 +6308,11 @@
         "randomfill": "^1.0.3"
       }
     },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -6394,6 +6433,23 @@
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
       "dev": true
+    },
+    "css-to-react-native": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "requires": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+          "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
+        }
+      }
     },
     "css-tree": {
       "version": "1.0.0-alpha.37",
@@ -6630,7 +6686,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -9174,8 +9229,7 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globby": {
       "version": "9.2.0",
@@ -9439,7 +9493,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
       "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
-      "dev": true,
       "requires": {
         "react-is": "^16.7.0"
       }
@@ -12015,8 +12068,7 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -12802,8 +12854,7 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-      "dev": true
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -14956,9 +15007,9 @@
       }
     },
     "react-hotkeys-hook": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-3.3.2.tgz",
-      "integrity": "sha512-sR98wtrz3qyVZ5G3I5TTRy7Odm1I9poGt1VwT4RN1ztnobRV/pNGja+6B+LONv+IBIyHLvidzW8IZRB7AuAUkw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-3.4.0.tgz",
+      "integrity": "sha512-TFtMNb9ALuL3uvtqGpaehwCeua3uYCrG3dKUqd+hEI2UgbVU94ifA1AEeemXSF6K81llPDX1RZvp7teUEQzAPA==",
       "requires": {
         "hotkeys-js": "3.8.7"
       }
@@ -15057,6 +15108,14 @@
       "dev": true,
       "requires": {
         "prop-types": "^15.5.8"
+      }
+    },
+    "react-shadow-picker": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-shadow-picker/-/react-shadow-picker-1.0.5.tgz",
+      "integrity": "sha512-jbBFRk7a0RPKJpQVQTeRgsTJEjqCZLcpe0NVqlcTOG1pd6hvucTZm0sDG9Y5MnzyzEuojlHDmJZ4deaOTFptgA==",
+      "requires": {
+        "styled-components": "^5.1.0"
       }
     },
     "react-spring": {
@@ -15965,6 +16024,11 @@
         }
       }
     },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -16172,8 +16236,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-loader": {
       "version": "0.2.4",
@@ -16848,6 +16911,23 @@
       "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
       "dev": true
+    },
+    "styled-components": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.0.tgz",
+      "integrity": "sha512-bPJKwZCHjJPf/hwTJl6TbkSZg/3evha+XPEizrZUGb535jLImwDUdjTNxXqjjaASt2M4qO4AVfoHJNe3XB/tpQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^0.8.8",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
+      }
     },
     "stylehacks": {
       "version": "4.0.3",
@@ -17576,8 +17656,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -17698,8 +17777,7 @@
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "trim-trailing-lines": {
       "version": "1.1.2",
@@ -18227,14 +18305,15 @@
       "dev": true
     },
     "use-theme-editor": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/use-theme-editor/-/use-theme-editor-1.0.9.tgz",
-      "integrity": "sha512-C33/eB6YJmedf33nNW+NakDnif7/sO6LVDgpX3wDP8WmsiCoAm3haVhZ5tarjlXFyRhwoyqyOVUcrN6qtOu3cQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/use-theme-editor/-/use-theme-editor-1.1.1.tgz",
+      "integrity": "sha512-DRGbdn1wznOfDkHDSjAujprgEbcXhlaPCQuRfU+W6thwYQVJ70IJlv4Fv7MTJKgxhzztZ7vG2WyR+HWonhvb1A==",
       "requires": {
         "balanced-match": "^2.0.0",
         "font-picker-react": "^3.5.2",
         "react-color": "^2.19.3",
         "react-hotkeys-hook": "^3.0.3",
+        "react-shadow-picker": "^1.0.5",
         "specificity": "^0.4.1",
         "tinycolor2": "^1.4.2"
       }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "classnames": "^2.2.6",
     "jest-environment-node": "^26.0.1",
     "photoswipe": "^4.1.3",
-    "use-theme-editor": "^1.0.9"
+    "use-theme-editor": "^1.1.1"
   }
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5983
---

This is the last batch of variables needed for themes. I also bumped the theme editor package to a newer version that fixes bugs and adds custom controls for many CSS properties.

All CSS changes are only adding variables and not changing the structure, so these changes should be safe. I changed one variable name (to use the shorthand), which I will update in the single theme (and page) that uses it.