### PR TITLE
PLANET-6328 WIP Make Submenu block saved in HTML

### DIFF
--- a/assets/src/blocks/Submenu/SubmenuBlock.js
+++ b/assets/src/blocks/Submenu/SubmenuBlock.js
@@ -1,6 +1,7 @@
 import { SubmenuEditor } from './SubmenuEditor.js';
 import { Tooltip } from '@wordpress/components';
 import {example} from './example';
+import { SubmenuFrontend } from './SubmenuFrontend';
 
 const { __ } = wp.i18n;
 
@@ -40,9 +41,10 @@ export const registerSubmenuBlock = () => {
         type: 'boolean',
         default: false,
       },
-      exampleMenuItems: { // Used for the block's preview, which can't extract items from anything.
+      menuItems: { // Used for the block's preview, which can't extract items from anything.
         type: 'array',
-      }
+        default: [],
+      },
     },
     supports: {
       multiple: false, // Use the block just once per post.
@@ -73,9 +75,40 @@ export const registerSubmenuBlock = () => {
       }
     ],
     edit: SubmenuEditor,
-    save() {
-      return null;
+    save: ({attributes}) => {
+      if (!attributes.menuItems) {
+        return null;
+      }
+      return <SubmenuFrontend { ...attributes }/>;
     },
     example,
+    deprecated: [
+      {
+        attributes: {
+          title: {
+            type: 'string',
+            default: ''
+          },
+          submenu_style: { // Needed for old blocks conversion
+            type: 'integer',
+            default: 0
+          },
+          levels: {
+            type: 'array',
+            default: [{ heading: 2, link: false, style: 'none' }]
+          },
+          isExample: {
+            type: 'boolean',
+            default: false,
+          },
+          exampleMenuItems: { // Used for the block's preview, which can't extract items from anything.
+            type: 'array',
+          },
+        },
+        save: () => {
+          return null;
+        }
+      }
+    ],
   });
 }

--- a/assets/src/blocks/Submenu/SubmenuFrontend.js
+++ b/assets/src/blocks/Submenu/SubmenuFrontend.js
@@ -3,10 +3,8 @@ import { SubmenuItems } from './SubmenuItems';
 import { makeHierarchical } from './makeHierarchical';
 import { getHeadingsFromDom } from './getHeadingsFromDom';
 
-export const SubmenuFrontend = ({ title, className, levels, submenu_style }) => {
+export const SubmenuFrontend = ({ title, className, submenu_style, menuItems }) => {
 
-  const headings = getHeadingsFromDom(levels);
-  const menuItems = makeHierarchical(headings);
   const style = getSubmenuStyle(className, submenu_style);
 
   return (

--- a/assets/src/blocks/Submenu/SubmenuItems.js
+++ b/assets/src/blocks/Submenu/SubmenuItems.js
@@ -1,28 +1,32 @@
+const renderMenuItems = (items) => {
+  return items.map(({ anchor, text, style, shouldLink, children }) => (
+    <li
+      key={anchor}
+      data-anchor={anchor}
+      className={`list-style-${style || 'none'} ${shouldLink ? "list-link" : "list-heading"}`}
+    >
+      {shouldLink ?
+        <a
+          className="icon-link submenu-link"
+          href={`#${anchor}`}
+        >
+          {text}
+        </a>
+        :
+        <span className="submenu-heading">{text}</span>
+      }
+      {children && children.length > 0 &&
+      <ul>
+        {renderMenuItems(children)}
+      </ul>
+      }
+    </li>
+  ));
+}
+
 export const SubmenuItems = ({ menuItems }) => {
 
-  const renderMenuItems = (items) => {
-    return items.map(({ anchor, text, style, shouldLink, children }) => (
-      <li key={anchor} className={`list-style-${style || 'none'} ${shouldLink ? "list-link" : "list-heading"}`}>
-        {shouldLink ?
-          <a
-            className="icon-link submenu-link"
-            href={`#${anchor}`}
-          >
-            {text}
-          </a>
-          :
-          <span className="submenu-heading">{text}</span>
-        }
-        {children && children.length > 0 &&
-          <ul>
-            {renderMenuItems(children)}
-          </ul>
-        }
-      </li>
-    ));
-  }
-
-  return menuItems.length > 0 && (
+  return !!menuItems && ( menuItems.length > 0) && (
     <div className="submenu-menu">
       <ul className="submenu-item">
         {renderMenuItems(menuItems)}

--- a/assets/src/blocks/Submenu/getHeadingsFromBlocks.js
+++ b/assets/src/blocks/Submenu/getHeadingsFromBlocks.js
@@ -49,7 +49,7 @@ export const getHeadingsFromBlocks = (blocks, selectedLevels) => {
         const blockLevel = parseInt(h.tagName.replace('H', ''));
         const levelConfig = selectedLevels.find(selected => selected.heading === blockLevel);
 
-        const anchor = h.id || generateAnchor(block.attributes.content, headings.map(h => h.anchor));
+        const anchor = h.id || generateAnchor(h.innerText, headings.map(h => h.anchor));
 
         return ({
           level: blockLevel,

--- a/assets/src/blocks/Submenu/makeHierarchical.js
+++ b/assets/src/blocks/Submenu/makeHierarchical.js
@@ -1,10 +1,8 @@
 export const makeHierarchical = headings => {
   let previousMenuItem;
 
-  return headings.reduce((menuItems, heading) => {
+  const withParents = headings.reduce((menuItems, heading) => {
     const { level, shouldLink, anchor, content, style } = heading;
-
-    // const parent = deeperThanPrevious ? previousHeading.children : menuItems;
     let possibleParent = previousMenuItem || menuItems;
 
     while (possibleParent.level && possibleParent.level >= level) {
@@ -30,4 +28,14 @@ export const makeHierarchical = headings => {
 
     return menuItems;
   }, []);
+  return removeParentsRef(withParents);
 };
+
+const removeParentsRef = items => {
+  return items.map(({parent, children, ...rest}) => {
+    return {
+      ...rest,
+      children: removeParentsRef(children),
+    };
+  })
+}

--- a/assets/src/frontendIndex.js
+++ b/assets/src/frontendIndex.js
@@ -20,7 +20,6 @@ const COMPONENTS = {
   'planet4-blocks/split-two-columns': SplittwocolumnsFrontend,
   'planet4-blocks/happypoint': HappypointFrontend,
   'planet4-blocks/gallery': GalleryFrontend,
-  'planet4-blocks/submenu': SubmenuFrontend,
   'planet4-blocks/media-video': MediaFrontend,
   'planet4-blocks/columns': ColumnsFrontend,
   'planet4-blocks/guestbook': GuestBookFrontend,

--- a/classes/blocks/class-submenu.php
+++ b/classes/blocks/class-submenu.php
@@ -30,8 +30,6 @@ class Submenu extends Base_Block {
 			self::get_full_block_name(),
 			[
 				'editor_script'   => 'planet4-blocks',
-				// todo: Remove when all content is migrated.
-				'render_callback' => [ self::class, 'render_frontend' ],
 				'attributes'      => [
 					'title'         => [
 						'type'    => 'string',


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6328

* It only needs to change when the post content changes. Add a
subscriber to the block's edit component, so that it auto updates the
content when other blocks change. As a result it doesn't require any
render on the front end anymore.
* Fix a bug with anchors in classic HTML blocks. Previously it was using
the entire classic block's HTML to generate an anchor. Not only could
that be huge, the same string was used for each anchor found in the
classic block, resulting in React complaining about items having the
same `key`.
* Missing piece to the puzzle: generating anchors. This could be tricky,
as it involves updating all blocks that have no anchor at some point to
have one. Challenge is that we want to update all headings that were
auto-generated, for example a user starts typing a word into a new
heading block. The anchor should update as long as the user didn't
specify an anchor themselves.

Perhaps we could add a button to generate all missing anchors on the block. This gets around the challenges of auto updating those whenever a new heading is added. We could add a block validation so that a message is shown to generate missing headers on the submenu block. The button can suggest to manually add those anchors as well.