### PR TITLE
Decouple image hover controls from Columns block

### DIFF
--- a/assets/src/blocks/CarouselHeader/ImagePlaceholder.js
+++ b/assets/src/blocks/CarouselHeader/ImagePlaceholder.js
@@ -1,13 +1,10 @@
+import { ImagePlaceholderIcon } from '../../components/ImagePlaceholderIcon';
+
 const { __ } = wp.i18n;
 
 export const ImagePlaceholder = () => (
   <div className='carousel-header-image-placeholder'>
-    <svg width='80' height='80' xmlns='https://www.w3.org/2000/svg' version='1.1' viewBox='0 0 512 376'>
-      <path d='M0,0v376h512V0H0z M480,344H32V32h448V344z' />
-      <circle cx='409.1' cy='102.9' r='40.9' />
-      <polygon
-        points='480,344 32,344 118.3,179.8 140,191.1 189,113.8 289,226.9 297.9,217.6 315,239.9 341,193.5 393.9,264.7 409,248.8' />
-    </svg>
+    <ImagePlaceholderIcon width={80} height={80}/>
     <p>
       {__('No image selected.', 'planet4-blocks-backend')}
     </p>

--- a/assets/src/blocks/Columns/ColumnsImagePlaceholder.js
+++ b/assets/src/blocks/Columns/ColumnsImagePlaceholder.js
@@ -1,10 +1,7 @@
+import { ImagePlaceholderIcon } from '../../components/ImagePlaceholderIcon';
+
 export const ColumnsImagePlaceholder = ({ width, height }) => (
   <div className='columns-image-placeholder' style={{ height, width }}>
-    <svg width={20} height={20} fill="#ffffff" xmlns='http://www.w3.org/2000/svg' version='1.1' viewBox='0 0 512 376'>
-      <path d='M0,0v376h512V0H0z M480,344H32V32h448V344z' />
-      <circle cx='409.1' cy='102.9' r='40.9' />
-      <polygon
-        points='480,344 32,344 118.3,179.8 140,191.1 189,113.8 289,226.9 297.9,217.6 315,239.9 341,193.5 393.9,264.7 409,248.8' />
-    </svg>
+    <ImagePlaceholderIcon width={20} height={20} fill={'#ffffff'}/>
   </div>
 );

--- a/assets/src/blocks/Columns/EditableColumns.js
+++ b/assets/src/blocks/Columns/EditableColumns.js
@@ -15,7 +15,7 @@ export const EditableColumns = ({
   columnImages,
 }) => {
   const getImageOrButton = (openMediaModal, index) => {
-    if (columns[index] && columns[index].attachment && (0 < columns[index].attachment)) {
+    if ((0 < columns[index].attachment)) {
 
       return <div className='columns-image-container'>
         <ImageHoverControls
@@ -23,41 +23,36 @@ export const EditableColumns = ({
           onRemove={() => toAttribute('attachment', index)(0)}
           isCompact={columns_block_style === LAYOUT_ICONS}
         />
-        <img src={columnImages[columns[index].attachment]}
-        />
+        <img src={columnImages[columns[index].attachment]} />
       </div>;
     }
 
     if (columns_block_style === LAYOUT_TASKS) {
-      return (
-        <Button
-            onClick={openMediaModal}
-            icon='plus-alt2'
-            isPrimary
-            className='tasks-image-button'
-          >
-          {__('Add image', 'planet4-blocks-backend')}
-        </Button>
-      );
+      return <Button
+        onClick={openMediaModal}
+        icon='plus-alt2'
+        isPrimary
+        className='tasks-image-button'
+      >
+        {__('Add image', 'planet4-blocks-backend')}
+      </Button>;
     }
 
-    return (
-      <div className='image-placeholder-container'>
-        <ColumnsImagePlaceholder
-          width={columns_block_style !== LAYOUT_ICONS ? '100%' : 100}
-          height={columns_block_style !== LAYOUT_ICONS ? 250 : 100}
-        />
-        <Button
-          onClick={openMediaModal}
-          icon='plus-alt2'
-          isPrimary
-          className='image-placeholder-button'
-        >
-          {/* For the Icons style we only show the button icon */}
-          {columns_block_style !== LAYOUT_ICONS ? __('Add image', 'planet4-blocks-backend') : ''}
-        </Button>
-      </div>
-    );
+    return <div className='image-placeholder-container'>
+      <ColumnsImagePlaceholder
+        width={columns_block_style !== LAYOUT_ICONS ? '100%' : 100}
+        height={columns_block_style !== LAYOUT_ICONS ? 250 : 100}
+      />
+      <Button
+        onClick={openMediaModal}
+        icon='plus-alt2'
+        isPrimary
+        className='image-placeholder-button'
+      >
+        {/* For the Icons style we only show the button icon */}
+        {columns_block_style !== LAYOUT_ICONS ? __('Add image', 'planet4-blocks-backend') : ''}
+      </Button>
+    </div>;
   };
 
   return (

--- a/assets/src/blocks/Columns/EditableColumns.js
+++ b/assets/src/blocks/Columns/EditableColumns.js
@@ -2,6 +2,7 @@ import { LAYOUT_NO_IMAGE, LAYOUT_ICONS, LAYOUT_TASKS, LAYOUT_IMAGES } from './Co
 import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
 import { ColumnsImagePlaceholder } from './ColumnsImagePlaceholder';
+import { ImageHoverControls } from '../../components/ImageHoverControls';
 
 const { __ } = wp.i18n;
 const { RichText } = wp.blockEditor;
@@ -13,40 +14,24 @@ export const EditableColumns = ({
   isCampaign,
   columnImages,
 }) => {
-  const getImageOrButton = (openEvent, index) => {
+  const getImageOrButton = (openMediaModal, index) => {
     if (columns[index] && columns[index].attachment && (0 < columns[index].attachment)) {
-      return (
-        <>
-          <div className='columns-image-container'>
-            <div className='buttons-overlay'>
-              <Button
-                onClick={openEvent}
-                icon='edit'
-                isPrimary
-                className='edit-image'
-              >
-                {columns_block_style !== LAYOUT_ICONS && __('Edit', 'planet4-blocks-backend')}
-              </Button>
-              <Button
-                className='remove-image'
-                onClick={() => toAttribute('attachment', index)(0)}
-                icon='trash'
-              />
-            </div>
-            <img
-              src={columnImages[columns[index].attachment]}
-              onClick={openEvent}
-            />
-          </div>
-        </>
 
-      );
+      return <div className='columns-image-container'>
+        <ImageHoverControls
+          onEdit={openMediaModal}
+          onRemove={() => toAttribute('attachment', index)(0)}
+          isCompact={columns_block_style === LAYOUT_ICONS}
+        />
+        <img src={columnImages[columns[index].attachment]}
+        />
+      </div>;
     }
 
     if (columns_block_style === LAYOUT_TASKS) {
       return (
         <Button
-            onClick={openEvent}
+            onClick={openMediaModal}
             icon='plus-alt2'
             isPrimary
             className='tasks-image-button'
@@ -63,7 +48,7 @@ export const EditableColumns = ({
           height={columns_block_style !== LAYOUT_ICONS ? 250 : 100}
         />
         <Button
-          onClick={openEvent}
+          onClick={openMediaModal}
           icon='plus-alt2'
           isPrimary
           className='image-placeholder-button'

--- a/assets/src/components/ImageHoverControls/index.js
+++ b/assets/src/components/ImageHoverControls/index.js
@@ -1,0 +1,26 @@
+import { Button } from '@wordpress/components';
+const { __ } = wp.i18n;
+
+export const ImageHoverControls = props => {
+  const {
+    onEdit,
+    onRemove,
+    isCompact,
+  } = props;
+
+  return <div className="buttons-overlay">
+    <Button
+      onClick={ onEdit }
+      icon="edit"
+      isPrimary
+      className="edit-image"
+    >
+      { !isCompact && __('Edit', 'planet4-blocks-backend') }
+    </Button>
+    <Button
+      className="remove-image"
+      onClick={ onRemove }
+      icon="trash"
+    />
+  </div>;
+};

--- a/assets/src/components/ImagePlaceholderIcon.js
+++ b/assets/src/components/ImagePlaceholderIcon.js
@@ -1,0 +1,7 @@
+export const ImagePlaceholderIcon = ({width, height, fill}) =>
+  <svg {...{width, height, fill}} xmlns='http://www.w3.org/2000/svg' version='1.1' viewBox='0 0 512 376'>
+    <path d='M0,0v376h512V0H0z M480,344H32V32h448V344z' />
+    <circle cx='409.1' cy='102.9' r='40.9' />
+    <polygon
+      points='480,344 32,344 118.3,179.8 140,191.1 189,113.8 289,226.9 297.9,217.6 315,239.9 341,193.5 393.9,264.7 409,248.8' />
+  </svg>;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6471

Since the image buttons will be used for the Take Action Boxout block as well, we should first extract them from the columns block.

This also simplifies some of the surrounding code.

- Extract SVG which was duplicated in Columns and Carousel Header. Will be used for Boxout too.
- Create a separate component for the hover buttons.

I might do a follow up with more decoupling, but this seems like already a sufficient amount to review.

TESTING:
This should produce the same result as before, so if you see any difference with how it behaves in master it's probably not intended.
Columns: https://www-dev.greenpeace.org/test-pandora/wp-admin/post.php?post=24037&action=edit
Carousel Header: https://www-dev.greenpeace.org/test-pandora/wp-admin/post.php?post=70&action=edit

I noticed that undoing seems to be buggy after removing the image, `master` has the same issue. It sometimes works, and sometimes doesn't seem to perform the undo anymore, even if you had other edits before changing the image. Didn't see any related console messages yet. Maybe it's because of the `MediaUpload` render prop.