### PR TITLE
Workaround to prevent local images CarouselHeader

### DIFF
--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -4,6 +4,39 @@ import { Button, Dropdown } from '@wordpress/components';
 import { toSrcSet } from './CarouselHeaderEditor';
 const { __ } = wp.i18n;
 
+const usesCdn = window.p4ge_vars.uses_cdn;
+
+// If the site uses CDN through the stateless plugin, it should never have the local folder in the URL.
+const isWrongSource = src => {
+  return usesCdn && src.includes('wp-content/uploads');
+}
+
+const ALERT_TEXT = `
+An issue with the image path was detected. This usually happens on the largest version of the image.
+Please try removing and re-adding the images until you don't get this alert anymore.
+If the alert persists, please provide the prior steps you did (including upload of image) to the Planet 4 team.
+`;
+
+// Due to a yet unidentified bug, it sometimes happens that the URL and the largest size don't use the CDN URL.
+// This has a nasty consequence: the URL on the server exists, but only temporary. It is removed on deploy. So an editor
+// can not see that this issue will occur. It's probably related to WPML.
+const preventLocalImage = (url, sizes) => {
+  const fixedSizes = sizes.filter(size => !isWrongSource(size.url || size.source_url));
+  let fixedUrl = url;
+  if (isWrongSource(url)) {
+    console.warn(`An image with "wp-content-uploads" in the URL was detected, excluding: ${url}`);
+    alert(ALERT_TEXT);
+    const largest = fixedSizes.reduce((largest, size) => {
+      if (!largest) {
+        return size;
+      }
+      return size.width < largest.width ? largest : size;
+    })
+    fixedUrl = largest.url;
+  }
+  return [fixedUrl, fixedSizes];
+}
+
 export const EditableBackground = ({
   image_url,
   image_alt,
@@ -20,7 +53,8 @@ export const EditableBackground = ({
     <MediaUpload
       onSelect={image => {
         const { id, alt_text, url, sizes } = image;
-        changeSlideImage(index, id, url, alt_text, toSrcSet(Object.values(sizes)));
+        const [fixedUrl, fixedSizes] = preventLocalImage(url, Object.values(sizes));
+        changeSlideImage(index, id, fixedUrl, alt_text, toSrcSet(fixedSizes));
       }}
       allowedTypes={['image']}
       value={image_id}

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -336,12 +336,15 @@ final class Loader {
 		$en_active = ! MigrationLog::from_wp_options()->already_ran( M001EnableEnFormFeature::get_id() )
 					|| Features::is_active( Features::ENGAGING_NETWORKS );
 
+		$uses_cdn = is_plugin_active( 'wp-stateless/wp-stateless-media.php' ) && get_option( 'sm_custom_domain' );
+
 		$reflection_vars = [
 			'home'            => P4GBKS_PLUGIN_URL . '/public/',
 			'planet4_options' => $option_values,
 			'features'        => [
 				'feature_engaging_networks' => $en_active,
 			],
+			'uses_cdn'        => $uses_cdn,
 		];
 		wp_localize_script( 'planet4-blocks-editor-script', 'p4ge_vars', $reflection_vars );
 


### PR DESCRIPTION
* We were not able to reproduce the issue yet, but it keeps on occurring
that a local image is used for the largest size of an image. Local means
it's on the PHP server, and doesn't use the CDN URL. This source is
removed when we deploy, resulting in an empty image.

While this doesn't fully address [the issue](https://jira.greenpeace.org/browse/PLANET-6372), it does prevent the worst effect (browser using 404 image).

I also added a blocking alert message, so that the editor in question knows it happens, and can contact the Planet 4 team with reproduction steps.