### PR TITLE
Fix display and focus of Articles image link

### DIFF
--- a/assets/src/blocks/Articles/ArticlePreview.js
+++ b/assets/src/blocks/Articles/ArticlePreview.js
@@ -70,7 +70,7 @@ export class ArticlePreview extends Component {
         data-ga-action="Image"
         data-ga-label="n/a">
           <img
-            className="d-flex topicwise-article-image"
+            className="topicwise-article-image"
             src={thumbnail_url}
             srcSet={thumbnail_srcset || null}
             alt={alt_text}

--- a/assets/src/styles/blocks/Articles.scss
+++ b/assets/src/styles/blocks/Articles.scss
@@ -57,6 +57,10 @@
 .article-list-item-image {
   order: 2;
 
+  a {
+    display: block;
+  }
+
   img {
     width: 100% !important;
     object-fit: cover;


### PR DESCRIPTION
ATTENTION: The focus state on the [test instance](https://www-dev.greenpeace.org/test-pandora/) still causes layout jumps, which is being addressed in https://github.com/greenpeace/planet4-master-theme/pull/1500/files

* `d-flex` is not needed and broke the display of the link around it.
* Ensure focus around image nicely uses the borders. Without block there
was a protrusion caused by the link being wider but narrower than the
image it contains.

<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
