### PR TITLE
Carousel Header: Remove redundant transform on previous icon

### DIFF
--- a/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
+++ b/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
@@ -570,7 +570,7 @@ $medium-image-height: 600px;
       }
 
       html[dir="rtl"] & {
-        transform: scaleX(-1);
+        transform: none;
       }
     }
   }


### PR DESCRIPTION
On RTL the icons are reversed, the previous icon is on the right.
So it's already pointing at the proper direction.

### Testing

- Look at the "broken" version on [production site](https://www.greenpeace.org/mena/ar).
- Locally you can use even the inspector to add `dir="rtl"` in the `<html>` tag. Otherwise you can use [nro-enable](https://support.greenpeace.org/planet4/development/installation#nro-sites) to have MENA site locally.
- Also deployed this on [MENA dev site](https://www-dev.greenpeace.org/mena/ar/).