### PR TITLE
Use accurates names for different types of theme settings in UI and code

### DIFF
--- a/assets/src/components/Sidebar/CampaignSidebar.js
+++ b/assets/src/components/Sidebar/CampaignSidebar.js
@@ -6,7 +6,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 import { savePreviewMeta } from '../../saveMetaToPreview';
 import { PostParentLink } from './PostParentLink';
 import { LegacyThemeSettings } from './LegacyThemeSettings';
-import { applyChangesToDom, NewThemeSettings, themeJsonUrl } from './NewThemeSettings';
+import { applyChangesToDom, LocalThemeSettings, themeJsonUrl } from './LocalThemeSettings';
 
 const isLegacy= theme => [
   'default',
@@ -156,7 +156,7 @@ export class CampaignSidebar extends Component {
           title={ __('Campaign Options', 'planet4-blocks-backend') }
         >
           { !!parent && <PostParentLink parent={ parent }/> }
-          { !parent && meta && <NewThemeSettings currentTheme={meta.theme} onChange={ async value => {
+          { !parent && meta && <LocalThemeSettings currentTheme={meta.theme} onChange={ async value => {
             this.handleThemeSwitch('theme', value, meta);
           } }/> }
           { !parent && <LegacyThemeSettings

--- a/assets/src/components/Sidebar/CampaignSidebar.js
+++ b/assets/src/components/Sidebar/CampaignSidebar.js
@@ -5,7 +5,7 @@ import { resolveField } from '../fromThemeOptions/fromThemeOptions';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { savePreviewMeta } from '../../saveMetaToPreview';
 import { PostParentLink } from './PostParentLink';
-import { LegacyThemeSettings } from './LegacyThemeSettings';
+import { ThemeSettings } from './ThemeSettings';
 import { applyChangesToDom, LocalThemeSettings, themeJsonUrl } from './LocalThemeSettings';
 
 const isLegacy= theme => [
@@ -159,7 +159,7 @@ export class CampaignSidebar extends Component {
           { !parent && meta && <LocalThemeSettings currentTheme={meta.theme} onChange={ async value => {
             this.handleThemeSwitch('theme', value, meta);
           } }/> }
-          { !parent && <LegacyThemeSettings
+          { !parent && <ThemeSettings
             theme={ options }
             handleThemeSwitch={ this.handleThemeSwitch }
             isLegacyTheme={isLegacyTheme}

--- a/assets/src/components/Sidebar/CampaignSidebar.js
+++ b/assets/src/components/Sidebar/CampaignSidebar.js
@@ -149,11 +149,11 @@ export class CampaignSidebar extends Component {
         <PluginSidebarMoreMenuItem
           target={ CampaignSidebar.getId() }
           icon={ CampaignSidebar.getIcon() }>
-          Campaign Options
+          { __('Theme Options', 'planet4-blocks-backend') }
         </PluginSidebarMoreMenuItem>
         <PluginSidebar
           name={ CampaignSidebar.getId() }
-          title={ __('Campaign Options', 'planet4-blocks-backend') }
+          title={ __('Theme Options', 'planet4-blocks-backend') }
         >
           { !!parent && <PostParentLink parent={ parent }/> }
           { !parent && meta && <LocalThemeSettings currentTheme={meta.theme} onChange={ async value => {

--- a/assets/src/components/Sidebar/LocalThemeSettings.js
+++ b/assets/src/components/Sidebar/LocalThemeSettings.js
@@ -114,7 +114,7 @@ export const LocalThemeSettings = ({ onChange, currentTheme }) => {
     <SelectControl
       label={ __('Local theme', 'planet4-blocks-backend') }
       title={ __('Choose from one of the themes created on this site (BETA).', 'planet4-blocks-backend') }
-      options={ [{ label: 'Legacy', value: '' }, ...keysAsLabel(serverThemes)] }
+      options={ [{ label: 'None', value: '' }, ...keysAsLabel(serverThemes)] }
       onChange={ setSelectedTheme }
       value={ selectedTheme || '' }
     />

--- a/assets/src/components/Sidebar/LocalThemeSettings.js
+++ b/assets/src/components/Sidebar/LocalThemeSettings.js
@@ -86,7 +86,7 @@ const excludeNewVersions = (themes, [name, theme]) => {
 
 const withoutNewVersionsOfThemes = themes => Object.entries(themes).reduce(excludeNewVersions, {});
 
-export const NewThemeSettings = ({ onChange, currentTheme }) => {
+export const LocalThemeSettings = ({ onChange, currentTheme }) => {
   const [selectedTheme, setSelectedTheme] = useState(currentTheme);
   const {editPost} = useDispatch('core/editor');
   const allServerThemes = useServerThemes();
@@ -109,12 +109,11 @@ export const NewThemeSettings = ({ onChange, currentTheme }) => {
 
   return <div className="components-panel__body is-opened">
     <span>
-      This dropdown contains themes that were created on this instance. It will be empty on production, as these won't
-      have any themes created. Once we confirmed the created themes we add them to below dropdown.
+      { __('Choose from one of the themes created on this site (BETA).', 'planet4-blocks-backend') }
     </span>
     <SelectControl
-      label={ __('New Theme', 'planet4-blocks-backend') }
-      title={ __('Only for reviewing themes, not intended to be 2 drop downs in the final version.', 'planet4-blocks-backend') }
+      label={ __('Local theme', 'planet4-blocks-backend') }
+      title={ __('Choose from one of the themes created on this site (BETA).', 'planet4-blocks-backend') }
       options={ [{ label: 'Legacy', value: '' }, ...keysAsLabel(serverThemes)] }
       onChange={ setSelectedTheme }
       value={ selectedTheme || '' }

--- a/assets/src/components/Sidebar/ThemeSettings.js
+++ b/assets/src/components/Sidebar/ThemeSettings.js
@@ -44,7 +44,7 @@ const themeOptions = [
 
 ];
 
-export const LegacyThemeSettings = props => {
+export const ThemeSettings = props => {
   const {
     handleThemeSwitch,
     theme,


### PR DESCRIPTION
Ref: <!-- Please add a url to the ticket this change is addressing. -->

---

Following name corrections:
- `LegacyThemeSettings` => `ThemeSettings`: These are now not legacy themes anymore, so the previous distinction between both dropdowns does not make sense anymore.
- `NewThemeSettings` => `LocalThemeSettings`: "local" because these themes only exist "locally" on the site in the database.
- More accurate title of "Theme Settings" for the sidebar.