### PR TITLE
PLANET-6453 Remove editor image rule that broke centering

### DIFF
--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -60,7 +60,3 @@
     text-align: right;
   }
 }
-
-figure.wp-block-image {
-  display: inline-block;
-}


### PR DESCRIPTION
* Still need to find if this is needed for some reason. If I remove it
then images center nicely again.

Ref: https://jira.greenpeace.org/browse/PLANET-6453