### PR TITLE
Fix cli command in test for wp-browser update

### DIFF
--- a/tests/acceptance/ENFormCest.php
+++ b/tests/acceptance/ENFormCest.php
@@ -127,7 +127,7 @@ class ENFormCest {
 
 		// Set dummy engaging networks api keys.
 		codecept_debug( 'Setting engaging networks api dummy keys' );
-		$I->cli( [ 'option', 'update', '--allow-root', 'p4en_main_settings', '{"p4en_private_api": "11119999"}', '--format=json' ] );
+		$I->cli( [ 'option', 'update', '--allow-root', 'p4en_main_settings', escapeshellarg('{"p4en_private_api": "11119999"}'), '--format=json' ] );
 	}
 
 	/**
@@ -159,27 +159,27 @@ class ENFormCest {
 
 		// Set fields transient.
 		$cache_key = 'ens_supporter_fields_response';
-		$supporter = json_encode( $fields_data['supporter'] );
+		$supporter = escapeshellarg( json_encode( $fields_data['supporter'] ) );
 		$I->cli( [ 'cache', 'set', '--allow-root', $cache_key, $supporter, 'transient', '600' ] );
 
 		// Set questions transient.
 		$cache_key = 'ens_supporter_questions_response';
-		$questions = json_encode( $questions_data['questions'] );
+		$questions = escapeshellarg( json_encode( $questions_data['questions'] ) );
 		$I->cli( [ 'cache', 'set', '--allow-root', $cache_key, $questions, 'transient', '600' ] );
 
 		// Set single question transient.
 		$cache_key = 'ens_supporter_question_by_id_response_236734';
-		$question  = json_encode( $question_data['question.236734'] );
+		$question  = escapeshellarg( json_encode( $question_data['question.236734'] ) );
 		$I->cli( [ 'cache', 'set', '--allow-root', $cache_key, $question, 'transient', '600' ] );
 
 		// Set single optin transient.
 		$cache_key = 'ens_supporter_question_by_id_response_3887';
-		$optin     = json_encode( $optin_data['question.3887'] );
+		$optin     = escapeshellarg( json_encode( $optin_data['question.3887'] ) );
 		$I->cli( [ 'cache', 'set', '--allow-root', $cache_key, $optin, 'transient', '600' ] );
 
 		// Set dependancy field optin transient.
 		$cache_key = 'ens_supporter_question_by_id_response_220954';
-		$optin     = json_encode( $dep_optin_data['question.220954'] );
+		$optin     = escapeshellarg( json_encode( $dep_optin_data['question.220954'] ) );
 		$I->cli( [ 'cache', 'set', '--allow-root', $cache_key, $optin, 'transient', '600' ] );
 
 		// Start testing.


### PR DESCRIPTION
To fix an error with the latest version of wp-browser, this argument needs to be escaped.
[`Error: Too many positional arguments: 11119999}`](https://app.circleci.com/pipelines/github/greenpeace/planet4-base/1105/workflows/ab53d2cf-9111-407e-beda-d8eac7cee690/jobs/6561/steps)

This PR comes to fix an issue following https://github.com/greenpeace/planet4-base/pull/145, and has to be merged before the planet4-base one.
This issue appears because we have to update our version of `wp-browser`, to use the one that fixes the dependency issue. This new version has changed its wp-cli dependency https://github.com/lucatume/wp-browser/releases/tag/3.0.0 , which might explain the necessity to escape arguments now.
Acceptance tests, of course, can't pass, because of the wp-browser issue :grimacing: 