### PR TITLE
Set theme variables on page load

### DIFF
--- a/assets/src/components/Sidebar/CampaignSidebar.js
+++ b/assets/src/components/Sidebar/CampaignSidebar.js
@@ -6,7 +6,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 import { savePreviewMeta } from '../../saveMetaToPreview';
 import { PostParentLink } from './PostParentLink';
 import { LegacyThemeSettings } from './LegacyThemeSettings';
-import { NewThemeSettings } from './NewThemeSettings';
+import { applyChangesToDom, NewThemeSettings, themeJsonUrl } from './NewThemeSettings';
 
 const isLegacy= theme => [
   'default',
@@ -111,6 +111,15 @@ export class CampaignSidebar extends Component {
       ) {
         const theme = await loadTheme(themeName);
         this.setState({ theme: theme });
+        if (themeName) {
+          try {
+            const response = await fetch(`${ themeJsonUrl + themeName.replace('-new', '') }.json`);
+            const theme = await response.json();
+            applyChangesToDom(theme, []);
+          } catch (e) {
+            console.log(`Failed loading config for ${ themeName }`);
+          }
+        }
       }
     } );
     wp.data.subscribe( () => {

--- a/assets/src/styles/editorFonts.scss
+++ b/assets/src/styles/editorFonts.scss
@@ -1,0 +1,42 @@
+@font-face {
+  font-family: Sanctuary;
+  src: url("../../public/fonts/SanctuaryLC-Regular.otf");
+}
+
+@font-face {
+  font-family: "Save the Arctic";
+  src: url("../../public/fonts/save-the-arctic.otf");
+}
+
+@font-face {
+  font-family: Jost;
+  src: url("../../public/fonts/Jost-Book.woff") format("woff");
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: Jost;
+  src: url("../../public/fonts/Jost-BookItalic.woff") format("woff");
+  font-weight: normal;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: Jost;
+  src: url("../../public/fonts/Jost-Black.woff") format("woff");
+  font-weight: bold;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: Jost;
+  src: url("../../public/fonts/Jost-BlackItalic.woff") format("woff");
+  font-weight: bold;
+  font-style: italic;
+}
+@import url("https://fonts.googleapis.com/css?family=Montserrat:300,400,500,600,700,800");
+@import url("https://fonts.googleapis.com/css?family=Kanit:400,500,600,800");
+@import url("https://fonts.googleapis.com/css?family=Open+Sans:400,500,600,800");
+@import url("https://fonts.googleapis.com/css?family=Anton:400,500,600,800");
+@import url("https://fonts.googleapis.com/css?family=Amiko:400,500,600,800");

--- a/assets/src/styles/editorStyle.scss
+++ b/assets/src/styles/editorStyle.scss
@@ -32,3 +32,4 @@
 @import "components/ValidationMessage";
 @import "components/FormField";
 @import "components/HTMLSidebarHelp";
+@import "editorFonts";


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6363

---

Previously the logic to set the theme variables was only triggered when the sidebar is open. With this change it's always run on page load because the `CampaignSidebar` component is always created when loading the editor.

Unfortunately the sidebar code still needs cleaning up, so I had to squeeze it into some already complex code. The sidebar needs to be entirely rewritten anyway, because it still uses class components and does some weird stuff, so I guess this can be improved at that point.

To test: With this change you should see the theme applied in the editor when you open a page, regardless of which sidebar is open. There could be a small delay before you see the styles applied.