### PR TITLE
Fix JS linter grep command return

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ jobs:
           when: always
           # For now lint only changed files to avoid bulk fixing.
           command: |
-            changed_files=$(git diff --name-only master...HEAD public/js tests/js assets/src | grep "\.js$")
+            changed_files=$(git diff --name-only master...HEAD -- {public/js,tests/js,assets/src}/**/*.js)
             echo "Changed files:"
             echo $changed_files | tr " " "\n"
             if [ -z "$changed_files" ]; then exit 0; fi


### PR DESCRIPTION
`grep` command can return code 1 on empty result, this seems to [make the CI fail](https://app.circleci.com/pipelines/github/greenpeace/planet4-plugin-gutenberg-blocks/5178/workflows/b4adbd56-e527-4ca5-b064-2c654a71636e/jobs/22006).
Replacing it with a glob in the `git diff` command should work.