### PR TITLE
PLANET-6307 Replace WP 5.8 deprecations

### DIFF
--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -180,36 +180,21 @@ const BETA_CAMPAIGN_BLOCK_TYPES = [
  * @return array of all blocks allowed.
  */
 function set_allowed_block_types( $allowed_block_types, $post ) {
-	// phpcs:disable Squiz.PHP.CommentedOutCode.Found -- allow these comments
+	// https://github.com/WordPress/gutenberg/blob/trunk/lib/blocks.php.
 	$wordpress_blocks = [
 		'core/block',
 		'core/paragraph',
 		'core/heading',
 		'core/image',
-		// 'core/gallery', // functionality replaced by P4 galleries.
 		'core/list',
-		'core/quote', // TODO: Styling or removal.
-		// 'core/audio', // removed, not needed.
-		// 'core/cover', // removed, not needed.
+		'core/quote',
 		'core/file',
-		// 'core/video', // TODO: Decision. Ideally only allow embedded video.
-		// 'core/preformatted', // removed, not needed.
-		// 'core/code', // functionality not needed and not styled.
 		'core/html',
-		'core/table', // TODO: Styling.
-		// 'core/pullquote', // removed, normal quote element is available.
-		// 'core/verse', // removed, not needed, not styled.
-		'core/buttons', // TODO: Styling.
-		// 'core/media-text' // removed, not needed.
-		// 'core/more', // removed, not needed.
-		// 'core/nextpage', // removed, not needed.
-		'core/separator', // TODO: Styling.
+		'core/table',
+		'core/buttons',
+		'core/separator',
 		'core/spacer',
 		'core/shortcode',
-		// 'core/archives', // removed, not needed.
-		// 'core/categories', // removed, not needed.
-		// 'core/latest-comments', // removed, not needed.
-		// 'core/latest-posts', // removed, functionality replaced by P4 article list.
 		'core/group',
 		'core/embed',
 		'core-embed/twitter',
@@ -221,12 +206,8 @@ function set_allowed_block_types( $allowed_block_types, $post ) {
 		'core-embed/spotify',
 		'core-embed/flickr',
 		'core-embed/vimeo',
-		// 'core-embed/animoto', // removed, not needed.
-		// 'core-embed/cloudup', // removed, not needed.
-		// 'core-embed/collegehumor', // removed, not needed.
 		'core-embed/dailymotion',
 		'core-embed/funnyordie',
-		// 'core-embed/hulu', // removed, not needed.
 		'core-embed/imgur',
 		'core-embed/issuu',
 		'core-embed/kickstarter',
@@ -235,18 +216,12 @@ function set_allowed_block_types( $allowed_block_types, $post ) {
 		'core-embed/photobucket',
 		'core-embed/polldaddy',
 		'core-embed/reddit',
-		// 'core-embed/reverbnation', // removed, not needed.
-		// 'core-embed/screencast', // removed, not needed.
 		'core-embed/scribd',
 		'core-embed/slideshare',
-		// 'core-embed/smugmug', // removed, not needed.
 		'core-embed/speaker',
 		'core-embed/ted',
-		// 'core-embed/tumblr', // removed, not needed.
 		'core-embed/videopress',
-		// 'core-embed/wordpress-tv', // removed, not needed.
 	];
-	// phpcs:enable
 
 	$migration_ran = MigrationLog::from_wp_options()->already_ran( M001EnableEnFormFeature::get_id() );
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6307

---

- `block_categories` replaced by `block_categories_all`
- `allowed_block_types` replaced by `allowed_block_types_all`
- `allowed_block_types_all` passes the context, so a minor code change was needed.
- Removed commented blocks, since this outdated anyway. Linked to the upstream codebase.