### PR TITLE
Remove characterLimit prop that only results in console warnings

### DIFF
--- a/assets/src/blocks/Accordion/AccordionEditor.js
+++ b/assets/src/blocks/Accordion/AccordionEditor.js
@@ -46,7 +46,6 @@ const renderView = ({ title, description, tabs, className }, setAttributes, isSe
           onChange={toAttribute('title')}
           keepPlaceholderOnFocus={true}
           withoutInteractiveFormatting
-          characterLimit={60}
           multiline="false"
           allowedFormats={[]}
         />
@@ -59,7 +58,6 @@ const renderView = ({ title, description, tabs, className }, setAttributes, isSe
         onChange={toAttribute('description')}
         keepPlaceholderOnFocus={true}
         withoutInteractiveFormatting
-        characterLimit={200}
         allowedFormats={['core/bold', 'core/italic']}
       />
       {tabs.map((tab, index) => (

--- a/assets/src/blocks/Articles/ArticlesEditor.js
+++ b/assets/src/blocks/Articles/ArticlesEditor.js
@@ -114,7 +114,6 @@ const renderView = ({ attributes, postType, posts, totalPosts }, toAttribute) =>
             onChange={toAttribute('article_heading')}
             keepPlaceholderOnFocus={true}
             withoutInteractiveFormatting
-            characterLimit={40}
             multiline="false"
             allowedFormats={[]}
           />
@@ -128,7 +127,6 @@ const renderView = ({ attributes, postType, posts, totalPosts }, toAttribute) =>
         onChange={toAttribute('articles_description')}
         keepPlaceholderOnFocus={true}
         withoutInteractiveFormatting
-        characterLimit={200}
         allowedFormats={['core/bold', 'core/italic']}
       />
       <ArticlesList posts={posts} postType={postType} />

--- a/assets/src/blocks/Columns/ColumnsEditor.js
+++ b/assets/src/blocks/Columns/ColumnsEditor.js
@@ -156,7 +156,6 @@ export const ColumnsEditor = ({ isSelected, attributes, setAttributes }) => {
               onChange={toAttribute('columns_title')}
               keepPlaceholderOnFocus={true}
               withoutInteractiveFormatting
-              characterLimit={40}
               multiline='false'
               allowedFormats={[]}
             />
@@ -171,7 +170,6 @@ export const ColumnsEditor = ({ isSelected, attributes, setAttributes }) => {
             onChange={toAttribute('columns_description')}
             keepPlaceholderOnFocus={true}
             withoutInteractiveFormatting
-            characterLimit={200}
             allowedFormats={['core/bold', 'core/italic']}
           />
         }

--- a/assets/src/blocks/Columns/EditableColumns.js
+++ b/assets/src/blocks/Columns/EditableColumns.js
@@ -111,7 +111,6 @@ export const EditableColumns = ({
               keepPlaceholderOnFocus={true}
               withoutInteractiveFormatting
               allowedFormats={[]}
-              characterLimit={40}
               multiline='false'
             />
             <RichText
@@ -121,7 +120,6 @@ export const EditableColumns = ({
               onChange={toAttribute('description', index)}
               keepPlaceholderOnFocus={true}
               withoutInteractiveFormatting
-              characterLimit={400}
               allowedFormats={['core/bold', 'core/italic']}
             />
             {columns_block_style === LAYOUT_TASKS && (

--- a/assets/src/blocks/Cookies/CookiesFrontend.js
+++ b/assets/src/blocks/Cookies/CookiesFrontend.js
@@ -84,7 +84,6 @@ export const CookiesFrontend = props => {
           onChange={toAttribute('title')}
           keepPlaceholderOnFocus={true}
           withoutInteractiveFormatting
-          characterLimit={40}
           multiline="false"
           editable={isEditing}
           allowedFormats={[]}
@@ -100,7 +99,6 @@ export const CookiesFrontend = props => {
         onChange={toAttribute('description')}
         keepPlaceholderOnFocus={true}
         withoutInteractiveFormatting
-        characterLimit={300}
         editable={isEditing}
         allowedFormats={['core/bold', 'core/italic']}
       />
@@ -133,7 +131,6 @@ export const CookiesFrontend = props => {
             onChange={toAttribute('necessary_cookies_name')}
             keepPlaceholderOnFocus={true}
             withoutInteractiveFormatting
-            characterLimit={40}
             multiline="false"
             editable={isEditing}
             allowedFormats={[]}
@@ -147,7 +144,6 @@ export const CookiesFrontend = props => {
           onChange={toAttribute('necessary_cookies_description')}
           keepPlaceholderOnFocus={true}
           withoutInteractiveFormatting
-          characterLimit={300}
           editable={isEditing}
           allowedFormats={['core/bold', 'core/italic']}
         />
@@ -180,7 +176,6 @@ export const CookiesFrontend = props => {
             onChange={toAttribute('all_cookies_name')}
             keepPlaceholderOnFocus={true}
             withoutInteractiveFormatting
-            characterLimit={40}
             multiline="false"
             editable={isEditing}
             allowedFormats={[]}
@@ -194,7 +189,6 @@ export const CookiesFrontend = props => {
           onChange={toAttribute('all_cookies_description')}
           keepPlaceholderOnFocus={true}
           withoutInteractiveFormatting
-          characterLimit={300}
           editable={isEditing}
           allowedFormats={['core/bold', 'core/italic']}
         />

--- a/assets/src/blocks/Counter/CounterEditor.js
+++ b/assets/src/blocks/Counter/CounterEditor.js
@@ -96,7 +96,6 @@ export class CounterEditor extends Component {
             onChange={this.toAttribute('title')}
             keepPlaceholderOnFocus={true}
             withoutInteractiveFormatting
-            characterLimit={60}
             multiline="false"
             allowedFormats={[]}
           />
@@ -109,7 +108,6 @@ export class CounterEditor extends Component {
           onChange={this.toAttribute('description')}
           keepPlaceholderOnFocus={true}
           withoutInteractiveFormatting
-          characterLimit={400}
           allowedFormats={['core/bold', 'core/italic']}
         />
       </div>

--- a/assets/src/blocks/Covers/CoversEditor.js
+++ b/assets/src/blocks/Covers/CoversEditor.js
@@ -93,7 +93,6 @@ const renderView = (attributes, toAttribute) => {
           onChange={toAttribute('title')}
           keepPlaceholderOnFocus={true}
           withoutInteractiveFormatting
-          characterLimit={60}
           multiline='false'
           allowedFormats={[]}
         />
@@ -106,7 +105,6 @@ const renderView = (attributes, toAttribute) => {
         onChange={toAttribute('description')}
         keepPlaceholderOnFocus={true}
         withoutInteractiveFormatting
-        characterLimit={400}
         allowedFormats={['core/bold', 'core/italic']}
       />
       {!loading && !covers.length ?

--- a/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
+++ b/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
@@ -157,7 +157,6 @@ const SideContent = ({attributes, setAttributes}) => {
         keepPlaceholderOnFocus={true}
         withoutInteractiveFormatting
         allowedFormats={[]}
-        characterLimit={60}
         multiline="false"
       />
       <RichText
@@ -167,7 +166,6 @@ const SideContent = ({attributes, setAttributes}) => {
         placeholder={__('Enter description', 'planet4-blocks-backend')}
         keepPlaceholderOnFocus={true}
         allowedFormats={[]}
-        characterLimit={400}
       />
     </div>
     </>
@@ -205,7 +203,6 @@ const Signup = ({attributes, setAttributes}) => {
             keepPlaceholderOnFocus={true}
             withoutInteractiveFormatting
             allowedFormats={[]}
-            characterLimit={60}
             multiline="false"
           />
           {en_form_style === 'side-style' &&
@@ -220,7 +217,6 @@ const Signup = ({attributes, setAttributes}) => {
             placeholder={__('Enter form description', 'planet4-blocks-backend')}
             keepPlaceholderOnFocus={true}
             allowedFormats={[]}
-            characterLimit={400}
           />
         </div>
 
@@ -279,7 +275,6 @@ const ThankYou = ({attributes, setAttributes}) => {
             keepPlaceholderOnFocus={true}
             withoutInteractiveFormatting
             allowedFormats={[]}
-            characterLimit={60}
             multiline="false"
           />
         </header>
@@ -291,7 +286,6 @@ const ThankYou = ({attributes, setAttributes}) => {
           placeholder={__('Enter description', 'planet4-blocks-backend')}
           keepPlaceholderOnFocus={true}
           allowedFormats={[]}
-          characterLimit={400}
           multiline="false"
         />
 
@@ -306,7 +300,6 @@ const ThankYou = ({attributes, setAttributes}) => {
               keepPlaceholderOnFocus={true}
               withoutInteractiveFormatting
               allowedFormats={[]}
-              characterLimit={400}
               multiline="false"
             />
           </div>
@@ -326,7 +319,6 @@ const ThankYou = ({attributes, setAttributes}) => {
                   placeholder={__('Enter donate message', 'planet4-blocks-backend')}
                   keepPlaceholderOnFocus={true}
                   allowedFormats={['core/bold', 'core/italic', 'core/link']}
-                  characterLimit={400}
                   multiline="false"
                 />
               </div>
@@ -342,7 +334,6 @@ const ThankYou = ({attributes, setAttributes}) => {
                   keepPlaceholderOnFocus={true}
                   withoutInteractiveFormatting
                   allowedFormats={[]}
-                  characterLimit={60}
                   multiline="false"
                 />
               </div>

--- a/assets/src/blocks/Gallery/GalleryEditor.js
+++ b/assets/src/blocks/Gallery/GalleryEditor.js
@@ -133,7 +133,6 @@ const renderView = (attributes, setAttributes) => {
           onChange={toAttribute('gallery_block_title')}
           keepPlaceholderOnFocus={true}
           withoutInteractiveFormatting
-          characterLimit={40}
           multiline="false"
           allowedFormats={[]}
         />
@@ -146,7 +145,6 @@ const renderView = (attributes, setAttributes) => {
         onChange={toAttribute('gallery_block_description')}
         keepPlaceholderOnFocus={true}
         withoutInteractiveFormatting
-        characterLimit={400}
         allowedFormats={['core/bold', 'core/italic']}
       />
       {layout === 'slider' && <GalleryCarousel images={images || []} />}

--- a/assets/src/blocks/Media/MediaEditor.js
+++ b/assets/src/blocks/Media/MediaEditor.js
@@ -87,7 +87,6 @@ const renderView = (attributes, toAttribute) => {
           onChange={toAttribute('video_title')}
           keepPlaceholderOnFocus={true}
           withoutInteractiveFormatting
-          characterLimit={40}
           multiline="false"
           allowedFormats={[]}
         />
@@ -100,7 +99,6 @@ const renderView = (attributes, toAttribute) => {
         onChange={toAttribute('description')}
         keepPlaceholderOnFocus={true}
         withoutInteractiveFormatting
-        characterLimit={200}
         allowedFormats={['core/bold', 'core/italic']}
       />
       {

--- a/assets/src/blocks/Splittwocolumns/SplittwocolumnsInPlaceEdit.js
+++ b/assets/src/blocks/Splittwocolumns/SplittwocolumnsInPlaceEdit.js
@@ -57,7 +57,6 @@ export const SplittwocolumnsInPlaceEdit = ({attributes, charLimit, setAttributes
             keepPlaceholderOnFocus={true}
             value={title}
             onChange={onTextChange('title')}
-            characterLimit={charLimit.title}
             multiline="false"
             withoutInteractiveFormatting
             allowedFormats={[]}
@@ -69,7 +68,6 @@ export const SplittwocolumnsInPlaceEdit = ({attributes, charLimit, setAttributes
             keepPlaceholderOnFocus={true}
             value={issue_description}
             onChange={onTextChange('issue_description')}
-            characterLimit={charLimit.description}
             multiline="false"
             allowedFormats={['core/bold', 'core/italic']}
             />
@@ -81,7 +79,6 @@ export const SplittwocolumnsInPlaceEdit = ({attributes, charLimit, setAttributes
               keepPlaceholderOnFocus={true}
               value={issue_link_text}
               onChange={onTextChange('issue_link_text')}
-              characterLimit={100}
               multiline="false"
               withoutInteractiveFormatting
               allowedFormats={[]}
@@ -113,7 +110,6 @@ export const SplittwocolumnsInPlaceEdit = ({attributes, charLimit, setAttributes
             keepPlaceholderOnFocus={true}
             value={tag_description}
             onChange={onTextChange('tag_description')}
-            characterLimit={charLimit.description}
             multiline="false"
             allowedFormats={['core/bold', 'core/italic']}
             />
@@ -124,7 +120,6 @@ export const SplittwocolumnsInPlaceEdit = ({attributes, charLimit, setAttributes
             keepPlaceholderOnFocus={true}
             value={button_text}
             onChange={onTextChange('button_text')}
-            characterLimit={charLimit.title}
             multiline="false"
             withoutInteractiveFormatting
             allowedFormats={[]}

--- a/assets/src/blocks/Submenu/SubmenuEditor.js
+++ b/assets/src/blocks/Submenu/SubmenuEditor.js
@@ -109,7 +109,6 @@ const renderView = (attributes, setAttributes, className) => {
         onChange={title => setAttributes({ title })}
         keepPlaceholderOnFocus={true}
         withoutInteractiveFormatting
-        characterLimit={60}
         multiline="false"
         allowedFormats={[]}
       />


### PR DESCRIPTION
* For some reason this was added to many RichText components, even
though they don't have this prop. So the only effect it had was cause a
whole lot of warnings flooding the console.
* This was copied from a component that was using the
`withCharacterCounter` HOC, that adds the counter and warnings around a
component. Don't use that component, HOCs are legacy, but we still need
to rewrite it. If we need to add a character counter in some places, we
should first rewrite the HOC.

Ref: No ticket, it only prevents warnings and removes non-functioning code.
