### PR TITLE
Upgrade to Boostrap 5.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4988,9 +4988,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "5.0.0-beta2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.0-beta2.tgz",
-      "integrity": "sha512-e+uPbPHqTQWKyCX435uVlOmgH9tUt0xtjvyOC7knhKgOS643BrQKuTo+KecGpPV7qlmOyZgCfaM4xxPWtDEN/g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
+      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
       "dev": true
     },
     "brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@wordpress/e2e-test-utils": "^4.5.0",
     "@wordpress/scripts": "3.3.0",
     "autoprefixer": "^9.7.0",
-    "bootstrap": "^5.0.0-beta2",
+    "bootstrap": "^5.1.3",
     "core-js": "^3.6.5",
     "css-loader": "^3.2.0",
     "eslint-plugin-react": "^7.20.3",


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6272

---

Counterpart of https://github.com/greenpeace/planet4-master-theme/pull/1498. [Visual regression tests](https://998-343690477-gh.circle-artifacts.com/0/app/backstop_data/html_report/index.html) after plugin is also deployed in the same instance.