### PR TITLE
PLANET-6471 Use same image controls as Columns block

### DIFF
--- a/assets/src/blocks/TakeActionBoxout/ImagePlaceholder.js
+++ b/assets/src/blocks/TakeActionBoxout/ImagePlaceholder.js
@@ -1,0 +1,7 @@
+import { ImagePlaceholderIcon } from '../../components/ImagePlaceholderIcon';
+
+export const ImagePlaceholder = ({children}) =>
+  <div className={'boxout-image-placeholder'}>
+    <ImagePlaceholderIcon width={20} height={20} fill={'#ffffff'}/>
+    {children}
+  </div>

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -11,6 +11,8 @@ import {
 } from '@wordpress/components';
 import { URLInput } from '../../components/URLInput/URLInput';
 import { TakeActionBoxoutFrontend } from './TakeActionBoxoutFrontend';
+import { ImagePlaceholder } from './ImagePlaceholder';
+import { ImageHoverControls } from '../../components/ImageHoverControls';
 
 // Planet 4 settings (Planet 4 >> Defaults content >> Take Action Covers default button text).
 const DEFAULT_BUTTON_TEXT = window.p4bk_vars.take_action_covers_button_text;
@@ -113,7 +115,23 @@ export const TakeActionBoxoutEditor = ({
     <section
       className={`boxout ${className || ''}`}
     >
-      {imageUrl && <img src={imageUrl} alt={imageAlt} />}
+      <div className={'boxout-image-container'}>
+        <MediaUploadCheck>
+          <MediaUpload
+            type='image'
+            onSelect={ selectImage }
+            value={ imageId }
+            allowedTypes={ ['image'] }
+            render={ ({ open }) => <ImageHoverControls
+              onEdit={ open }
+              onRemove={ removeImage }
+              isAdd={ !imageUrl }
+            />
+            }
+          />
+        </MediaUploadCheck>
+        {!imageUrl ? <ImagePlaceholder/> : <img src={imageUrl} alt={imageAlt} />}
+      </div>
       <div className="boxout-content">
         <RichText
           tagName="div"

--- a/assets/src/components/ImageHoverControls/index.js
+++ b/assets/src/components/ImageHoverControls/index.js
@@ -6,21 +6,31 @@ export const ImageHoverControls = props => {
     onEdit,
     onRemove,
     isCompact,
+    isAdd,
   } = props;
 
-  return <div className="buttons-overlay">
-    <Button
+  return <div className='buttons-overlay'>
+    { isAdd && <Button
       onClick={ onEdit }
-      icon="edit"
+      icon='plus-alt2'
       isPrimary
-      className="edit-image"
+      className='edit-image'
+    >
+      { __('Add image', 'planet4-blocks-backend') }
+    </Button> }
+
+    { !isAdd && <Button
+      onClick={ onEdit }
+      icon='edit'
+      isPrimary
+      className='edit-image'
     >
       { !isCompact && __('Edit', 'planet4-blocks-backend') }
-    </Button>
-    <Button
-      className="remove-image"
+    </Button> }
+    { !isAdd && <Button
+      className='remove-image'
       onClick={ onRemove }
-      icon="trash"
-    />
+      icon='trash'
+    /> }
   </div>;
 };

--- a/assets/src/styles/blocks/ColumnsEditor.scss
+++ b/assets/src/styles/blocks/ColumnsEditor.scss
@@ -1,52 +1,52 @@
 .columns-image-container {
   position: relative;
+}
 
-  .buttons-overlay {
-    position: absolute;
-    z-index: 2;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-    display: flex;
+.buttons-overlay {
+  position: absolute;
+  z-index: 2;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  display: flex;
+
+  button {
+    display: none;
+  }
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.3);
 
     button {
-      display: none;
+      display: inline-flex;
+    }
+  }
+
+  .block-style-icons & {
+    justify-content: flex-start;
+    margin-left: 10px;
+
+    .edit-image .dashicon {
+      margin: 0;
+    }
+  }
+
+  .block-style-tasks & {
+    height: calc(100% - 32px);
+  }
+
+  .remove-image {
+    margin-inline-start: 10px;
+    background: $grey-80;
+    color: $white;
+
+    .dashicon {
+      margin: 0;
     }
 
     &:hover {
-      background: rgba(255, 255, 255, 0.3);
-
-      button {
-        display: inline-flex;
-      }
-    }
-
-    .block-style-icons & {
-      justify-content: flex-start;
-      margin-left: 10px;
-
-      .edit-image .dashicon {
-        margin: 0;
-      }
-    }
-
-    .block-style-tasks & {
-      height: calc(100% - 32px);
-    }
-
-    .remove-image {
-      margin-inline-start: 10px;
-      background: $grey-80;
-      color: $white;
-
-      .dashicon {
-        margin: 0;
-      }
-
-      &:hover {
-        background: $grey-60;
-      }
+      background: $grey-60;
     }
   }
 }

--- a/assets/src/styles/blocks/TakeActionBoxout/edit.scss
+++ b/assets/src/styles/blocks/TakeActionBoxout/edit.scss
@@ -10,3 +10,29 @@
     -webkit-line-clamp: unset !important;
   }
 }
+
+// I had to put these styles on the container to get the image controls to work, and remove some from the image itself.
+.boxout-image-container {
+  position: relative;
+  background: $grey-20;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  float: left;
+  width: 120px;
+  height: 120px;
+
+  @include medium-and-up {
+    height: 100%;
+    width: 45%;
+    padding: 0;
+    margin-inline-end: 16px;
+  }
+
+  img {
+    width: 100%;
+    // Account for different markup in the editor, where it needs a wrapper to work.
+    margin-inline-end: 0;
+  }
+}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6471

* Move buttons-overlay class outside of the columns-specific class so it can be reused.
* Put styles on wrapper div instead of on img in editor only.
* Convert earlier added unintentional double quotes to single.

The image controls should work the same as for the columns block. The alignment issue is resolved, but only for the Boxout block. I'll address that in a follow up because it needs more changes in the Columns block's editor code.

Example on test instance: https://www-dev.greenpeace.org/test-venus/wp-admin/post.php?post=50288&action=edit