### PR TITLE
PLANET-6436 Fix all tag data included in attributes, and prevent notice when closing an unmodified post

### DIFF
--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutBlock.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutBlock.js
@@ -51,10 +51,6 @@ export const registerTakeActionBoxoutBlock = () => registerBlockType(BLOCK_NAME,
       type: 'string',
       default: ''
     },
-    tags: {
-      type: 'array',
-      default: [],
-    },
   },
   edit: TakeActionBoxoutEditor,
   save() {

--- a/classes/blocks/class-takeactionboxout.php
+++ b/classes/blocks/class-takeactionboxout.php
@@ -72,12 +72,6 @@ class TakeActionBoxout extends Base_Block {
 					'imageAlt'         => [
 						'type' => 'string',
 					],
-					'tags'             => [
-						'type'  => 'array',
-						'items' => [
-							'type' => 'object',
-						],
-					],
 				],
 			]
 		);
@@ -97,9 +91,7 @@ class TakeActionBoxout extends Base_Block {
 		if ( empty( $page_id ) ) {
 			$tag_ids = $fields['tag_ids'] ?? '';
 
-			if ( isset( $fields['tags'] ) && ! empty( $fields['tags'] ) ) {
-				$tags = $fields['tags'];
-			} elseif ( empty( $tag_ids ) || 1 !== preg_match( '/^\d+(,\d+)*$/', implode( ' ', $tag_ids ) ) ) {
+			if ( empty( $tag_ids ) ) {
 				$tags = [];
 			} else {
 				// Explode comma separated list of tag ids and get an array of \WP_Terms objects.


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6436 and https://jira.greenpeace.org/browse/PLANET-6437

---
The previous code resulted in the editor immediately having changes just by opening it. That means that when you try to reload that page or close it, you will get a blocking prompt, even if you didn't do any action in the editor.

For a user this is confusing because they have no idea what these changes are, and likely don't see the Take Action Boxout block so can't know why one post has this warning and others don't.

Other issues that will likely be fixed as a byproduct of these changes, or can be done later:
* After querying the tags, the previous code set the entire result data on the block attributes, most of which is not used by the block. If a tag has 10 pages of description, this would be entirely included in the block attributes. Because of the first mentioned issue, this data is inserted the moment you open a post with the block.
![Screenshot from 2021-10-08 16-15-02](https://user-images.githubusercontent.com/7604138/136574724-95dcd086-15d7-4f9b-89f3-6dcd160c04bc.png)

* Only the first 50 tags were selected, which can be problematic in case of many tags.

To test:
[This page](https://www-dev.greenpeace.org/test-pluto/wp-admin/post.php?post=30300&action=edit) was created with the old version. You can open the editor and close it without getting a prompt.

If you add a new block with tags, or change an existing block's tags, this should only store the ids of the tags.