### PR TITLE
PLANET-6225 Fix source maps for generated CSS variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1832,27 +1832,12 @@
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "@greenpeace/dashdash": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@greenpeace/dashdash/-/dashdash-1.1.1.tgz",
-      "integrity": "sha512-bFMEtgXBxFTj5Ls3A2GqYn5lu8Cbb+RaN0cIIHv6mgEHcZ1HRDJROud6dHGhcIkdPN+M2cAymr+4MC4t2Q7MVg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@greenpeace/dashdash/-/dashdash-1.1.2.tgz",
+      "integrity": "sha512-C/GyGPfK38xMISQf9vLxg7ffXSv8CiQltGyM5wU/EApvr+p3tOhtIP+FtjDGyj0OGFp11iPRnB15HHAtVGfYLw==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.32"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "@icons/material": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/plugin-proposal-nullish-coalescing-operator": "*",
     "@babel/plugin-proposal-optional-chaining": "*",
     "@commitlint/cli": "^12.1.4",
-    "@greenpeace/dashdash": "^1.1.1",
+    "@greenpeace/dashdash": "^1.1.2",
     "@wordpress/components": "^8.3.2",
     "@wordpress/data": "^4.9.2",
     "@wordpress/e2e-test-utils": "^4.5.0",


### PR DESCRIPTION
This was fixed in the package previously, but still needed to be bumped here.

To test, inspect an element that uses variables on any page of the test instance, and control + click on a CSS rule that has a generated variable (in Chrome). This should open the sources panel with the right line for the variable selected.

relevant changes: https://github.com/greenpeace/planet4-dashdash/commit/a265f9d64eaea6e1acbf10c7a0e0fec379e796e3#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R72 
Ref: <!-- Please add a url to the ticket this change is addressing. -->

---

<!--
Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
