### PR TITLE
Fine tune Carousel Header slide re-ordering design and UX

### DIFF
--- a/assets/src/blocks/CarouselHeader/SidebarSlide.js
+++ b/assets/src/blocks/CarouselHeader/SidebarSlide.js
@@ -1,9 +1,11 @@
 import {
-  SelectControl,
+  PanelRow,
+  PanelBody,
   FocalPointPicker,
   CheckboxControl,
 } from '@wordpress/components';
 import { URLInput } from '../../components/URLInput/URLInput';
+import { useState, useEffect } from 'react';
 const { __ } = wp.i18n;
 
 export const SidebarSlide = ({
@@ -12,8 +14,18 @@ export const SidebarSlide = ({
   link_url_new_tab,
   index,
   image_url,
+  image_alt,
+  image_srcset,
+  isLastItem,
+  header,
   changeSlideAttribute,
+  onDragStartHandler,
+  onDragEndHandler,
+  onDragOverHandler,
+  upOrDownHandler,
+  goToSlideHandler,
 }) => {
+  const [ isOpened, setIsOpened ] = useState(false);
 
   const onFocalPointsChange = (index, value) => {
     let focalPoints = null;
@@ -23,45 +35,103 @@ export const SidebarSlide = ({
     changeSlideAttribute('focal_points', index)(focalPoints);
   }
 
+  const onToggleHandler = (opened) => {
+    setIsOpened(opened);
+  }
+
+  useEffect(() => {
+    if(isOpened) {
+      goToSlideHandler(index);
+    }
+  }, [ isOpened ]);
+
   return (
-    <>
-      <div className='carousel-header-slide-container'>
-        <div className='carousel-header-slide-options-wrapper'>
-          <div className='row'>
-            <div className='col'>
-              <URLInput
-                label={__('Url for link', 'planet4-blocks-backend')}
-                value={link_url}
-                onChange={changeSlideAttribute('link_url', index)}
-              />
+    <div
+      className={`sidebar-slide ${isOpened ? 'opened-slide' : ''}`}
+      data-index={index}
+      draggable={!isOpened}
+      onDragStart={onDragStartHandler}
+      onDragEnd={onDragEndHandler}
+      onDragOver={onDragOverHandler}
+    >
+      <PanelBody
+        key={ index }
+        initialOpen={ isOpened }
+        onToggle={onToggleHandler}
+        title={
+          <div className='slide-item-wrapper'>
+            <div
+              className='slide-item-draggable-button'
+              onClick={(evt) => {
+                // This method avoids to propagate the toggle event
+                evt.stopPropagation();
+              }}
+            >
+              <svg width="8" height="14" viewBox="0 0 8 14" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="2" height="2" fill="black"/><rect x="6" width="2" height="2" fill="black"/><rect y="6" width="2" height="2" fill="black"/><rect x="6" y="6" width="2" height="2" fill="black"/><rect y="12" width="2" height="2" fill="black"/><rect x="6" y="12" width="2" height="2" fill="black"/></svg>
             </div>
-          </div>
-          <div className='row'>
-            <div className='col'>
-              <CheckboxControl
-                label={__('Open in a new tab', 'planet4-blocks-backend')}
-                value={link_url_new_tab}
-                checked={link_url_new_tab}
-                onChange={changeSlideAttribute('link_url_new_tab', index)}
-              />
+            <div className='slide-item-order-arrows'>
+              <div
+                className={`arrow-button ${index === 0 ? 'disabled' : ''}`}
+                onClick={ upOrDownHandler }
+                data-index={index}
+                data-type='up' />
+              <div
+                className={`arrow-button ${isLastItem ? 'disabled' : ''}`}
+                onClick={ upOrDownHandler }
+                data-index={index}
+                data-type='down' />
             </div>
+            <img
+              className='slide-item-image'
+              draggable={ false }
+              srcSet={ image_srcset }
+              alt={ image_alt }
+            />
+            <span className='slide-item-text'>{ header || <i>{__('No title', 'planet4-blocks-backend')}</i> }</span>
+            <div className='arrow-button' data-type='toggle' />
           </div>
-          {image_url && (
-            <div className='row'>
-              <div className='col'>
-                <FocalPointPicker
-                  label={__('Image focal point', 'planet4-blocks-backend')}
-                  url={image_url}
-                  dimensions={{ width: 300, height: 100 }}
-                  value={focal_points?.x && focal_points?.y ? focal_points : { x: .5, y: .5 }}
-                  onChange={value => onFocalPointsChange(index, value)}
-                  key={index}
-                />
+        }
+      >
+        <PanelRow>
+          <div>
+            <div>
+              <div className='row'>
+                <div className='col'>
+                  <URLInput
+                    label={__('Url for link', 'planet4-blocks-backend')}
+                    value={link_url}
+                    onChange={changeSlideAttribute('link_url', index)}
+                  />
+                </div>
               </div>
+              <div className='row'>
+                <div className='col'>
+                  <CheckboxControl
+                    label={__('Open in a new tab', 'planet4-blocks-backend')}
+                    value={link_url_new_tab}
+                    checked={link_url_new_tab}
+                    onChange={changeSlideAttribute('link_url_new_tab', index)}
+                  />
+                </div>
+              </div>
+              {image_url && (
+                <div className='row'>
+                  <div className='col'>
+                    <FocalPointPicker
+                      label={__('Image focal point', 'planet4-blocks-backend')}
+                      url={image_url}
+                      dimensions={{ width: 300, height: 100 }}
+                      value={focal_points?.x && focal_points?.y ? focal_points : { x: .5, y: .5 }}
+                      onChange={value => onFocalPointsChange(index, value)}
+                      key={index}
+                    />
+                  </div>
+                </div>
+              )}
             </div>
-          )}
-        </div>
-      </div>
-    </>
+          </div>
+        </PanelRow>
+      </PanelBody>
+    </div>
   );
 }

--- a/assets/src/styles/blocks/CarouselHeader/CarouselHeaderEditorStyle.scss
+++ b/assets/src/styles/blocks/CarouselHeader/CarouselHeaderEditorStyle.scss
@@ -1,14 +1,7 @@
 @import "../../master-theme/assets/src/scss/base/colors";
 @import "../../master-theme/assets/src/scss/base/mixins";
 @import "../../master-theme/assets/src/scss/base/variables";
-
-.carousel-sidebar-slide {
-  border-top-width: 3px;
-}
-
-.carousel-sidebar-insert-before {
-  border-top: 3px solid var(--wp-admin-theme-color, blue) !important;
-}
+@import "./SidebarSlidesEditor.scss";
 
 .visually-hidden {
   display: none;

--- a/assets/src/styles/blocks/CarouselHeader/SidebarSlidesEditor.scss
+++ b/assets/src/styles/blocks/CarouselHeader/SidebarSlidesEditor.scss
@@ -1,0 +1,137 @@
+.sidebar-slides {
+  position: relative;
+}
+
+.sidebar-slide {
+  pointer-events: none;
+
+  .components-panel__arrow {
+    display: none;
+  }
+
+  .components-panel__body-toggle {
+    pointer-events: none;
+    padding-right: 16px;
+    padding-left: 9px;
+  }
+}
+
+.cloned-slide {
+  transition: top 500ms ease;
+  position: absolute;
+  width: 100%;
+  opacity: 1;
+}
+
+.dragged-slide {
+  opacity: .25;
+}
+
+.opened-slide {
+  pointer-events: auto;
+
+  .slide-item-draggable-button {
+    pointer-events: none;
+  }
+
+  .arrow-button[data-type="up"],
+  .arrow-button[data-type="down"] {
+    pointer-events: none;
+  }
+
+  .arrow-button[data-type="toggle"] {
+    transform: rotate(-90deg);
+  }
+}
+
+.slide-item-wrapper {
+  flex-direction: row;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  width: 100%;
+
+  * {
+    display: inline-block;
+  }
+}
+
+.slide-item-draggable-button {
+  pointer-events: auto;
+  flex-basis: 8px;
+  flex-shrink: 0;
+  height: 14px;
+  margin-right: 10px;
+  cursor: grab;
+  display: inline-flex;
+}
+
+.slide-item-order-arrows {
+  flex-direction: column;
+  display: inline-flex;
+  align-items: center;
+  flex-grow: 0;
+  justify-content: center;
+  margin-right: 12px;
+
+  > * {
+    &:not(:last-child) {
+      margin-bottom: 6px;
+    }
+  }
+}
+
+.arrow-button {
+  position: relative;
+  overflow: hidden;
+  flex-shrink: 0;
+  width: 15px;
+  height: 15px;
+  pointer-events: auto;
+
+  &::before {
+    content: "";
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background-size: 9px 9px;
+    background-image: url("../../public/images/icons/chevron.svg");
+    background-repeat: no-repeat;
+    background-position: center;
+    transform-origin: center;
+  }
+
+  &[data-type="up"] {
+    transform: rotate(-90deg);
+  }
+
+  &[data-type="toggle"] {
+    transition: rotate 250ms ease;
+  }
+
+  &[data-type="down"], &[data-type="toggle"] {
+    transform: rotate(90deg);
+  }
+
+  &.disabled {
+    opacity: .5;
+    pointer-events: none;
+  }
+}
+
+.slide-item-image {
+  background-color: $grey-10;
+  flex: 0 0 50px;
+  width: 50px;
+  // Overriden from block-editor__container img
+  height: 50px !important;
+  margin-right: 12px;
+}
+
+.slide-item-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis "...";
+  width: 100%;
+  margin-right: 14px;
+}


### PR DESCRIPTION
:point_right: [Demo page](https://www-dev.greenpeace.org/test-atlas/demo-page-fine-tune-carousel-header-slide-re-ordering-design-and-ux/)
[Figma](https://www.figma.com/file/IqISN3iLC17g2B2xxy0Clt/Carousel?node-id=301%3A2)

Ref: https://jira.greenpeace.org/browse/PLANET-6376

The current implementation is not working as expected. Not only when user editor wants to drag and drop any slide but also when he wants to edit any other value whenever the Slide is opened.

**What is included**
- Implement the ability to re order the list clicking on the up and down arrow button (**new feature**)
- Modify and fix the drag and drop logic since It has not been working correctly. In addition, someone has reported this issue through this [Slack message](https://greenpeace.slack.com/archives/C0151L0KKNX/p1637874331098400).
- Add ellipsis to texts
- Overrides some functionalities of the PanelBody component. Allowing to click on up and down arrow and stopped the propagation of the [onToggle PanelBody's method](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/panel/body.js#L44-L49).
- Fix the Image focal point logic when the Slide is opened
- Move Slide styles to a separate file for a more specificity
- Implement style logic when the Slide is opened.
