### PR TITLE
PLANET-5798 Align Articles block links with design system

### DIFF
--- a/assets/src/styles/blocks/Articles.scss
+++ b/assets/src/styles/blocks/Articles.scss
@@ -25,10 +25,6 @@
       margin-top: 0;
     }
   }
-
-  a {
-    color: inherit;
-  }
 }
 
 .article-list-item-image-max-width {
@@ -89,27 +85,39 @@
   }
 }
 
-.article-list-item-headline --block-articles--article--headline-- {
-  font-weight: 500;
-  color: $grey-80;
-  margin: 4px 0;
-}
-
-.article-list-item-meta --block-articles--article--meta-- {
-  color: $grey-60;
-  font-family: $roboto;
-  font-style: italic;
-  font-size: 0.875rem;
-  font-weight: 300;
-  margin: 0;
-
-  &:hover {
-    color: $grey-60;
+.article-list-item-headline {
+  --block-articles--article--headline-- {
+    font-weight: 500;
+    color: $grey-80;
+    margin: 4px 0;
   }
 
-  @include large-and-up {
-    font-size: 0.9375rem;
-    width: 80%;
+  a {
+    color: inherit;
+  }
+}
+
+.article-list-item-meta {
+  --block-articles--article--meta-- {
+    color: $grey-60;
+    font-family: $roboto;
+    font-style: italic;
+    font-size: 0.875rem;
+    font-weight: 300;
+    margin: 0;
+
+    &:hover {
+      color: $grey-60;
+    }
+
+    @include large-and-up {
+      font-size: 0.9375rem;
+      width: 80%;
+    }
+  }
+
+  a {
+    color: inherit;
   }
 }
 


### PR DESCRIPTION
### Description

See [PLANET-5798](https://jira.greenpeace.org/browse/PLANET-5798)

Related PR: [master-theme](https://github.com/greenpeace/planet4-master-theme/pull/1494)

I had to remove the `color: inherit;` that we had applied to all links in the Articles block, for its breadcrumbs to get the expected link colors and behaviour described in the ticket. However we still need that `inherit` for the title and meta links of the block so that they don't get affected by our generic link rules and states.

### Testing

You can see the changes on the test-phobos instance, for example:
- The Articles block on the [homepage](https://www-dev.greenpeace.org/test-phobos/)
- The contextual navigation links on these different pages:
  - [Post](https://www-dev.greenpeace.org/test-phobos/story/43455/reimagine-a-better-city-economics-covid-pandemic/)
  - [Act page](https://www-dev.greenpeace.org/test-phobos/act/forests-are-life/)
  - [Tag page](https://www-dev.greenpeace.org/test-phobos/tag/energy-revolution/)
  - [Issue page](https://www-dev.greenpeace.org/test-phobos/explore/nature/) (I think? 😅)
  - I couldn't find an Evergreen page 🤔 