### PR TITLE
Remove button block edit component override

### DIFF
--- a/assets/src/BlockFilters.js
+++ b/assets/src/BlockFilters.js
@@ -57,7 +57,6 @@ const addButtonBlockFilter = () => {
       newAttributes.className = Object.assign({ default: "is-style-secondary" }, newAttributes.className);
 
       lodash.assign( settings, {
-        edit: P4ButtonEdit,
         attributes: newAttributes,
         styles: p4ButtonStyle,
       } );


### PR DESCRIPTION
* Maybe temporarily to make this branch work, but we should remove this.
Every core upgrade can will fail in an unexpected way, and someone (not
necessarily the person who created the override) will not be able to
implement his feature and needs to search within hundreds of lines of
code to see what's not working anymore.

Ref: <!-- Please add a url to the ticket this change is addressing. -->

---

<!--
Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
