### PR TITLE
Bump use-theme-editor package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2319,9 +2319,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.15.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
-          "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -16924,9 +16924,9 @@
       "dev": true
     },
     "styled-components": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.0.tgz",
-      "integrity": "sha512-bPJKwZCHjJPf/hwTJl6TbkSZg/3evha+XPEizrZUGb535jLImwDUdjTNxXqjjaASt2M4qO4AVfoHJNe3XB/tpQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.1.tgz",
+      "integrity": "sha512-JThv2JRzyH0NOIURrk9iskdxMSAAtCfj/b2Sf1WJaCUsloQkblepy1jaCLX/bYE+mhYo3unmwVSI9I5d9ncSiQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -18316,9 +18316,9 @@
       "dev": true
     },
     "use-theme-editor": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/use-theme-editor/-/use-theme-editor-1.1.1.tgz",
-      "integrity": "sha512-DRGbdn1wznOfDkHDSjAujprgEbcXhlaPCQuRfU+W6thwYQVJ70IJlv4Fv7MTJKgxhzztZ7vG2WyR+HWonhvb1A==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/use-theme-editor/-/use-theme-editor-1.2.4.tgz",
+      "integrity": "sha512-E8ktAgWuYRAIY1Uu0EmY/VKSZ3cDnnJPcAlY36LokMBGdyNA7rvtwP6bI3NLvBQDNHH50g3vmBapkZbU7TE1Eg==",
       "requires": {
         "balanced-match": "^2.0.0",
         "font-picker-react": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "jest-environment-node": "^26.0.1",
     "photoswipe": "^4.1.3",
     "react-dom": "^17.0.2",
-    "use-theme-editor": "^1.1.1"
+    "use-theme-editor": "^1.2.4"
   }
 }


### PR DESCRIPTION
Contains various UI improvements:
* Put property name first.
* Remove "collapse" toggle.
* Allow manual input. For example for non-clickable elements like `.skewed-overlay`.
* More compact controls.
* Fix stored position of editor not being applied on page load,

<img src="https://user-images.githubusercontent.com/7604138/133980610-2947dabb-0c8e-4aaa-8392-366b90e76660.png" width="400">

Changes: https://github.com/Inwerpsel/use-theme-editor/compare/1a2cce6da66958d3962ee9db2d74814626c9dc03..5e84c35dc84c41115dbd680996bbbeae3b6f43ec