### PR TITLE
Restore z-index to 2000 to fix slide transition. Hide caption of exiting slide.

### DIFF
--- a/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
+++ b/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
@@ -278,7 +278,6 @@ $medium-image-height: 600px;
       z-index: 1000;
       display: block;
       opacity: 1;
-      position: relative;
 
       .carousel-caption .main-header .carousel-captions-wrapper {
         h1, p {
@@ -298,7 +297,6 @@ $medium-image-height: 600px;
       z-index: 1000;
       display: block;
       opacity: 1;
-      position: relative;
 
       .carousel-caption .main-header .carousel-captions-wrapper {
         h1, p {


### PR DESCRIPTION
The transition effect was gone because the z-index of the new slide was higher so it immediately covered the whole previous slide. 

After restoring it to 2000, the carousel caption started to slide along with the image (unlike in the old version). This is probably because the new version is using an `img` tag instead of a background image. So not easy to fix without rewriting a lot of CSS. This is solved by hiding the caption of the exiting slide during the transition. That's slightly different than the old version, where the caption stays in place and gets covered by the new slide, but it's hardly noticeable. Arguably it even provides better UX, as otherwise it's hard to see that a button gets replaced with another button if it's about the same size and at the same height.

I also removed `position: relative` from the entering slide. On the front end this seems to make no difference at all. In the editor, it resolves the issue that during transition the width of the whole editor is increased and pushes the sidebar off the side of the screen.

Can be tested on https://www-dev.greenpeace.org/test-nix/