### PR TITLE
PLANET-6455 Ensure boxout always scrolls

### DIFF
--- a/public/js/post_action.js
+++ b/public/js/post_action.js
@@ -4,7 +4,7 @@ jQuery(($) => {
   'use strict';
 
   const $post = $('.post-content');
-  const $boxout = $post.find('> #action-card').not('.action-card-bottom, .action-card-scroll');
+  const $boxout = $post.find('#action-card');
   const offset = $boxout.offset();
   const topPadding = 100;
 


### PR DESCRIPTION
* Remove direct descendant selector as there's just one item with that
ID.
* Remove extra classes check which was only needed for an AB test.

Ref: https://jira.greenpeace.org/browse/PLANET-6455
