### PR TITLE
PLANET-6091 Align blocks with page width

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -20,21 +20,17 @@ export const CarouselControls = ({
     {/* Indicators */}
     <div className='carousel-indicators-wrapper'>
       <div className='container'>
-        <div className='row'>
-          <div className='col'>
-            <ol className='carousel-indicators'>
-              {
-                slides.map((slide, index) =>
-                  <li
-                    onClick={() => goToSlide(index)}
-                    key={index}
-                    className={index === currentSlide ? 'active' : ''}
-                  ></li>
-                )
-              }
-            </ol>
-          </div>
-        </div>
+        <ol className='carousel-indicators'>
+          {
+            slides.map((slide, index) =>
+              <li
+                onClick={() => goToSlide(index)}
+                key={index}
+                className={index === currentSlide ? 'active' : ''}
+              ></li>
+            )
+          }
+        </ol>
       </div>
     </div>
   </>

--- a/assets/src/blocks/Columns/ColumnsFrontend.js
+++ b/assets/src/blocks/Columns/ColumnsFrontend.js
@@ -47,12 +47,12 @@ export const ColumnsFrontend = ({ columns_block_style, columns_title, columns_de
         {columns_description &&
           <div className='page-section-description' dangerouslySetInnerHTML={{ __html: columns_description }} />
         }
+        <Columns
+          columns_block_style={columns_block_style}
+          columns={columns}
+          isCampaign={postType === 'campaign'}
+        />
       </div>
-      <Columns
-        columns_block_style={columns_block_style}
-        columns={columns}
-        isCampaign={postType === 'campaign'}
-      />
     </section>
   );
 }

--- a/assets/src/blocks/Gallery/GalleryEditor.js
+++ b/assets/src/blocks/Gallery/GalleryEditor.js
@@ -124,30 +124,32 @@ const renderView = (attributes, setAttributes) => {
 
   return (
     <section className={`block ${GALLERY_BLOCK_CLASSES[layout]} ${className ?? ''}`}>
-      <header className="articles-title-container">
+      <div className='container'>
+        <header className="articles-title-container">
+          <RichText
+            tagName="h2"
+            className="page-section-header"
+            placeholder={__('Enter title', 'planet4-blocks-backend')}
+            value={gallery_block_title}
+            onChange={toAttribute('gallery_block_title')}
+            withoutInteractiveFormatting
+            multiline="false"
+            allowedFormats={[]}
+          />
+        </header>
         <RichText
-          tagName="h2"
-          className="page-section-header"
-          placeholder={__('Enter title', 'planet4-blocks-backend')}
-          value={gallery_block_title}
-          onChange={toAttribute('gallery_block_title')}
+          tagName="p"
+          className="page-section-description"
+          placeholder={__('Enter description', 'planet4-blocks-backend')}
+          value={gallery_block_description}
+          onChange={toAttribute('gallery_block_description')}
           withoutInteractiveFormatting
-          multiline="false"
-          allowedFormats={[]}
+          allowedFormats={['core/bold', 'core/italic']}
         />
-      </header>
-      <RichText
-        tagName="p"
-        className="page-section-description"
-        placeholder={__('Enter description', 'planet4-blocks-backend')}
-        value={gallery_block_description}
-        onChange={toAttribute('gallery_block_description')}
-        withoutInteractiveFormatting
-        allowedFormats={['core/bold', 'core/italic']}
-      />
-      {layout === 'slider' && <GalleryCarousel images={images || []} isEditing />}
-      {layout === 'three-columns' && <GalleryThreeColumns images={images || []} postType={postType} />}
-      {layout === 'grid' && <GalleryGrid images={images || []} />}
+        {layout === 'slider' && <GalleryCarousel images={images || []} isEditing />}
+        {layout === 'three-columns' && <GalleryThreeColumns images={images || []} postType={postType} />}
+        {layout === 'grid' && <GalleryGrid images={images || []} />}
+      </div>
     </section>
   );
 }

--- a/assets/src/blocks/Gallery/GalleryFrontend.js
+++ b/assets/src/blocks/Gallery/GalleryFrontend.js
@@ -31,20 +31,22 @@ export const GalleryFrontend = ({
 
   return (
     <section className={`block ${GALLERY_BLOCK_CLASSES[layout]} ${className ?? ''}`}>
-      {gallery_block_title &&
-        <header>
-          <h2 className="page-section-header" dangerouslySetInnerHTML={{ __html: gallery_block_title }} />
-        </header>
-      }
+      <div className='container'>
+        {gallery_block_title &&
+          <header>
+            <h2 className="page-section-header" dangerouslySetInnerHTML={{ __html: gallery_block_title }} />
+          </header>
+        }
 
-      {gallery_block_description &&
-        <div className="page-section-description" dangerouslySetInnerHTML={{ __html: gallery_block_description }} />
-      }
-      {layout === 'slider' && <GalleryCarousel onImageClick={openLightbox} images={images || []} />}
-      {layout === 'three-columns' && <GalleryThreeColumns onImageClick={openLightbox} images={images || []} postType={postType} />}
-      {layout === 'grid' && <GalleryGrid onImageClick={openLightbox} images={images || []} />}
+        {gallery_block_description &&
+          <div className="page-section-description" dangerouslySetInnerHTML={{ __html: gallery_block_description }} />
+        }
+        {layout === 'slider' && <GalleryCarousel onImageClick={openLightbox} images={images || []} />}
+        {layout === 'three-columns' && <GalleryThreeColumns onImageClick={openLightbox} images={images || []} postType={postType} />}
+        {layout === 'grid' && <GalleryGrid onImageClick={openLightbox} images={images || []} />}
 
-      <Lightbox isOpen={isOpen} index={index} items={items} onClose={closeLightbox} />
+        <Lightbox isOpen={isOpen} index={index} items={items} onClose={closeLightbox} />
+      </div>
     </section>
   );
 }

--- a/assets/src/blocks/Gallery/GalleryGrid.js
+++ b/assets/src/blocks/Gallery/GalleryGrid.js
@@ -1,24 +1,22 @@
 import { IMAGE_SIZES } from './imageSizes';
 
 export const GalleryGrid = ({ images, onImageClick }) => (
-  <div className="container">
-    <div className="grid-row">
-      {images.map((image, index) => (
-        <div key={image.image_src} className="grid-item">
-          <img
-            loading='lazy'
-            src={image.image_src}
-            srcSet={image.image_srcset}
-            sizes={IMAGE_SIZES.grid}
-            style={{ objectPosition: image.focus_image }}
-            alt={image.alt_text}
-            title={image.alt_text}
-            onClick={() => {
-              onImageClick(index);
-            }}
-          />
-        </div>
-      ))}
-    </div>
+  <div className="grid-row">
+    {images.map((image, index) => (
+      <div key={image.image_src} className="grid-item">
+        <img
+          loading='lazy'
+          src={image.image_src}
+          srcSet={image.image_srcset}
+          sizes={IMAGE_SIZES.grid}
+          style={{ objectPosition: image.focus_image }}
+          alt={image.alt_text}
+          title={image.alt_text}
+          onClick={() => {
+            onImageClick(index);
+          }}
+        />
+      </div>
+    ))}
   </div>
 );

--- a/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
+++ b/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
@@ -318,10 +318,7 @@ $medium-image-height: 600px;
       position: relative;
       top: 0;
       left: 0;
-      padding-top: 24px;
-      padding-bottom: 24px;
-      padding-left: 24px;
-      padding-right: 24px;
+      padding: 16px;
       background: $white;
       height: auto;
       width: 100%;
@@ -332,8 +329,6 @@ $medium-image-height: 600px;
 
       @include medium-and-up {
         padding-top: $n40;
-        padding-left: $n40;
-        padding-right: $n40;
       }
 
       @include large-and-up {
@@ -388,14 +383,13 @@ $medium-image-height: 600px;
         width: 100%;
 
         @include large-and-up {
-          padding-inline-start: 80px;
           padding-top: 180px;
           padding-bottom: 32px;
+          margin-inline-start: 80px;
         }
 
         @include x-large-and-up {
-          padding-bottom: 54px;
-          padding-inline-start: 0;
+          margin-inline-start: auto;
         }
 
         h1 {
@@ -627,6 +621,14 @@ $medium-image-height: 600px;
     bottom: 0;
     z-index: 3000;
 
+    @include large-and-up {
+      margin-inline-start: 80px;
+    }
+
+    @include x-large-and-up {
+      margin-inline-start: auto;
+    }
+
     .carousel-indicators {
       display: block;
       position: relative;
@@ -651,15 +653,10 @@ $medium-image-height: 600px;
         padding-right: 0;
         width: auto;
         display: block;
-        padding-inline-start: 80px;
 
         html[dir="rtl"] & {
           text-align: right;
         }
-      }
-
-      @include x-large-and-up {
-        padding-inline-start: 0;
       }
 
       li {

--- a/assets/src/styles/blocks/Gallery/styles/GalleryCarousel.scss
+++ b/assets/src/styles/blocks/Gallery/styles/GalleryCarousel.scss
@@ -44,6 +44,10 @@
       height: 665px;
     }
 
+    @include xx-large-and-up {
+      height: 765px;
+    }
+
     .carousal-item-credit {
       position: absolute;
       right: 0;
@@ -77,6 +81,10 @@
 
       @include x-large-and-up {
         height: 600px;
+      }
+
+      @include xx-large-and-up {
+        height: 700px;
       }
     }
   }
@@ -131,6 +139,10 @@
       top: 580px;
     }
 
+    @include xx-large-and-up {
+      top: 680px;
+    }
+
     li {
       width: 40px;
       height: 3px;
@@ -171,6 +183,10 @@
 
     @include x-large-and-up {
       top: 290px;
+    }
+
+    @include xx-large-and-up {
+      top: 340px;
     }
   }
 


### PR DESCRIPTION
### Description

See [PLANET-6091](https://jira.greenpeace.org/browse/PLANET-6091)

- There used to be a small width difference between the CarouselHeader slides content and the rest of the page content.
- The Columns block also used to be slightly different because its content was put outside of the `container` div.
- The Gallery block was missing the `container` block.

We also need to update the donation pages, there is another [PR](https://github.com/greenpeace/planet4-en-petitions/pull/8) for that.

Main PR: [master-theme](https://github.com/greenpeace/planet4-master-theme/pull/1508)

### Testing

You can test the changes on this [test instance](https://www-dev.greenpeace.org/test-jupiter/) or on local.