### PR TITLE
PLANET-5797 Align standalone links with the design system

### DIFF
--- a/assets/src/blocks/Columns/Columns.js
+++ b/assets/src/blocks/Columns/Columns.js
@@ -75,7 +75,7 @@ export const Columns = ({ columns, columns_block_style, isCampaign, isExample = 
                 href={cta_link}
                 className={isCampaign || columns_block_style === LAYOUT_NO_IMAGE ?
                   `btn btn-${isCampaign ? 'primary' : 'secondary'}` :
-                  'call-to-action-link'
+                  'standalone-link'
                 }
                 data-ga-category='Columns Block'
                 data-ga-action='Call to Action'

--- a/assets/src/blocks/Columns/EditableColumns.js
+++ b/assets/src/blocks/Columns/EditableColumns.js
@@ -137,7 +137,7 @@ export const EditableColumns = ({
               tagName='div'
               className={isCampaign || [LAYOUT_NO_IMAGE, LAYOUT_TASKS].includes(columns_block_style) ?
                 `btn btn-${isCampaign ? 'primary' : 'secondary'}` :
-                'call-to-action-link'
+                ''
               }
               placeholder={[LAYOUT_NO_IMAGE, LAYOUT_TASKS].includes(columns_block_style) ?
                 __('Enter column button text', 'planet4-blocks-backend') :

--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -143,10 +143,6 @@
         --block-columns--link-- {
           font-family: $roboto;
         }
-
-        &.call-to-action-link {
-          position: relative;
-        }
       }
 
       .attachment-container {
@@ -395,10 +391,6 @@
 
       a {
         font-family: $roboto;
-
-        &.call-to-action-link {
-          position: relative;
-        }
       }
 
       .attachment-container {

--- a/tests/acceptance/ColumnsIconsCept.php
+++ b/tests/acceptance/ColumnsIconsCept.php
@@ -43,4 +43,4 @@ $I->see('Columns Block description', 'div');
 $I->see('Column 1', 'h3 > a');
 $I->see('Column 1 description', '.column-wrap p');
 $I->seeElement('.attachment-container a img');
-$I->see('Explore', '.column-wrap a.call-to-action-link');
+$I->see('Explore', '.column-wrap a.standalone-link');

--- a/tests/acceptance/ColumnsImagesCept.php
+++ b/tests/acceptance/ColumnsImagesCept.php
@@ -49,12 +49,12 @@ $I->see( 'Images Column Block description', '.block-style-image > div > div' );
 $I->see( 'Column 1', 'h3 > a' );
 $I->see( 'Column 1 description', '.column-wrap p' );
 $I->seeElement( '.attachment-container > a > img' );
-$I->see( 'Act', 'div:nth-child(1) > a.call-to-action-link' );
+$I->see( 'Act', 'div:nth-child(1) > a.standalone-link' );
 // Open in new tab setting.
-$I->canSeeElement( 'div:nth-child(1) > a.call-to-action-link', [ 'target' => '_blank' ] );
+$I->canSeeElement( 'div:nth-child(1) > a.standalone-link', [ 'target' => '_blank' ] );
 
 // Column 2.
 $I->see( 'Column 2', 'h3 > a' );
 $I->see( 'Column 2 description', '.column-wrap p' );
 $I->seeElement( '.attachment-container > a > img' );
-$I->see( 'Explore', 'a.call-to-action-link' );
+$I->see( 'Explore', 'a.standalone-link' );


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-5797

I've also changed the class name to `standalone-link` rather than `call-to-action-link` since I think it makes more sense.

Related PR: [master-theme](https://github.com/greenpeace/planet4-master-theme/pull/1503)

### Testing

On local, you can add a Columns block and test the standalone links in Icons and Images styles. Or you can check out [this page](https://www-dev.greenpeace.org/test-uranus/standalone-links-tests/) I made for UAT 🙂 