### PR TITLE
PLANET-6239 Fix block alignment issues in the editor

### DIFF
--- a/assets/src/styles/blocks/SocialMedia/SocialMediaEditorStyle.scss
+++ b/assets/src/styles/blocks/SocialMedia/SocialMediaEditorStyle.scss
@@ -1,0 +1,4 @@
+.social-media-block {
+  display: inline-block;
+  width: 100%;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,6 +83,7 @@ const cssConfig = {
     TimelineStyle: './assets/src/styles/blocks/Timeline/TimelineStyle.scss',
     TimelineEditorStyle: './assets/src/styles/blocks/Timeline/TimelineEditorStyle.scss',
     SocialMediaStyle: './assets/src/styles/blocks/SocialMedia/SocialMediaStyle.scss',
+    SocialMediaEditorStyle: './assets/src/styles/blocks/SocialMedia/SocialMediaEditorStyle.scss',
     CoversStyle: './assets/src/styles/blocks/Covers/CoversStyle.scss',
   },
   output: {


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-6239

Sometimes blocks with alignment overlap in the editor, making it difficult for editors to update them. I've tested all blocks (including the Image one which also has alignment options) and this actually only seems to occur with the SocialMedia block, hence why this PR only fixes this one.

### Testing

On local you can add several SocialMedia blocks in a row on a page, with different alignment values, and make sure that they never overlap in the editor. Otherwise you can check the broken/fixed versions on the test instances:
- [Broken](https://www-dev.greenpeace.org/test-sinope/social-media-wysiwyg-tests/)
- [Fixed](https://www-dev.greenpeace.org/test-rhea/social-media-block-alignment-tests/)