### PR TITLE
Fix empty CarouselHeader page crash

### DIFF
--- a/assets/src/blocks/CarouselHeader/deprecated/carouselHeaderV1.js
+++ b/assets/src/blocks/CarouselHeader/deprecated/carouselHeaderV1.js
@@ -20,7 +20,7 @@ export const carouselHeaderV1 = {
     },
   },
   isEligible({ slides }) {
-    return slides.some(slide => typeof slide.header_size !== 'undefined');
+    return slides?.some(slide => typeof slide.header_size !== 'undefined');
   },
   migrate( { slides, ...attributes } ) {
     return {


### PR DESCRIPTION
### Description

Before this fix, adding an empty CarouselHeader block to a page would cause it to crash on reload because the slides attribute was undefined in `carouselHeaderV1`