### PR TITLE
PLANET-6362 Add new version of themes

### DIFF
--- a/assets/src/components/Sidebar/LegacyThemeSettings.js
+++ b/assets/src/components/Sidebar/LegacyThemeSettings.js
@@ -24,12 +24,24 @@ const themeOptions = [
     label: 'Climate Emergency',
   },
   {
+    value: 'climate-new',
+    label: 'Climate Emergency (new)',
+  },
+  {
     value: 'forest',
     label: 'Forest',
   },
   {
+    value: 'forest-new',
+    label: 'Forest (new)',
+  },
+  {
     value: 'oceans',
     label: 'Oceans',
+  },
+  {
+    value: 'oceans-new',
+    label: 'Oceans (new)',
   },
   {
     value: 'oil',
@@ -38,6 +50,10 @@ const themeOptions = [
   {
     value: 'plastic',
     label: 'Plastics',
+  },
+  {
+    value: 'plastic-new',
+    label: 'Plastics (new)',
   },
 
 ];

--- a/assets/src/components/Sidebar/LegacyThemeSettings.js
+++ b/assets/src/components/Sidebar/LegacyThemeSettings.js
@@ -21,7 +21,7 @@ const themeOptions = [
   },
   {
     value: 'climate',
-    label: 'Climate Emergency',
+    label: 'Climate Emergency (old)',
   },
   {
     value: 'climate-new',
@@ -29,7 +29,7 @@ const themeOptions = [
   },
   {
     value: 'forest',
-    label: 'Forest',
+    label: 'Forest (old)',
   },
   {
     value: 'forest-new',
@@ -37,7 +37,7 @@ const themeOptions = [
   },
   {
     value: 'oceans',
-    label: 'Oceans',
+    label: 'Oceans (old)',
   },
   {
     value: 'oceans-new',
@@ -49,7 +49,7 @@ const themeOptions = [
   },
   {
     value: 'plastic',
-    label: 'Plastics',
+    label: 'Plastics (old)',
   },
   {
     value: 'plastic-new',


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6362

This PR does the following:

- Add refactored versions of themes as options of the existing dropdown, and suffix the old theme with `(old)` to remove confusion.
- Exclude these themes from the new themes dropdown (only relevant for test instances which might have a theme with the same name in the options).
- Remove some console logs

To test:
You can switch all content using the old theme to the new version and it should look identical, except for minor spacing changes or over-use of capitalization that was not preserved. Needs to be tested together with https://github.com/greenpeace/planet4-master-theme/pull/1435, else the themes won't exist.

I deployed the latest version to GPI, where I'm currently switching all campaign pages (that use a theme) to the new version. https://www-dev.greenpeace.org/international/?s=&orderby=_score&f[ctype][Campaign]=4 You can compare these to production on https://www.greenpeace.org/international/?s=&orderby=_score&f[ctype][Campaign]=4

Later this day I'll deploy the other dev sites that have campaign pages with a theme.

I did not preserve the over-use of `text-transform: uppercase` in many cases, because it's bad for accessibility. I'll try to confirm with someone whether this is a change we can make.

Keep in mind that deploying this won't automatically switch to the new themes. We'll do this one by one after deploy. So this PR doesn't have to be blocked by minor differences we notice in the themes. I'll try to reach out to authors of the pages to check if these differences should be taken up. I already did this for the Plastic campaign, and almost all differences with the old theme were perceived as improvements.