### PR TITLE
PLANET-6460 Use click to ensure keyboard accessibility on Covers load more

### DIFF
--- a/public/js/load_more.js
+++ b/public/js/load_more.js
@@ -1,6 +1,6 @@
 jQuery(($) => {
   // Add click event for load more button in Covers blocks.
-  $('.btn-load-more-posts-click').on('mouseup touchend', function (e) {
+  $('.btn-load-more-posts-click').on('click', function (e) {
     e.preventDefault();
 
     const $row = $('.post-column:hidden', $(this).closest('.container'));
@@ -26,7 +26,7 @@ jQuery(($) => {
   });
 
   // Add click event for load more button in Covers blocks.
-  $('.btn-load-more-covers-click').on('mouseup touchend', function (e) {
+  $('.btn-load-more-covers-click').on('click', function (e) {
     e.preventDefault();
 
     const $row = $('.cover-card-column:hidden', $(this).closest('.container'));


### PR DESCRIPTION
* The previous mouseup and touchend events do not fire when enter or
space is pressed on the focused button.
* Click still works for the previous, and also for keyboard.

I found this while working on the focus states for buttons. Technically it's not needed to fulfill that ticket, however it makes little sense to be able to focus a non working button.

Ref: https://jira.greenpeace.org/browse/PLANET-6460