### PR TITLE
Hubspot Form block: With custom hubspot form CSS

### DIFF
--- a/assets/src/blocks/HubspotForm/HubspotFormBlock.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormBlock.js
@@ -1,0 +1,102 @@
+import ReactDOMServer from 'react-dom/server';
+import { RawHTML, Fragment } from '@wordpress/element';
+import { Tooltip } from '@wordpress/components';
+import { HubspotFormEditor } from './HubspotFormEditor';
+import { HubspotFormFrontend } from './HubspotFormFrontend';
+
+const { __ } = wp.i18n;
+const { registerBlockType } = wp.blocks;
+
+const BLOCK_NAME = 'planet4-blocks/hubspot-form';
+
+const getStyleLabel = (label, help) => (
+  (help)
+    ? <Tooltip text={help}>
+        <span>{label}</span>
+      </Tooltip>
+    : label
+);
+
+export const registerHubspotFormBlock = () => {
+  return registerBlockType(BLOCK_NAME, {
+    title: 'Hubspot Form (beta)',
+    icon: 'feedback',
+    category: 'planet4-blocks-beta',
+    supports: {
+      multiple: false,
+      html: false,
+    },
+    attributes: {
+      block_title: {
+        type: 'string',
+      },
+      block_text: {
+        type: 'string',
+      },
+      block_background_image_id: {
+        type: 'integer',
+      },
+      block_background_image_url: {
+        type: 'string',
+      },
+      cta_text: {
+        type: 'string',
+      },
+      cta_link: {
+        type: 'string',
+      },
+      cta_new_tab: {
+        type: 'boolean',
+        default: false,
+      },
+      form_title: {
+        type: 'string',
+      },
+      form_description: {
+        type: 'string',
+      },
+      hubspot_shortcode: {
+        type: 'string',
+      },
+      hubspot_thankyou_message: {
+        type: 'string',
+      },
+      enable_custom_hubspot_thankyou_message: {
+        type: 'boolean',
+        default: true,
+      },
+      version: {
+        type: 'integer',
+        default: 1,
+      },
+    },
+    styles: [
+      {
+        name: 'imageFullWidth',
+        label: getStyleLabel(
+          __('Image full width', 'planet4-blocks-backend'),
+          __('Image full width version', 'planet4-blocks-backend'),
+        ),
+        isDefault: true,
+      },
+    ],
+    edit: (props) => (
+      <Fragment>
+        <HubspotFormEditor {...props} />
+      </Fragment>
+    ),
+    save: ({
+      attributes,
+    }) => {
+      const markup = ReactDOMServer.renderToString(
+        <div
+          data-hydrate={BLOCK_NAME}
+          data-attributes={JSON.stringify({...attributes})}
+        >
+          <HubspotFormFrontend {...attributes} />
+        </div>
+      );
+      return <RawHTML>{ markup }</RawHTML>;
+    },
+  })
+}

--- a/assets/src/blocks/HubspotForm/HubspotFormBlock.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormBlock.js
@@ -65,6 +65,10 @@ export const registerHubspotFormBlock = () => {
         type: 'boolean',
         default: true,
       },
+      use_custom_style: {
+        type: 'boolean',
+        default: false,
+      },
       version: {
         type: 'integer',
         default: 1,

--- a/assets/src/blocks/HubspotForm/HubspotFormBlock.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormBlock.js
@@ -65,7 +65,7 @@ export const registerHubspotFormBlock = () => {
         type: 'boolean',
         default: true,
       },
-      use_custom_style: {
+      use_custom_styles: {
         type: 'boolean',
         default: false,
       },

--- a/assets/src/blocks/HubspotForm/HubspotFormContext.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormContext.js
@@ -16,6 +16,7 @@ const ContextProvider = ({
   hubspot_shortcode,
   hubspot_thankyou_message,
   enable_custom_hubspot_thankyou_message,
+  use_custom_style,
   children,
 }) => (
   <Provider
@@ -31,6 +32,7 @@ const ContextProvider = ({
       hubspot_shortcode,
       hubspot_thankyou_message,
       enable_custom_hubspot_thankyou_message,
+      use_custom_style,
     }}>
     {children}
   </Provider>

--- a/assets/src/blocks/HubspotForm/HubspotFormContext.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormContext.js
@@ -16,7 +16,7 @@ const ContextProvider = ({
   hubspot_shortcode,
   hubspot_thankyou_message,
   enable_custom_hubspot_thankyou_message,
-  use_custom_style,
+  use_custom_styles,
   children,
 }) => (
   <Provider
@@ -32,7 +32,7 @@ const ContextProvider = ({
       hubspot_shortcode,
       hubspot_thankyou_message,
       enable_custom_hubspot_thankyou_message,
-      use_custom_style,
+      use_custom_styles,
     }}>
     {children}
   </Provider>

--- a/assets/src/blocks/HubspotForm/HubspotFormContext.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormContext.js
@@ -1,0 +1,43 @@
+import { createContext } from '@wordpress/element';
+
+const Context = createContext({});
+Context.displayName = 'HubspotFormContext';
+const { Provider, Consumer } = Context;
+
+const ContextProvider = ({
+  form_title,
+  form_description,
+  block_background_image_url,
+  block_title,
+  block_text,
+  cta_link,
+  cta_text,
+  cta_new_tab,
+  hubspot_shortcode,
+  hubspot_thankyou_message,
+  enable_custom_hubspot_thankyou_message,
+  children,
+}) => (
+  <Provider
+    value={{
+      form_title,
+      form_description,
+      block_background_image_url,
+      block_title,
+      block_text,
+      cta_link,
+      cta_text,
+      cta_new_tab,
+      hubspot_shortcode,
+      hubspot_thankyou_message,
+      enable_custom_hubspot_thankyou_message,
+    }}>
+    {children}
+  </Provider>
+);
+
+export {
+  ContextProvider as HubspotFormProvider,
+  Consumer as HubspotFormConsumer,
+  Context as HubspotFormContext,
+};

--- a/assets/src/blocks/HubspotForm/HubspotFormEditor.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormEditor.js
@@ -1,0 +1,179 @@
+import { MediaUpload, MediaUploadCheck, RichText } from '@wordpress/block-editor';
+import { Button } from '@wordpress/components';
+import { Fragment, useRef } from '@wordpress/element';
+import { useDynamicHeight } from './useDynamicHeight';
+import { Sidebar } from './HubspotFormSidebar';
+
+const { __ } = wp.i18n;
+
+export const HubspotFormEditor = ({
+  attributes: {
+    block_background_image_id,
+    block_background_image_url,
+    cta_text,
+    cta_link,
+    cta_new_tab,
+    block_text,
+    block_title,
+    form_description,
+    form_title,
+    hubspot_shortcode,
+    hubspot_thankyou_message,
+    enable_custom_hubspot_thankyou_message,
+  },
+  setAttributes,
+}) => {
+  const wrapperRef = useRef(null);
+  const [ blockHeight ] = useDynamicHeight(wrapperRef);
+
+  const onSelectImageHandler = ({ id, url }) => {
+    if(url && id) {
+      setAttributes({
+        block_background_image_id: id,
+        block_background_image_url: url,
+      });
+    }
+  };
+
+  const getImageOrButton = (openEvent) => {
+    return (openEvent) ? (
+      <div>
+        <Button
+          onClick={openEvent}
+          className='button'
+        >
+          + {__('Select Background Image', 'planet4-blocks-backend')}
+        </Button>
+      </div>
+    ) : null;
+  };
+  
+  const toAttribute = (attributeName) => value => {
+    if(setAttributes) {
+      setAttributes({
+        [attributeName]: value,
+      });
+    }
+  };
+
+  return (
+    <Fragment>
+      <Sidebar { ...{
+        cta_link,
+        cta_new_tab,
+        enable_custom_hubspot_thankyou_message,
+        setAttributes
+      } } />
+      <MediaUploadCheck>
+        <MediaUpload
+          title={__('Select Background Image', 'planet4-blocks-backend')}
+          type='image'
+          onSelect={onSelectImageHandler}
+          value={block_background_image_id}
+          allowedTypes={[ 'image' ]}
+          render={({ open }) => {
+            return getImageOrButton(open);
+          }}
+        />
+      </MediaUploadCheck>
+      <section
+        className='hubspot-form hubspot-form--image-full-width'
+        style={{ height: blockHeight }}
+      >
+        <div
+          ref={wrapperRef}
+          className='hubspot-form__wrapper block-wide'
+          style={{ backgroundImage: `url(${block_background_image_url ?? ''})` }}
+        >
+          <div className='hubspot-form__content container'>
+            <div
+              className='hubspot-form__inner-content hubspot-form__inner-content--heading'
+              style={{ backgroundImage: `url(${block_background_image_url ?? ''})` }}
+            >
+              <RichText
+                tagName='h1'
+                className='hubspot-form__title'
+                placeholder={__('Enter description', 'planet4-blocks-backend')}
+                value={block_title}
+                onChange={toAttribute('block_title')}
+                keepPlaceholderOnFocus={true}
+                withoutInteractiveFormatting={true}
+                allowedFormats={[]}
+              />
+              <RichText
+                tagName='p'
+                className='hubspot-form__text'
+                placeholder={__('Enter description', 'planet4-blocks-backend')}
+                value={block_text}
+                onChange={toAttribute('block_text')}
+                keepPlaceholderOnFocus={true}
+                withoutInteractiveFormatting={true}
+                allowedFormats={['core/bold', 'core/italic']}
+              />
+              <RichText
+                tagName='div'
+                className='hubspot-form__button'
+                placeholder={__('Enter CTA text', 'planet4-blocks-backend')}
+                value={cta_text}
+                onChange={toAttribute('cta_text')}
+                keepPlaceholderOnFocus={true}
+                withoutInteractiveFormatting
+                allowedFormats={[]}
+              />
+            </div>
+            <div className='hubspot-form__inner-content hubspot-form__inner-content--form'>
+              <header className='hubspot-form__form-header'>
+                <RichText
+                  tagName='h1'
+                  className='hubspot-form__form-title'
+                  placeholder={__('Form title goes here', 'planet4-blocks-backend')}
+                  value={form_title}
+                  onChange={toAttribute('form_title')}
+                  keepPlaceholderOnFocus={true}
+                  withoutInteractiveFormatting={true}
+                  allowedFormats={[]}
+                />
+                <RichText
+                  tagName='p'
+                  className='hubspot-form__form-description'
+                  placeholder={__('Enter text', 'planet4-blocks-backend')}
+                  value={form_description}
+                  onChange={toAttribute('form_description')}
+                  keepPlaceholderOnFocus={true}
+                  withoutInteractiveFormatting={true}
+                  allowedFormats={['core/bold', 'core/italic']}
+                />
+              </header>
+              <div className='hubspot-form__form-wrapper hubspot-form__form-wrapper--editor'>
+                <label className='hubspot-form__shortcode-label'>{__('Enter the Hubspot shortcode', 'planet4-blocks-backend')}</label>
+                <RichText
+                  tagName='p'
+                  className='hubspot-form__shortcode-editor'
+                  placeholder={__('[hubspot type="form" portal="XXXXXX" id="XXXX-XXXX-XXXX-XXXX"]', 'planet4-blocks-backend')}
+                  value={hubspot_shortcode}
+                  onChange={toAttribute('hubspot_shortcode')}
+                  keepPlaceholderOnFocus={true}
+                  withoutInteractiveFormatting={true}
+                  allowedFormats={[]}
+                />
+                {enable_custom_hubspot_thankyou_message && <Fragment>
+                  <label className='hubspot-form__shortcode-label'>{__('Display a thank you message', 'planet4-blocks-backend')}</label>
+                  <RichText
+                    tagName='p'
+                    className='hubspot-form__shortcode-editor'
+                    placeholder={__('e.g. Thanks for submitting the form.', 'planet4-blocks-backend')}
+                    value={hubspot_thankyou_message}
+                    onChange={toAttribute('hubspot_thankyou_message')}
+                    keepPlaceholderOnFocus={true}
+                    withoutInteractiveFormatting={true}
+                    allowedFormats={[]}
+                  />
+                </Fragment>}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </Fragment>
+  );
+};

--- a/assets/src/blocks/HubspotForm/HubspotFormEditorScript.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormEditorScript.js
@@ -1,0 +1,3 @@
+import { registerHubspotFormBlock } from './HubspotFormBlock';
+
+registerHubspotFormBlock();

--- a/assets/src/blocks/HubspotForm/HubspotFormFrontend.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormFrontend.js
@@ -1,0 +1,98 @@
+import { Fragment, useContext, useRef } from '@wordpress/element';
+import { HubspotFormContext, HubspotFormProvider } from './HubspotFormContext';
+import { useCreateHubspotForm } from './useCreateHubspotForm';
+
+const { __ } = wp.i18n;
+
+const Component = () => {
+  const {
+    form_title,
+    form_description,
+    block_background_image_url,
+    block_title,
+    block_text,
+    cta_link,
+    cta_text,
+    cta_new_tab,
+    hubspot_shortcode,
+    hubspot_thankyou_message,
+    enable_custom_hubspot_thankyou_message,
+  } = useContext(HubspotFormContext);
+  const hubspotFormRef = useRef(null);
+  const { submitted } = useCreateHubspotForm(hubspot_shortcode, hubspotFormRef);
+
+  const renderSuccessMessage = () => (
+    <div className='hubspot-form__submitted-message'>
+      <svg width="24" height="20" viewBox="0 0 24 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M2 10.4211L8.4 18L22 2" stroke="#074365" strokeWidth="4" strokeLinecap="round" strokeLinejoin="round"/>
+      </svg>&nbsp;
+      <span>{ hubspot_thankyou_message }</span>
+    </div>
+  );
+
+  return (
+    <Fragment>
+      <section className='hubspot-form hubspot-form--image-full-width'>
+        <div
+          className='hubspot-form__wrapper block-wide'
+          style={{ backgroundImage: block_background_image_url ? `url(${block_background_image_url})` : 'none' }}
+        >
+          <div className='hubspot-form__content container'>
+            <div
+              className='hubspot-form__inner-content hubspot-form__inner-content--heading'
+              style={{ backgroundImage: block_background_image_url ? `url(${block_background_image_url})` : 'none' }}
+            >
+              <h1 className='hubspot-form__title'>{ block_title }</h1>
+              <p
+                className='hubspot-form__text'
+                dangerouslySetInnerHTML={{ __html: block_text }}
+              />
+              {(cta_link && cta_text) && <a
+                href={cta_link}
+                className='hubspot-form__button'
+                data-ga-category='Hubspot Forms Block'
+                data-ga-action='custom form'
+                data-ga-label={cta_link}
+                { ...cta_new_tab && { target: '_blank' } }
+              >{cta_text}</a>}
+            </div>
+            <div
+              className={`
+                hubspot-form__inner-content hubspot-form__inner-content--form 
+                ${submitted ? 'hubspot-form__form-wrapper--signed' : ''}
+              `}
+            >
+              <header className='hubspot-form__form-header'>
+                {!submitted ? (
+                  <Fragment>
+                    <h1 className='hubspot-form__form-title'>{form_title}</h1>
+                    <p className='hubspot-form__form-description'>{form_description}</p>
+                  </Fragment>
+                ) : null} 
+              </header>
+              <div className='hubspot-form__form-wrapper'>
+                <div
+                  ref={hubspotFormRef}
+                  id='hubspot-api-form'
+                  className={`
+                    hubspot-form__api-form
+                    ${submitted ? 'hubspot-form__api-form--submitted' : ''}
+                    ${submitted && enable_custom_hubspot_thankyou_message ? 'hubspot-form__api-form--hide-custom-message' : ''}
+                  `}>
+                  <div className='hubspot-form__spinner'>{__('Loading', 'planet4-blocks-backend')}</div>
+                </div>
+                {submitted && enable_custom_hubspot_thankyou_message ? renderSuccessMessage() : null}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </Fragment>
+  )
+}
+
+export const HubspotFormFrontend = (props) => (
+  <HubspotFormProvider {...props}>
+    <Component />
+  </HubspotFormProvider>
+);

--- a/assets/src/blocks/HubspotForm/HubspotFormFrontend.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormFrontend.js
@@ -73,7 +73,7 @@ const Component = () => {
               <div
                 className={`
                   hubspot-form__form-wrapper 
-                  ${use_custom_style ? 'hubspot-form__form-wrapper--with-custom-style' : ''}
+                  ${use_custom_styles ? 'hubspot-form__form-wrapper--with-custom-style' : ''}
                 `}
               >
                 <div

--- a/assets/src/blocks/HubspotForm/HubspotFormFrontend.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormFrontend.js
@@ -70,7 +70,12 @@ const Component = () => {
                   </Fragment>
                 ) : null} 
               </header>
-              <div className='hubspot-form__form-wrapper'>
+              <div
+                className={`
+                  hubspot-form__form-wrapper 
+                  ${use_custom_style ? 'hubspot-form__form-wrapper--with-custom-style' : ''}
+                `}
+              >
                 <div
                   ref={hubspotFormRef}
                   id='hubspot-api-form'

--- a/assets/src/blocks/HubspotForm/HubspotFormScript.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormScript.js
@@ -1,0 +1,5 @@
+import { HubspotFormFrontend } from './HubspotFormFrontend';
+import { hydrateBlock } from '../../functions/hydrateBlock';
+
+hydrateBlock('planet4-blocks/hubspot-form', HubspotFormFrontend);
+

--- a/assets/src/blocks/HubspotForm/HubspotFormSidebar.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormSidebar.js
@@ -1,0 +1,44 @@
+import { CheckboxControl, PanelBody, PanelRow } from '@wordpress/components';
+import { InspectorControls } from '@wordpress/block-editor';
+import { URLInput } from '../../components/URLInput/URLInput';
+
+const { __ } = wp.i18n;
+
+export const Sidebar = ({
+  cta_link,
+  cta_new_tab,
+  enable_custom_hubspot_thankyou_message,
+  setAttributes,
+}) => (
+  <InspectorControls>
+    <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
+      <PanelRow>
+        <URLInput
+          label={__('Call to action', 'planet4-blocks-backend')}
+          placeholder={__('Enter the button link', 'planet4-blocks-backend')}
+          value={cta_link}
+          onChange={value => {
+            setAttributes({ cta_link: value });
+          }}
+        />
+      </PanelRow>
+      <PanelRow>
+        <CheckboxControl
+          label={__('Open in a new tab', 'planet4-blocks-backend')}
+          value={cta_new_tab}
+          checked={cta_new_tab}
+          onChange={value => setAttributes({ cta_new_tab: value })}
+        />
+      </PanelRow>
+      <PanelRow>
+        <CheckboxControl
+          label={__('Enable custom thank you message', 'planet4-blocks-backend')}
+          help={__('This functionality overrides the default thank you message set to the Form on Hubspot', 'planet4-blocks-backend')}
+          value={enable_custom_hubspot_thankyou_message}
+          checked={enable_custom_hubspot_thankyou_message}
+          onChange={value => setAttributes({ enable_custom_hubspot_thankyou_message: value })}
+        />
+      </PanelRow>
+    </PanelBody>
+  </InspectorControls>
+);

--- a/assets/src/blocks/HubspotForm/HubspotFormSidebar.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormSidebar.js
@@ -8,6 +8,7 @@ export const Sidebar = ({
   cta_link,
   cta_new_tab,
   enable_custom_hubspot_thankyou_message,
+  use_custom_styles,
   setAttributes,
 }) => (
   <InspectorControls>
@@ -37,6 +38,14 @@ export const Sidebar = ({
           value={enable_custom_hubspot_thankyou_message}
           checked={enable_custom_hubspot_thankyou_message}
           onChange={value => setAttributes({ enable_custom_hubspot_thankyou_message: value })}
+        />
+      </PanelRow>
+      <PanelRow>
+        <CheckboxControl
+          label={__('Use custom styles', 'planet4-blocks-backend')}
+          value={use_custom_styles}
+          checked={use_custom_styles}
+          onChange={value => setAttributes({ use_custom_styles: value })}
         />
       </PanelRow>
     </PanelBody>

--- a/assets/src/blocks/HubspotForm/useCreateHubspotForm.js
+++ b/assets/src/blocks/HubspotForm/useCreateHubspotForm.js
@@ -1,0 +1,70 @@
+import { useState, useEffect } from '@wordpress/element';
+
+export const useCreateHubspotForm = (shortcode, targetRef) => {
+  const [ submitted, setSubmitted ] = useState(false);
+
+  const onHubspotMessageHandler = evt => {
+    if(evt.data.type === 'hsFormCallback') {
+      if(evt.data.eventName === 'onFormSubmit') {
+        setSubmitted(false);
+      }
+      
+      if(evt.data.eventName === 'onFormSubmitted') {
+        setSubmitted(true);
+    
+        return () => {
+          clearTimeout(timer);
+        }
+      }
+    }
+  }
+
+  const createHubspotForm = () => {
+    if(window.hbspt) {
+      let portalId = ''; 
+      let formId = ''; 
+      
+      shortcode.replace(/["'\]\[]/g,'').split(' ').forEach(value => {
+        if(/portal=/.test(value)) {
+          portalId = value.split('=')[1];
+        }
+        if(/id=/.test(value)) {
+           formId = value.split('=')[1];
+        }
+      });
+
+      window.hbspt.forms.create({
+        portalId,
+        formId,
+        target: `#${targetRef.current.attributes.id.value}`,
+      });
+      
+      window.addEventListener('message', onHubspotMessageHandler);
+      
+      return () => {
+        window.removeEventListener('message', onHubspotMessageHandler);
+      }
+    }
+  }
+
+  const fetchHubspotLibrary = () => {
+    const script = document.createElement('script');
+    script.src = 'https://js.hsforms.net/forms/v2.js';
+    document.body.appendChild(script);
+    script.addEventListener('load', createHubspotForm);
+  }
+
+  useEffect(() => {
+    if(shortcode) {
+      if(!window.hbspt) {
+        fetchHubspotLibrary();
+      } else {
+        createHubspotForm();
+      }
+    }
+  }, []);
+
+  return {
+    submitted,
+  };
+}

--- a/assets/src/blocks/HubspotForm/useDynamicHeight.js
+++ b/assets/src/blocks/HubspotForm/useDynamicHeight.js
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react';
+
+export const useDynamicHeight = (wrapperRef) => {
+  const [ blockHeight, setBlockHeight ] = useState(0);
+
+  const updateBlockHeight = () => {
+    if(wrapperRef && wrapperRef.current) {
+      setBlockHeight(wrapperRef.current.getBoundingClientRect().height);
+    }
+  };
+
+  const onResizeHandler = (evt) => {
+    evt.preventDefault();
+    updateBlockHeight();
+  };
+
+  useEffect(() => {
+    updateBlockHeight();
+  }, [
+    wrapperRef,
+  ]);
+
+  useEffect(() => {
+    window.addEventListener('resize', onResizeHandler);
+
+    return () => {
+      window.removeEventListener('resize', onResizeHandler);
+    }
+  }, []);
+
+  return [
+    blockHeight,
+  ];
+}

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -43,7 +43,6 @@ new TakeactionboxoutBlock();
 new ENFormBlock();
 registerTimelineBlock();
 registerGuestBookBlock();
-
 addBlockFilters();
 setupImageBlockExtension();
 addButtonLinkPasteWarning();

--- a/assets/src/styles/blocks.scss
+++ b/assets/src/styles/blocks.scss
@@ -15,6 +15,7 @@
 @import "blocks/SplitTwoColumns";
 @import "blocks/Submenu";
 @import "blocks/Cookies";
+@import "blocks/HubspotForm/HubspotFormStyles";
 
 // A/B test for Take Action Boxout
 @import "blocks/OldCovers/TakeActionBoxoutScroll";

--- a/assets/src/styles/blocks/HubspotForm/HubspotFormOverrides.scss
+++ b/assets/src/styles/blocks/HubspotForm/HubspotFormOverrides.scss
@@ -1,0 +1,50 @@
+@mixin custom-hubsport-form-style {
+  .hs-form {
+    width: 100%;
+
+    fieldset {
+      &.form-columns-1, &.form-columns-2 {
+        max-width: 100%;
+
+        .hs-form-field {
+          margin-bottom: 14px;
+
+          .input {
+            margin-right: 0;
+
+            .hs-input {
+              width: 100%;
+              padding: 6px 10px;
+            }
+          }
+
+          .hs-error-msgs {
+            padding-left: 0;
+            list-style: none;
+            font-size: 15px !important;
+            color: orange;
+          }
+        }
+      }
+    }
+
+    .hs-button {
+      color: $white;
+      font-size: 16px;
+      padding: 12px 0;
+      font-family: $roboto;
+      font-style: bold;
+      font-weight: 700;
+      border: none;
+      border-radius: 4px;
+
+      &.primary {
+        background: $orange;
+
+        &.large {
+          width: 100%;
+        }
+      }
+    }
+  }
+}

--- a/assets/src/styles/blocks/HubspotForm/HubspotFormStyles.scss
+++ b/assets/src/styles/blocks/HubspotForm/HubspotFormStyles.scss
@@ -1,0 +1,217 @@
+@mixin background-image {
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center center;
+}
+
+.hubspot-form {
+  position: relative;
+  margin-bottom: 32px;
+  font-family: $roboto;
+
+  &--image-full-width {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
+  &__wrapper {
+    @include background-image;
+
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    top: 0;
+    left: 0;
+    background-color: $grey-80;
+
+    @media (max-width: #{$large-width}) {
+      padding-bottom: 32px 0 0 0;
+      background-image: none !important;
+    }
+
+    @include large-and-up {
+      padding-top: 156px;
+      padding-bottom: 156px;
+    }
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+
+    @media (max-width: #{$large-width}) {
+      max-width: 100% !important;
+      padding: 0 !important;
+    }
+
+    @include large-and-up {
+      flex-direction: row;
+    }
+  }
+
+  &__inner-content {
+    &--heading {
+      @include background-image;
+      padding: 32px 26px;
+
+      @include large-and-up {
+        background-image: none !important;
+        margin-right: 20px;
+        width: 100%;
+      }
+    }
+
+    &--form {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      flex: 0 0 auto;
+      width: 100%;
+      height: fit-content;
+      background-color: $white;
+      border-radius: 0;
+      overflow: hidden;
+      padding: 32px 26px;
+
+      @include large-and-up {
+        padding-right: 32px;
+        padding-left: 32px;
+        width: 450px;
+        min-height: 400px;
+        border-radius: 4px;
+      }
+    }
+  }
+
+  &__title {
+    font-size: 28px;
+    line-height: 32px;
+    text-align: left;
+    color: $white !important;
+    margin: 0 !important;
+    word-break: break-word !important;
+
+    @include large-and-up {
+      font-size: 40px;
+      line-height: 46px;
+    }
+  }
+
+  &__text {
+    font-size: 16px;
+    font-family: $lora;
+    font-weight: 400;
+    color: $white;
+    line-height: 26px;
+    text-align: left;
+    margin-top: 24px;
+    margin-bottom: 32px;
+
+    @include large-and-up {
+      font-size: 20px;
+      line-height: 28px;
+    }
+  }
+
+  &__button {
+    border: solid 1px $white;
+    background: transparent;
+    padding: 13px 61px;
+    border-radius: 4px;
+    color: $white;
+    line-height: 19px;
+    font-size: 16px;
+    font-weight: 700;
+    width: fit-content;
+
+    &.external-link {
+      &::after {
+        display: none;
+      }
+    }
+
+    &:hover {
+      background-color: $white;
+      color: $grey-80;
+      text-decoration: none;
+    }
+  }
+
+  &__form-title {
+    color: $grey-80;
+    font-size: 20px !important;
+    margin: 0 0 16px 0 !important;
+  }
+
+  &__form-description {
+    color: $grey-80;
+    font-family: $roboto;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 26px;
+  }
+
+  &__form-wrapper {
+    display: flex;
+    flex: 1 0 auto;
+    width: 100%;
+
+    &--editor {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      background: $grey-10;
+      padding: 10px;
+    }
+
+    &--signed {
+      align-items: center;
+      justify-content: center;
+    }
+  }
+
+  &__shortcode-label {
+    font-weight: bold;
+  }
+
+  &__shortcode-editor {
+    margin: 0 !important;
+    background-color: white;
+    padding: 10px;
+    font-size: 15px !important;
+  }
+
+  &__submitted-message {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    font-family: $roboto;
+    font-size: 20px;
+    font-weight: 700;
+  }
+
+  &__api-form {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+
+    &--submitted {
+      align-items: center;
+    }
+
+    &--hide-custom-message {
+      display: none;
+    }
+  }
+
+  &__spinner {
+    display: flex;
+    justify-content: center;
+    padding: 30px 0;
+    width: 100%;
+    font-size: 16px;
+    color: $grey-40;
+  }
+}

--- a/assets/src/styles/blocks/HubspotForm/HubspotFormStyles.scss
+++ b/assets/src/styles/blocks/HubspotForm/HubspotFormStyles.scss
@@ -1,3 +1,5 @@
+@import "./HubspotFormOverrides.scss";
+
 @mixin background-image {
   background-size: cover;
   background-repeat: no-repeat;
@@ -169,6 +171,10 @@
       align-items: center;
       justify-content: center;
     }
+
+    &--with-custom-style {
+      @include custom-hubsport-form-style;
+     }
   }
 
   &__shortcode-label {

--- a/classes/blocks/class-hubspotform.php
+++ b/classes/blocks/class-hubspotform.php
@@ -78,6 +78,10 @@ class HubspotForm extends Base_Block {
 						'type' => 'boolean',
 						'default' => true,
 					],
+					'use_custom_style' => [
+						'type' => 'boolean',
+						'default' => false,
+					],
 				],
 			]
 		);

--- a/classes/blocks/class-hubspotform.php
+++ b/classes/blocks/class-hubspotform.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Hubspot Forms block class
+ *
+ * @package P4GBKS
+ * @since 0.1
+ */
+
+namespace P4GBKS\Blocks;
+
+/**
+ * Class HubspotForm
+ * Registers the HubspotForm block.
+ *
+ * @package P4BKS
+ * @since 0.1
+ */
+class HubspotForm extends Base_Block {
+
+	/**
+	 * Block name.
+	 *
+	 * @const string BLOCK_NAME.
+	 */
+	const BLOCK_NAME = 'hubspot-form';
+
+	/**
+	 * HubspotForm constructor.
+	 */
+	public function __construct() {
+		add_action( 'init', [ $this, 'register_hubspotform_block' ] );
+	}
+
+	/**
+	 * Register HubspotForm block.
+	 */
+	public function register_hubspotform_block() {
+		register_block_type(
+			self::get_full_block_name(),
+			[
+				'render_callback' => [ $this, 'front_end_rendered_fallback' ],
+				'attributes' => [
+					'block_title'	=> [
+						'type' => 'string',
+					],
+					'block_text'	=> [
+						'type' => 'string',
+					],
+					'block_background_image_id'	=> [
+						'type' => 'string',
+					],
+					'block_background_image_url' => [
+						'type' => 'string',
+					],
+					'cta_text' => [
+						'type' => 'string',
+					],
+					'cta_link' => [
+						'type' => 'string',
+					],
+					'cta_new_tab' => [
+						'type' => 'boolean',
+						'default' => false,
+					],
+					'form_title' => [
+						'type' => 'string',
+					],
+					'form_description' => [
+						'type' => 'string',
+					],
+					'hubspot_shortcode' => [
+						'type' => 'string',
+					],
+					'hubspot_thankyou_message' => [
+						'type' => 'string',
+					],
+					'enable_custom_hubspot_thankyou_message' => [
+						'type' => 'boolean',
+						'default' => true,
+					],
+				],
+			]
+		);
+
+		add_action( 'enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ] );
+		add_action(
+			'wp_enqueue_scripts',
+			static function () {
+				if ( has_block( self::get_full_block_name() ) ) {
+					wp_enqueue_script(
+						'hammer',
+						'https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js',
+						[],
+						'2.0.8',
+						true
+					);
+				}
+			}
+		);
+		add_action( 'wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ] );
+	}
+
+	/**
+	 * Required by the `Base_Block` class.
+	 *
+	 * @param array $fields Unused, required by the abstract function.
+	 */
+	public function prepare_data( $fields ): array {
+		return [];
+	}
+
+	/**
+	 * If the content is not empty, it's the new version and doesn't need any back end rendering.
+	 * Otherwise, it means the block was not migrated in the editor yet. Fall back to front end rendering from scratch.
+	 *
+	 * @param array  $attributes Attributes of the block.
+	 * @param string $content Content of the block.
+	 *
+	 * @return string The block's content string.
+	 */
+	public function front_end_rendered_fallback( $attributes, $content ) {
+		if ( ! empty( $content ) ) {
+			return $content;
+		}
+
+		$json = wp_json_encode( [ 'attributes' => $attributes ] );
+
+		// Render the block using a regular front end rendered, until the block data was migrated in the editor. For
+		// production sites we will do this for all occurrences of the block, right after deploy.
+		return '<div data-render="' . self::get_full_block_name() . '" data-attributes="' . htmlspecialchars( $json ) . '">'
+		. '</div>';
+	}
+}

--- a/classes/blocks/class-hubspotform.php
+++ b/classes/blocks/class-hubspotform.php
@@ -78,7 +78,7 @@ class HubspotForm extends Base_Block {
 						'type' => 'boolean',
 						'default' => true,
 					],
-					'use_custom_style' => [
+					'use_custom_styles' => [
 						'type' => 'boolean',
 						'default' => false,
 					],

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -84,6 +84,7 @@ final class Loader {
 		new Blocks\OldENForm();
 		new Blocks\ENForm();
 		new Blocks\GuestBook();
+		new Blocks\HubspotForm();
 	}
 
 	/**

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -142,6 +142,7 @@ const PAGE_BLOCK_TYPES = [
 const BETA_PAGE_BLOCK_TYPES = [
 	'planet4-blocks/covers-beta',
 	'planet4-blocks/enform-beta',
+	'planet4-blocks/hubspot-form',
 ];
 
 // campaigns allow all block types.
@@ -169,6 +170,7 @@ const BETA_CAMPAIGN_BLOCK_TYPES = [
 	'planet4-blocks/covers-beta',
 	'planet4-blocks/enform-beta',
 	'planet4-blocks/social-media-cards',
+	'planet4-blocks/hubspot-form',
 ];
 
 /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,8 +43,10 @@ const publicJsConfig = {
     ENFormScript: './assets/src/blocks/ENForm/ENFormScript.js',
     SpreadsheetScript: './assets/src/blocks/Spreadsheet/SpreadsheetScript.js',
     TimelineScript: './assets/src/blocks/Timeline/TimelineScript.js',
+    HubspotFormScript: './assets/src/blocks/HubspotForm/HubspotFormScript.js',
   },
 };
+
 const adminJsConfig = {
   ...jsConfig,
   resolve: {
@@ -64,6 +66,7 @@ const adminJsConfig = {
     SpreadsheetEditorScript: './assets/src/blocks/Spreadsheet/SpreadsheetEditorScript.js',
     TimelineEditorScript: './assets/src/blocks/Timeline/TimelineEditorScript.js',
     SocialMediaEditorScript: './assets/src/blocks/SocialMedia/SocialMediaEditorScript.js',
+    HubspotFormEditorScript: './assets/src/blocks/HubspotForm/HubspotFormEditorScript.js',
   },
 };
 const cssConfig = {


### PR DESCRIPTION
This PR is about to add a custom css file overriding the default Hubspot Style.

[Demo Page](https://www-dev.greenpeace.org/test-leda/huspot-form-block-custom-css)

- To enable this functionality you must to Publish the as `Raw HTML` see [here](https://www-dev.greenpeace.org/dmptest/wp-admin/admin.php?page=leadin_forms&leadin_route%5B0%5D=editor&leadin_route%5B1%5D=ddbcce66-e064-4fe2-9348-36a476cad9d3&leadin_route%5B2%5D=edit&leadin_route%5B3%5D=test)
- And then go to the block settings and check the `use custom style` option.

![use custom css](https://user-images.githubusercontent.com/77975803/132683338-a844913f-4af4-4c3f-bc70-7cabea756619.png)


This PR needs to be merged once this https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/641 is merged.

[Parent PR](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/641)

---

<!--
Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
