### PR TITLE
Check version and conditionally use new filter introduced in 5.8

### DIFF
--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -167,8 +167,10 @@ final class Loader {
 		// Set color palette.
 		add_action( 'admin_init', [ $this, 'set_color_palette' ] );
 
+		global $wp_version;
+		$category_filter = version_compare( $wp_version, '5.8', '>=' ) ? 'block_categories_all' : 'block_categories';
 		// Register a block category.
-		add_filter( 'block_categories', [ $this, 'register_block_category' ], 10, 2 );
+		add_filter( $category_filter, [ $this, 'register_block_category' ], 10, 2 );
 		// Provide hook for other plugins.
 		do_action( 'p4gbks_plugin_loaded' );
 	}

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -281,7 +281,24 @@ function set_allowed_block_types( $allowed_block_types, $post ) {
 	return $allowed_block_types;
 }
 
-add_filter( 'allowed_block_types', 'set_allowed_block_types', 10, 2 );
+/**
+ * Allowed block types based on post type
+ *
+ * @param array  $allowed_block_types array of allowed block types.
+ * @param object $context The editor context.
+ *
+ * @return array of all blocks allowed.
+ */
+function set_allowed_block_types_new( $allowed_block_types, $context ) {
+	return set_allowed_block_types( $allowed_block_types, $context->post );
+}
+
+global $wp_version;
+if ( version_compare( $wp_version, '5.8', '>=' ) ) {
+	add_filter( 'allowed_block_types_all', 'set_allowed_block_types_new', 10, 2 );
+} else {
+	add_filter( 'allowed_block_types', 'set_allowed_block_types', 10, 2 );
+}
 
 /**
  * @param array $block the block being rendered.


### PR DESCRIPTION
WordPress was so nice to deprecate a function and only introduce the alternative within the same version. To be able to fix the notice in advance, the code needs to be written to check the WP version and add the appropriate filter.