### PR TITLE
Remove PHP 7.3 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,6 @@ orbs:
 workflows:
   branch:
     jobs:
-      - php73-tests:
-          context: org-global
       - php74-tests:
           context: org-global
       - frontend-tests:
@@ -184,16 +182,6 @@ commands:
           path: planet4-docker-compose/artifacts
 
 jobs:
-  php73-tests:
-    <<: *php_job
-    docker:
-      - image: greenpeaceinternational/p4-unit-tests:php7.3
-        auth:
-          <<: *docker_auth
-      - image: circleci/mysql:5.7.26
-        auth:
-          <<: *docker_auth
-
   php74-tests:
     <<: *php_job
     docker:


### PR DESCRIPTION
Version 7.3 is not used anymore, we moved to 7.4 since https://jira.greenpeace.org/browse/PLANET-6306