### PR TITLE
PLANET-5608 Implement new Take Action cover designs

### DIFF
--- a/assets/src/blocks/Covers/TakeActionCovers.js
+++ b/assets/src/blocks/Covers/TakeActionCovers.js
@@ -27,7 +27,7 @@ export const TakeActionCovers = ({ initialRowsLimit, covers, row, loadMoreCovers
             tags,
             image,
             excerpt,
-            button_text
+            button_text,
           } = cover;
           const hideCover = !!initialRowsLimit && index >= row * amountPerRow;
 
@@ -36,30 +36,28 @@ export const TakeActionCovers = ({ initialRowsLimit, covers, row, loadMoreCovers
           }
 
           return (
-            <div key={title} className='col-lg-4 col-md-6 cover-card-column'>
-              <div className='cover-card card-one' style={{ backgroundImage: `url(${image})` }}>
+            <div key={title} className='col-lg-4 col-md-6'>
+              <div className='cover-card-new'>
                 <a
                   className='cover-card-overlay'
+                  data-ga-category='Take Action Covers'
+                  data-ga-action='Card'
+                  data-ga-label='n/a'
+                  href={button_link}
+                  aria-label={__('Take action cover, link to ' + title, 'planet4-blocks')}
+                />
+                <a
                   data-ga-category='Take Action Covers'
                   data-ga-action='Image'
                   data-ga-label='n/a'
                   href={button_link}
                   aria-label={__('Take action cover, link to ' + title, 'planet4-blocks')}
-                />
+                >
+                  <img src={image} />
+                </a>
                 <div className='cover-card-content'>
-                  {tags && tags.map(tag => (
-                    <a
-                      key={tag.name}
-                      className='cover-card-tag'
-                      data-ga-category='Take Action Covers'
-                      data-ga-action='Navigation Tag'
-                      data-ga-label='n/a'
-                      href={tag.href}
-                    >
-                      <span aria-label='hashtag'>#</span>
-                      {tag.name}
-                    </a>
-                  ))}
+                  {/* Regardless of how many tags there are, we only show the first one */}
+                  {tags && tags.length > 0 && <span className='cover-card-tag'>{tags[0].name}</span>}
                   <a
                     className='cover-card-heading'
                     data-ga-category='Take Action Covers'
@@ -69,10 +67,10 @@ export const TakeActionCovers = ({ initialRowsLimit, covers, row, loadMoreCovers
                   >
                     {title}
                   </a>
-                  <p>{excerpt}</p>
+                  <p className="cover-card-excerpt">{excerpt}</p>
                 </div>
                 <a
-                  className='btn btn-action btn-block cover-card-btn'
+                  className='btn cover-card-btn btn-primary'
                   data-ga-category='Take Action Covers'
                   data-ga-action='Call to Action'
                   data-ga-label='n/a'
@@ -87,8 +85,8 @@ export const TakeActionCovers = ({ initialRowsLimit, covers, row, loadMoreCovers
       </div>
       {showLoadMore &&
         <div className='row'>
-          <div onClick={loadMoreCovers} className='col-lg-5 col-md-12 load-more-covers-button-div'>
-            <button className='btn btn-block btn-secondary btn-load-more-covers-click'>
+          <div className='load-more-covers-button-div-new'>
+            <button onClick={loadMoreCovers} className='btn btn-block btn-secondary'>
               {__( 'Load more', 'planet4-blocks' )}
             </button>
           </div>

--- a/assets/src/styles/blocks/Covers/layouts/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/layouts/TakeActionCovers.scss
@@ -4,86 +4,46 @@
     flex-wrap: wrap;
   }
 
-  .limit-visibility {
-    margin-top: -$space-md;
-
-    @include large-and-up {
-      margin-top: -$space-lg;
-    }
+  .load-more-covers-button-div-new {
+    margin-top: $space-xs;
+    text-align: center;
   }
 }
 
-// Visibility  of covers in different screens
-// S,M should have 4 covers
-// L & XL should have all sent from backend
-// L & XL with show-3-covers class should show first 3 covers
-// L & XL with show-6-covers class should show first 6 covers
-// L & XL with show-all-covers class should show all covers
-// remove limit visibility class on load more button click
-.show-3-covers .limit-visibility {
-  .cover-card-column:nth-child(n+3) {
-    display: none;
-  }
-
-  @include large-and-up {
-    .cover-card-column:nth-child(-n+4) {
-      display: block;
-    }
-
-    .cover-card-column:nth-child(n+4) {
-      display: none;
-    }
-  }
-}
-
-.show-6-covers .limit-visibility {
-  .cover-card-column:nth-child(n+5) {
-    display: none;
-  }
-
-  @include large-and-up {
-    .cover-card-column:nth-child(-n+7) {
-      display: block;
-    }
-
-    .cover-card-column:nth-child(n+7) {
-      display: none;
-    }
-  }
-}
-
-.show-all-covers .limit-visibility {
-  .cover-card-column:nth-child(n+5) {
-    display: none;
-  }
-
-  @include large-and-up {
-    .cover-card-column:nth-child(n+5) {
-      display: block;
-    }
-  }
-}
-
-.cover-card {
+.cover-card-new {
+  box-shadow: 0 4px 3px rgba(0, 0, 0, 0.16);
+  transition: box-shadow 0.2s;
+  min-height: 440px;
+  border-radius: 4px;
+  background: white;
   cursor: pointer;
-  flex-basis: 100%;
-  padding: 32px $n15 $n60;
-  margin-top: $space-xs;
   position: relative;
-  box-shadow: 0 0 10px rgba(0, 0, 0, .35);
-  background-size: cover;
-  background-position: top;
-  color: $grey-80;
+  font-family: $roboto;
+  margin: auto;
+  margin-bottom: 24px;
 
-  img,
-  .cover-card-more,
-  .not-now {
-    display: none;
+  &.action-card {
+    margin-bottom: $space-lg;
   }
 
-  .cover-card-content {
+  &.dark-card-bg {
+    color: $white;
+  }
+
+  &:hover {
+    box-shadow: 0 5px 5px rgba(0, 0, 0, 0.3);
+  }
+
+  img {
+    height: 196px;
+    max-height: 196px;
+    min-height: 196px;
+    width: 100%;
+    object-fit: cover;
+    margin-inline-end: 0;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
     position: relative;
-    pointer-events: none;
     z-index: 1;
   }
 
@@ -95,18 +55,86 @@
     right: 0;
   }
 
+  .cover-card-content {
+    padding: 24px;
+
+    .cover-card-tag {
+      color: $grey-40;
+      font-size: 14px;
+      font-weight: bold;
+    }
+
+    .cover-card-heading {
+      position: relative;
+      z-index: 1;
+      color: black;
+      font-size: 18px;
+      font-weight: 700;
+      margin: 8px 0;
+      line-height: 1.2;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      /* stylelint-disable property-no-vendor-prefix */
+      /*! autoprefixer: off */
+      -webkit-box-orient: vertical;
+      /*! autoprefixer: on */
+      /* stylelint-enable property-no-vendor-prefix */
+      overflow: hidden;
+    }
+
+    .cover-card-excerpt {
+      font-family: $lora;
+      font-size: 14px;
+      line-height: 1.5;
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      margin: 0;
+      /* stylelint-disable property-no-vendor-prefix */
+      /*! autoprefixer: off */
+      -webkit-box-orient: vertical;
+      /*! autoprefixer: on */
+      /* stylelint-enable property-no-vendor-prefix */
+      overflow: hidden;
+    }
+  }
+
+  .cover-card-btn {
+    font-size: 14px;
+    line-height: 1;
+    padding: 10px 20px;
+    right: 24px;
+    bottom: 24px;
+    left: auto;
+    position: absolute;
+    margin: 0;
+    border: none;
+
+    html[dir="rtl"] & {
+      left: 24px;
+      right: auto;
+    }
+  }
+
   @include medium-and-up {
-    flex-basis: 48%;
-    min-height: 414px;
-    padding: 18px $n15 $n60;
+    min-height: 490px;
+    width: auto;
+
+    img {
+      height: 220px;
+      max-height: 220px;
+      min-height: 220px;
+    }
+
+    .cover-card-content {
+      padding-top: 32px;
+
+      .cover-card-heading {
+        font-size: 20px;
+      }
+    }
   }
 
   @include large-and-up {
-    margin-top: $space-md;
-    flex-basis: 32%;
-    min-height: 364px;
-    max-height: 364px;
-
     &.action-card {
       position: absolute;
       right: 0;
@@ -117,164 +145,4 @@
       }
     }
   }
-
-  @include x-large-and-up {
-    padding: 32px 24px $n60;
-  }
-
-  &:before {
-    content: "";
-    opacity: 0;
-    transition: opacity 100ms linear;
-    position: absolute;
-  }
-
-  &:after {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-image: linear-gradient(180deg, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0));
-  }
-
-  &:hover, &:focus, &:focus-within {
-    @include background-before-opacity(linear-gradient(180deg, rgba(51, 51, 51, 0.6), rgba(250, 247, 236, 0.9), rgba(255, 255, 255, 0.8)), 1);
-    box-shadow: 0 0 10px transparentize($grey-80, .5);
-
-    @include medium-and-up {
-      p {
-        color: $grey-80;
-        display: block;
-      }
-    }
-
-    .cover-card-btn {
-      display: block;
-    }
-  }
-
-  &--evergreen {
-    @include background-before-opacity($grey-80, .25);
-
-    &:hover {
-      h2,
-      p {
-        color: $white;
-      }
-    }
-  }
-
-  &.action-card {
-    margin-bottom: $space-lg;
-  }
-
-  &.dark-card-bg {
-    color: $white;
-  }
-
-  & > * {
-    position: relative;
-    z-index: 1;
-  }
-
-  .cover-card-heading {
-    font-size: 1.5rem;
-    line-height: 1.2;
-    font-weight: 500;
-    margin-bottom: 24px;
-    padding-top: 0;
-    max-width: 80%;
-    transition: color 100ms linear;
-
-    --block-covers--heading-- {
-      color: $white;
-    }
-
-    text-shadow: 1px 1px 3px $grey-80;
-    display: table;
-    z-index: 1;
-    pointer-events: all;
-    font-family: $roboto;
-
-    @include large-and-up {
-      font-size: 1.5rem;
-      margin-top: 8px;
-      max-width: 100%;
-    }
-  }
-
-  p {
-    font-size: 0.9375rem;
-    line-height: 1.6;
-    display: none;
-  }
-
-  @include large-and-up {
-    transition: box-shadow 150ms linear;
-    padding-bottom: 70px;
-
-    &:not(.single-cover) {
-      box-shadow: none;
-
-      &:hover {
-        box-shadow: 0 0 10px transparentize($grey-80, .5);
-      }
-    }
-  }
-}
-
-.cover-card-tag {
-  --block-covers--card-tag-- {
-    color: $yellow;
-
-    &:hover {
-      text-decoration: underline;
-      color: $yellow;
-    }
-  }
-
-  display: inline-block;
-  margin-bottom: 8px;
-  text-decoration: none;
-  text-shadow: 1.5px 1.5px 1.5px $grey-80;
-  font-weight: 800;
-  font-family: $roboto;
-  pointer-events: all;
-  position: relative;
-  margin-inline-end: 8px;
-
-  @include large-and-up {
-    margin-bottom: 0;
-    font-size: 0.875rem;
-    margin-right: 4px;
-  }
-}
-
-.cover-card-btn {
-  --block-covers--card-button-- {
-    display: none;
-    color: white;
-    background-color: $orange;
-    border-color: $orange;
-
-    &:hover, &:focus {
-      color: white;
-      background-color: $orange-hover;
-      border-color: $orange-hover;
-    }
-  }
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  margin: $n15 auto;
-  width: 92%;
-  z-index: 1;
-  pointer-events: all;
-}
-
-.load-more-covers-button-div {
-  margin-top: $space-lg;
 }

--- a/assets/src/styles/blocks/OldCovers/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/OldCovers/TakeActionCovers.scss
@@ -223,56 +223,56 @@
       }
     }
   }
-}
 
-.cover-card-tag {
-  --block-covers--card-tag-- {
-    color: $yellow;
-
-    &:hover {
-      text-decoration: underline;
+  .cover-card-tag {
+    --block-covers--card-tag-- {
       color: $yellow;
+
+      &:hover {
+        text-decoration: underline;
+        color: $yellow;
+      }
+    }
+
+    display: inline-block;
+    margin-bottom: 8px;
+    text-decoration: none;
+    text-shadow: 1.5px 1.5px 1.5px $grey-80;
+    font-weight: 800;
+    font-family: $roboto;
+    pointer-events: all;
+    position: relative;
+    margin-inline-end: 8px;
+
+    @include large-and-up {
+      margin-bottom: 0;
+      font-size: 0.875rem;
+      margin-right: 4px;
     }
   }
 
-  display: inline-block;
-  margin-bottom: 8px;
-  text-decoration: none;
-  text-shadow: 1.5px 1.5px 1.5px $grey-80;
-  font-weight: 800;
-  font-family: $roboto;
-  pointer-events: all;
-  position: relative;
-  margin-inline-end: 8px;
-
-  @include large-and-up {
-    margin-bottom: 0;
-    font-size: 0.875rem;
-    margin-right: 4px;
-  }
-}
-
-.cover-card-btn {
-  --block-covers--card-button-- {
-    display: none;
-    color: white;
-    background-color: $orange;
-    border-color: $orange;
-
-    &:hover, &:focus {
+  .cover-card-btn {
+    --block-covers--card-button-- {
+      display: none;
       color: white;
-      background-color: $orange-hover;
-      border-color: $orange-hover;
+      background-color: $orange;
+      border-color: $orange;
+
+      &:hover, &:focus {
+        color: white;
+        background-color: $orange-hover;
+        border-color: $orange-hover;
+      }
     }
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: $n15 auto;
+    width: 92%;
+    z-index: 1;
+    pointer-events: all;
   }
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  margin: $n15 auto;
-  width: 92%;
-  z-index: 1;
-  pointer-events: all;
 }
 
 .load-more-covers-button-div {


### PR DESCRIPTION
### Description

I've implemented the new designs only for the WYSIWYG version of the block, by adding `-new` to its classes which we'll be able to remove once we remove it from from beta blocks. That way existing blocks should not be affected, and we can merge these changes despite not being ready to merge the related changes for the post page designs.

See https://jira.greenpeace.org/browse/PLANET-5608

### Testing

I've set up a [page](https://www-dev.greenpeace.org/test-iocaste/new-take-action-covers/) for UAT, but you can also test it on local by creating a new "Covers (beta)" block and selecting the "Take Action covers" style. You can also check the non-WYSIWYG Covers block to make sure that it isn't affected by the changes!