### PR TITLE
Add Carousel indicator color variable in repo where it's used

### DIFF
--- a/assets/src/styles/blocks/Gallery_carousel.scss
+++ b/assets/src/styles/blocks/Gallery_carousel.scss
@@ -1,3 +1,5 @@
+$carousel-indi-color: #8bcc49;
+
 .carousel-wrap {
   overflow: hidden;
 


### PR DESCRIPTION
* This was first in master theme, and removed there but the PR was
merged too early, which breaks stuff in master. Instead we can add it
back in its only usage and we won't need another master theme PR.


see https://github.com/greenpeace/planet4-master-theme/pull/1506
<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
