### PR TITLE
PLANET-6430: Carousel Header - CTA button is not editable in Safari

### DIFF
--- a/assets/src/blocks/CarouselHeader/Caption.js
+++ b/assets/src/blocks/CarouselHeader/Caption.js
@@ -28,25 +28,15 @@ export const Caption = ({ slide, index, changeSlideAttribute }) => (
           </div>
 
           <div className='col-xs-12 col-sm-8 col-md-4 action-button'>
-            <a href={slide.link_url}
-              target={slide.link_url_new_tab ? '_blank' : '_self'}
+            <RichText
+              tagName='div'
               className='btn btn-primary btn-block'
-              data-ga-category='Carousel Header'
-              data-ga-action='Call to Action'
-              rel='noopener noreferrer'
-              data-ga-label={slide.index}
-              onClick={e => e.preventDefault()}
-            >
-              <RichText
-                tagName='span'
-                className=''
-                placeholder={__('Enter CTA text', 'planet4-blocks-backend')}
-                value={slide.link_text}
-                onChange={changeSlideAttribute('link_text', index)}
-                withoutInteractiveFormatting
-                allowedFormats={[]}
-              />
-            </a>
+              placeholder={__('Enter CTA text', 'planet4-blocks-backend')}
+              value={slide.link_text}
+              onChange={changeSlideAttribute('link_text', index)}
+              withoutInteractiveFormatting
+              allowedFormats={[]}
+            />
           </div>
         </div>
       </div>

--- a/assets/src/styles/blocks/CarouselHeader/CarouselHeaderEditorStyle.scss
+++ b/assets/src/styles/blocks/CarouselHeader/CarouselHeaderEditorStyle.scss
@@ -110,3 +110,8 @@
     padding-inline-start: 110px;
   }
 }
+
+// Fix Safari issue with forced min-width:1px in editor
+.carousel-header .carousel-item .carousel-caption .main-header .action-button div.btn {
+  overflow: initial;
+}

--- a/assets/src/styles/blocks/SplitTwoColumnsEditor.scss
+++ b/assets/src/styles/blocks/SplitTwoColumnsEditor.scss
@@ -16,3 +16,8 @@
 .block-editor .split-two-column a {
   pointer-events: auto;
 }
+
+// Fix Safari issue with forced min-width:1px in editor
+.split-two-column-item-button {
+  overflow: initial;
+}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6430

> Seems like for the folks on macs the button label on the carousel block is not editable in Safari

Change editable button to a div so that Safari issues on links related to pointer events and user selection can't happen.
Change overflow strategy to limit the ellipsis effect in the editor.

## Test

You need __Safari on MacOS__ to test this issue.
Has to be tested with https://github.com/greenpeace/planet4-master-theme/pull/1510


- Edit a page, add a Carousel header, try to edit the CTA button text:
  - On main branch, clicking on the CTA button doesn't have any effect,
  - With this branch, a click makes a caret appear and text is editable.
