### PR TITLE
Add RTL css to Submenu block

### DIFF
--- a/assets/src/styles/blocks/Submenu.scss
+++ b/assets/src/styles/blocks/Submenu.scss
@@ -9,7 +9,7 @@ div[data-render="planet4-blocks/submenu"] {
 
   h1,
   h2 {
-    padding-left: 16px;
+    padding-inline-start: 16px;
     color: $grey-60;
     font-family: $roboto;
   }
@@ -100,7 +100,12 @@ div[data-render="planet4-blocks/submenu"] {
     @include medium-and-up {
       float: right;
       max-width: 350px;
-      margin: 0 0 15px 15px;
+      margin-bottom: 16px;
+      margin-inline-start: 16px;
+
+      html[dir="rtl"] & {
+        float: left;
+      }
     }
 
     .submenu-menu {

--- a/assets/src/styles/blocks/SubmenuEditor.scss
+++ b/assets/src/styles/blocks/SubmenuEditor.scss
@@ -18,5 +18,11 @@
     float: none;
     margin-right: 0;
     margin-left: auto;
+
+    html[dir="rtl"] & {
+      float: none;
+      margin-right: auto;
+      margin-left: 0;
+    }
   }
 }


### PR DESCRIPTION
### Description

The sidebar style of the Submenu block should be on the left instead of the right for RTL sites. This commit also updates the margin values to 16px instead of 15px, to be consistent with our new 8px spacing system.

### Testing

Add a Submenu block with the "Short sidebar" style on a relatively long page with headers for it to be displayed (usually Privacy or Copyright pages work fine 👌). Then add dir="rtl" to the `html` element of the page and make sure the block behaves as expected both in the editor and in the frontend.