### PR TITLE
Update to default if dependency has no options

### DIFF
--- a/assets/src/components/fromThemeOptions/fromThemeOptions.js
+++ b/assets/src/components/fromThemeOptions/fromThemeOptions.js
@@ -68,6 +68,10 @@ export const getDependencyUpdates = ( theme, fieldName, value, meta ) => {
         return typeof meta[ field.id  ] !== 'undefined'
       }
 
+      if (!configuration.options) {
+        return true;
+      }
+
       return !(configuration.options.some(option => option.value === meta[ field.id ] ));
     }
   );


### PR DESCRIPTION
* This way we can show a single option in the sidebar, but have it
result in multiple variables changing.

I made this to allow a [POC for master theme](https://github.com/greenpeace/planet4-master-theme/pull/1518), but it can be merged since it doesn't conflict with anything. Before this change the code would just crash if there are no options.