### PR TITLE
Allow theming counter block spacing and display

### DIFF
--- a/assets/src/styles/blocks/Counter.scss
+++ b/assets/src/styles/blocks/Counter.scss
@@ -23,6 +23,9 @@
     }
 
     .progress-container {
+      _-- {
+        display: block;
+      }
       height: 20px;
     }
   }

--- a/assets/src/styles/blocks/ENForm/components/_enform-side-style.scss
+++ b/assets/src/styles/blocks/ENForm/components/_enform-side-style.scss
@@ -119,7 +119,7 @@
         padding-top: 0;
       }
 
-      .counter-block {
+      .counter-block _-- {
         margin-bottom: 0;
         margin-top: 32px;
       }

--- a/assets/src/styles/blocks/OldENForm/components/_enform-side-style.scss
+++ b/assets/src/styles/blocks/OldENForm/components/_enform-side-style.scss
@@ -119,7 +119,7 @@
         padding-top: 0;
       }
 
-      .counter-block {
+      .counter-block _-- {
         margin-bottom: 0;
         margin-top: 32px;
       }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6362

Add a few variables needed to style the counter block in ENForm style. These are used in https://github.com/greenpeace/planet4-master-theme/pull/1441/files for the "climate" theme.