### PR TITLE
Remove cookie that gets set on render

### DIFF
--- a/assets/src/blocks/Cookies/CookiesFrontend.js
+++ b/assets/src/blocks/Cookies/CookiesFrontend.js
@@ -81,12 +81,6 @@ export const CookiesFrontend = props => {
   }
   useEffect(toggleHubSpotConsent, [allCookiesChecked, userRevokedAllCookies])
 
-  // Make the necessary cookies checked by default on user's first visit.
-  // Here if the No cookies set(absence of 'greenpeace' & 'no_track' cookies) consider as first visit of user.
-  if (!consentCookie && !readCookie('no_track') && !userRevokedNecessary) {
-    setConsentCookie(ONLY_NECESSARY);
-  }
-
   return <Fragment>
     <section className={`block cookies-block ${className ?? ''}`}>
       {(isEditing || title) &&


### PR DESCRIPTION
* This caused the cookie to be set just by going to the privacy page,
without seeing the block (it's below the fold).

Ref: <!-- Please add a url to the ticket this change is addressing. -->

---

<!--
Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
