### PR TITLE
Prevent rare crash where block is null

### DIFF
--- a/assets/src/BlockEditorValidation.js
+++ b/assets/src/BlockEditorValidation.js
@@ -32,9 +32,8 @@ export const blockEditorValidation = () => {
 
         return results;
       }, [] );
-      if (results.length > 0) {
-        invalidBlocks.push(...results)
-      }
+
+      invalidBlocks.push(...results);
 
       return invalidBlocks;
     }, []);
@@ -42,6 +41,7 @@ export const blockEditorValidation = () => {
 
     const postType = wp.data.select('core/editor').getCurrentPostType();
     let currentlyValid = (0 === invalidBlocks.length);
+
     if ('campaign' === postType) {
       const meta = wp.data.select('core/editor').getEditedPostAttribute('meta');
       const metaValid = !!meta['p4_campaign_name'] && 'not set' !== meta['p4_campaign_name'];

--- a/assets/src/BlockEditorValidation.js
+++ b/assets/src/BlockEditorValidation.js
@@ -14,6 +14,12 @@ export const blockEditorValidation = () => {
 
     const currentMessages = [];
     const invalidBlocks = blocks.reduce( (invalidBlocks, block ) => {
+      // Normally `blocks` contains a valid list of blocks, however it can happen that one of them is `null` in rare
+      // cases. It happened to me once while running with WordPress 5.8.1 and undoing multiple edits. This made the
+      // editor crash while it's trying to access `block.name`.
+      if (!block) {
+        return;
+      }
       const validations = blockValidations[ block.name ] || {};
 
       const results = Object.entries( validations ).reduce( (results, [attrName, validate]) => {


### PR DESCRIPTION
* The editor crashed on this code for me because it received `null` for
the block. It happened on WordPress 5.8, but that could be coincidence.
* I was undoing multiple edits involving a Query Loop block and can't
remember which particular one triggered the crash. Haven't managed to
reproduce the issue.

Ref: No ticket
