### PR TITLE
Allow picking campaign pages in TAB block

### DIFF
--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -44,15 +44,21 @@ export const TakeActionBoxoutEditor = ({
   } = attributes;
 
   const actPageList = useSelect(select => {
-    const args = {
+    const commonArgs = {
       per_page: -1,
       sort_order: 'asc',
       sort_column: 'post_title',
-      parent: window.p4ge_vars.planet4_options.act_page,
       post_status: 'publish',
     };
+    const actArgs = {
+      ...commonArgs,
+      parent: window.p4ge_vars.planet4_options.act_page,
+    };
 
-    return select('core').getEntityRecords('postType', 'page', args) || [];
+    const actPages = select('core').getEntityRecords('postType', 'page', actArgs) || [];
+    const campaignPages = select('core').getEntityRecords('postType', 'campaign', commonArgs) || [];
+
+    return [...actPages, ...campaignPages];
   }, []);
 
   const tagsList = useSelect(select => {
@@ -96,7 +102,7 @@ export const TakeActionBoxoutEditor = ({
     imageAlt: alt_text,
   });
 
-  const actPageOptions = actPageList.map(actPage => ({ label: actPage.title.raw, value: actPage.id }));
+  const actPageOptions = actPageList.map(actPage => ({ label: actPage.title?.raw || actPage.id, value: actPage.id }));
 
   const renderEditInPlace = () => (takeActionPageSelected ?
     <TakeActionBoxoutFrontend {...{tags}} {...attributes} /> :


### PR DESCRIPTION
* Because people end up wanting to use those anyway. But because the
block is hard coded to work with a very specific type of pages, they end
up needing a workaround of entering the data manually and saving as a
reusable block. That doesn't work well because of how the block is
implemented.
* This does not need any other changes to work.

**ATTENTION** The test instance this was deployed to apparently already has a branch with other changes for master theme. Normally this shouldn't happen so it indicates an issue in our test instance deployments. But the changes should not interfere with these changes so testing is still possible. Just be aware it doesn't have the take action page selector option.

Ref: <!-- Please add a url to the ticket this change is addressing. -->

---

<!--
Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
