### PR TITLE
PLANET-6464 Remove highly specific text color rule on boxout that caused regression in GPNL child theme

### DIFF
--- a/assets/src/styles/blocks/Covers/layouts/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/layouts/TakeActionCovers.scss
@@ -24,10 +24,6 @@
 
   &.action-card {
     margin-bottom: $space-lg;
-
-    .cover-card-heading {
-      color: $white;
-    }
   }
 
   &:hover {

--- a/assets/src/styles/blocks/OldCovers/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/OldCovers/TakeActionCovers.scss
@@ -168,10 +168,6 @@
 
   &.action-card {
     margin-bottom: $space-lg;
-
-    .cover-card-heading {
-      color: $white;
-    }
   }
 
   & > * {


### PR DESCRIPTION
* This caused a regression on GPNL, where it started overriding their
child theme rule.

Ref: https://jira.greenpeace.org/browse/PLANET-6464

![Screenshot from 2021-11-05 11-19-26](https://user-images.githubusercontent.com/7604138/140499213-7a78a27e-5e70-4d94-acd2-df01c8185f77.png)
