### PR TITLE
Remove blocks container classes

### DIFF
--- a/assets/src/blocks/Articles/ArticlesFrontend.js
+++ b/assets/src/blocks/Articles/ArticlesFrontend.js
@@ -29,42 +29,40 @@ export const ArticlesFrontend = (props) => {
 
   return (
     <section className={`block articles-block ${className ?? ''}`}>
-      <div className="container">
-        <header>
-          <h2 className="page-section-header">{ article_heading }</h2>
-        </header>
-        { articles_description &&
-          <div className="page-section-description" dangerouslySetInnerHTML={{ __html: articles_description }} />
-        }
-        <ArticlesList posts={ posts } postType={ postType }/>
-        { hasMorePages &&
-        <div className="row">
-          { read_more_link ?
-            <div className="col-md-12 col-lg-5 col-xl-5">
-              <a
-                className="btn btn-secondary btn-block article-load-more"
-                href={ read_more_link }
-                target={ button_link_new_tab ? '_blank' : '' }
-              >
-                { read_more_text }
-              </a>
-            </div> :
-            <div className="col-md-12 col-lg-5 col-xl-5">
-              <button
-                className="btn btn-secondary btn-block article-load-more"
-                onClick={ loadNextPage }
-                disabled={ loading }
-                data-ga-category="Articles Block"
-                data-ga-action="Load More Button"
-                data-ga-label="n/a"
-              >
-                { read_more_text }
-              </button>
-            </div>
-          }
-        </div>
+      <header>
+        <h2 className="page-section-header">{ article_heading }</h2>
+      </header>
+      { articles_description &&
+        <div className="page-section-description" dangerouslySetInnerHTML={{ __html: articles_description }} />
+      }
+      <ArticlesList posts={ posts } postType={ postType }/>
+      { hasMorePages &&
+      <div className="row">
+        { read_more_link ?
+          <div className="col-md-12 col-lg-5 col-xl-5">
+            <a
+              className="btn btn-secondary btn-block article-load-more"
+              href={ read_more_link }
+              target={ button_link_new_tab ? '_blank' : '' }
+            >
+              { read_more_text }
+            </a>
+          </div> :
+          <div className="col-md-12 col-lg-5 col-xl-5">
+            <button
+              className="btn btn-secondary btn-block article-load-more"
+              onClick={ loadNextPage }
+              disabled={ loading }
+              data-ga-category="Articles Block"
+              data-ga-action="Load More Button"
+              data-ga-label="n/a"
+            >
+              { read_more_text }
+            </button>
+          </div>
         }
       </div>
+      }
     </section>
   );
 };

--- a/assets/src/blocks/CarouselHeader/Caption.js
+++ b/assets/src/blocks/CarouselHeader/Caption.js
@@ -5,40 +5,36 @@ export const Caption = ({ slide, index, changeSlideAttribute }) => (
   <div className='carousel-caption'>
     <div className='caption-overlay'></div>
     <div className='container main-header'>
-      <div className='row'>
-        <div className='col'>
-          <div className='carousel-captions-wrapper'>
-            <RichText
-              tagName='h1'
-              placeholder={__('Enter title', 'planet4-blocks-backend')}
-              value={slide.header}
-              onChange={changeSlideAttribute('header', index)}
-              withoutInteractiveFormatting
-              allowedFormats={[]}
-              multiline='false'
-            />
-            <RichText
-              tagName='p'
-              placeholder={__('Enter description', 'planet4-blocks-backend')}
-              value={slide.description}
-              onChange={changeSlideAttribute('description', index)}
-              withoutInteractiveFormatting
-              allowedFormats={[]}
-            />
-          </div>
+      <div className='carousel-captions-wrapper'>
+        <RichText
+          tagName='h1'
+          placeholder={__('Enter title', 'planet4-blocks-backend')}
+          value={slide.header}
+          onChange={changeSlideAttribute('header', index)}
+          withoutInteractiveFormatting
+          allowedFormats={[]}
+          multiline='false'
+        />
+        <RichText
+          tagName='p'
+          placeholder={__('Enter description', 'planet4-blocks-backend')}
+          value={slide.description}
+          onChange={changeSlideAttribute('description', index)}
+          withoutInteractiveFormatting
+          allowedFormats={[]}
+        />
+      </div>
 
-          <div className='col-xs-12 col-sm-8 col-md-4 action-button'>
-            <RichText
-              tagName='div'
-              className='btn btn-primary btn-block'
-              placeholder={__('Enter CTA text', 'planet4-blocks-backend')}
-              value={slide.link_text}
-              onChange={changeSlideAttribute('link_text', index)}
-              withoutInteractiveFormatting
-              allowedFormats={[]}
-            />
-          </div>
-        </div>
+      <div className='col-xs-12 col-sm-8 col-md-4 action-button'>
+        <RichText
+          tagName='div'
+          className='btn btn-primary btn-block'
+          placeholder={__('Enter CTA text', 'planet4-blocks-backend')}
+          value={slide.link_text}
+          onChange={changeSlideAttribute('link_text', index)}
+          withoutInteractiveFormatting
+          allowedFormats={[]}
+        />
       </div>
     </div>
   </div>

--- a/assets/src/blocks/Columns/ColumnsEditor.js
+++ b/assets/src/blocks/Columns/ColumnsEditor.js
@@ -144,49 +144,47 @@ export const ColumnsEditor = ({ isSelected, attributes, setAttributes }) => {
 
   return (
     <section className={`block columns-block block-style-${columns_block_style} ${className ?? ''}`}>
-      <div className='container'>
-        {renderEdit(attributes, toAttribute, setAttributes, isSelected)}
-        {!isExample &&
-          <header className='articles-title-container'>
-            <RichText
-              tagName='h2'
-              className='page-section-header'
-              placeholder={__('Enter title', 'planet4-blocks-backend')}
-              value={columns_title}
-              onChange={toAttribute('columns_title')}
-              withoutInteractiveFormatting
-              multiline='false'
-              allowedFormats={[]}
-            />
-          </header>
-        }
-        {!isExample &&
+      {renderEdit(attributes, toAttribute, setAttributes, isSelected)}
+      {!isExample &&
+        <header className='articles-title-container'>
           <RichText
-            tagName='p'
-            className='page-section-description'
-            placeholder={__('Enter description', 'planet4-blocks-backend')}
-            value={columns_description}
-            onChange={toAttribute('columns_description')}
+            tagName='h2'
+            className='page-section-header'
+            placeholder={__('Enter title', 'planet4-blocks-backend')}
+            value={columns_title}
+            onChange={toAttribute('columns_title')}
             withoutInteractiveFormatting
-            allowedFormats={['core/bold', 'core/italic']}
+            multiline='false'
+            allowedFormats={[]}
           />
-        }
-        {isExample ?
-          <Columns
-            columns={exampleColumns}
-            isCampaign={postType === 'campaign'}
-            columns_block_style={columns_block_style}
-            isExample
-          /> :
-          <EditableColumns
-            isCampaign={postType === 'campaign'}
-            columns={columns}
-            columns_block_style={columns_block_style}
-            toAttribute={toAttribute}
-            columnImages={columnImages}
-          />
-        }
-      </div>
+        </header>
+      }
+      {!isExample &&
+        <RichText
+          tagName='p'
+          className='page-section-description'
+          placeholder={__('Enter description', 'planet4-blocks-backend')}
+          value={columns_description}
+          onChange={toAttribute('columns_description')}
+          withoutInteractiveFormatting
+          allowedFormats={['core/bold', 'core/italic']}
+        />
+      }
+      {isExample ?
+        <Columns
+          columns={exampleColumns}
+          isCampaign={postType === 'campaign'}
+          columns_block_style={columns_block_style}
+          isExample
+        /> :
+        <EditableColumns
+          isCampaign={postType === 'campaign'}
+          columns={columns}
+          columns_block_style={columns_block_style}
+          toAttribute={toAttribute}
+          columnImages={columnImages}
+        />
+      }
     </section>
   );
 }

--- a/assets/src/blocks/Columns/ColumnsFrontend.js
+++ b/assets/src/blocks/Columns/ColumnsFrontend.js
@@ -38,21 +38,19 @@ export const ColumnsFrontend = ({ columns_block_style, columns_title, columns_de
 
   return (
     <section className={`block columns-block block-style-${columns_block_style} ${className ?? ''}`}>
-      <div className='container'>
-        {columns_title &&
-          <header>
-            <h2 className='page-section-header' dangerouslySetInnerHTML={{ __html: columns_title }} />
-          </header>
-        }
-        {columns_description &&
-          <div className='page-section-description' dangerouslySetInnerHTML={{ __html: columns_description }} />
-        }
-        <Columns
-          columns_block_style={columns_block_style}
-          columns={columns}
-          isCampaign={postType === 'campaign'}
-        />
-      </div>
+      {columns_title &&
+        <header>
+          <h2 className='page-section-header' dangerouslySetInnerHTML={{ __html: columns_title }} />
+        </header>
+      }
+      {columns_description &&
+        <div className='page-section-description' dangerouslySetInnerHTML={{ __html: columns_description }} />
+      }
+      <Columns
+        columns_block_style={columns_block_style}
+        columns={columns}
+        isCampaign={postType === 'campaign'}
+      />
     </section>
   );
 }

--- a/assets/src/blocks/Counter/CounterFrontend.js
+++ b/assets/src/blocks/Counter/CounterFrontend.js
@@ -104,22 +104,20 @@ export class CounterFrontend extends Component {
 
     const percent = Math.min(target > 0 ? Math.round(completed / target * 100) : 0, 100);
 
-    let counterClassName = `block container counter-block counter-style-${style} ${className ?? ''}`;
+    let counterClassName = `block counter-block counter-style-${style} ${className ?? ''}`;
     if (isEditing) counterClassName += ` editing`;
 
     return (
       <Fragment>
         <section className={counterClassName}>
-          <div className="container">
-            {title && !isEditing &&
-              <header>
-                <h2 className="page-section-header">{title}</h2>
-              </header>
-            }
-            {description && !isEditing &&
-              <p className="page-section-description" dangerouslySetInnerHTML={{ __html: description }} />
-            }
-          </div>
+          {title && !isEditing &&
+            <header>
+              <h2 className="page-section-header">{title}</h2>
+            </header>
+          }
+          {description && !isEditing &&
+            <p className="page-section-description" dangerouslySetInnerHTML={{ __html: description }} />
+          }
           <div className="content-counter">
             {(style === 'bar' || style === 'en-forms-bar') &&
               <div className="progress-container">

--- a/assets/src/blocks/Covers/CampaignCovers.js
+++ b/assets/src/blocks/Covers/CampaignCovers.js
@@ -6,7 +6,7 @@ export const CampaignCovers = ({ covers, initialRowsLimit, row, loadMoreCovers, 
   const showLoadMore = !!initialRowsLimit && covers.length > amountPerRow * row;
 
   return (
-    <div className='container'>
+    <>
       <div className='thumbnail-largeview-container'>
         {covers.map((cover, index) => {
           const { href, image, alt_text, name, src_set } = cover;
@@ -54,6 +54,6 @@ export const CampaignCovers = ({ covers, initialRowsLimit, row, loadMoreCovers, 
           </div>
         </div>
       }
-    </div>
+    </>
   );
 };

--- a/assets/src/blocks/Covers/ContentCovers.js
+++ b/assets/src/blocks/Covers/ContentCovers.js
@@ -19,7 +19,7 @@ export const ContentCovers = ({ covers, initialRowsLimit, row, loadMoreCovers, i
   const showLoadMore = !!initialRowsLimit && covers.length > amountPerRow * row;
 
   return (
-    <div className='container'>
+    <>
       <div className='row publications-slider'>
         {covers.map((cover, index) => {
           const {
@@ -101,6 +101,6 @@ export const ContentCovers = ({ covers, initialRowsLimit, row, loadMoreCovers, i
           </div>
         </div>
       }
-    </div>
+    </>
   );
 };

--- a/assets/src/blocks/Covers/TakeActionCovers.js
+++ b/assets/src/blocks/Covers/TakeActionCovers.js
@@ -18,7 +18,7 @@ export const TakeActionCovers = ({ initialRowsLimit, covers, row, loadMoreCovers
 
   const showLoadMore = !!initialRowsLimit && covers.length > amountPerRow * row;
   return (
-    <div className='container'>
+    <>
       <div className='row'>
         {covers.map((cover, index) => {
           const {
@@ -101,7 +101,6 @@ export const TakeActionCovers = ({ initialRowsLimit, covers, row, loadMoreCovers
           </div>
         </div>
       }
-    </div>
-
+    </>
   );
 };

--- a/assets/src/blocks/Gallery/GalleryEditor.js
+++ b/assets/src/blocks/Gallery/GalleryEditor.js
@@ -124,32 +124,30 @@ const renderView = (attributes, setAttributes) => {
 
   return (
     <section className={`block ${GALLERY_BLOCK_CLASSES[layout]} ${className ?? ''}`}>
-      <div className='container'>
-        <header className="articles-title-container">
-          <RichText
-            tagName="h2"
-            className="page-section-header"
-            placeholder={__('Enter title', 'planet4-blocks-backend')}
-            value={gallery_block_title}
-            onChange={toAttribute('gallery_block_title')}
-            withoutInteractiveFormatting
-            multiline="false"
-            allowedFormats={[]}
-          />
-        </header>
+      <header className="articles-title-container">
         <RichText
-          tagName="p"
-          className="page-section-description"
-          placeholder={__('Enter description', 'planet4-blocks-backend')}
-          value={gallery_block_description}
-          onChange={toAttribute('gallery_block_description')}
+          tagName="h2"
+          className="page-section-header"
+          placeholder={__('Enter title', 'planet4-blocks-backend')}
+          value={gallery_block_title}
+          onChange={toAttribute('gallery_block_title')}
           withoutInteractiveFormatting
-          allowedFormats={['core/bold', 'core/italic']}
+          multiline="false"
+          allowedFormats={[]}
         />
-        {layout === 'slider' && <GalleryCarousel images={images || []} isEditing />}
-        {layout === 'three-columns' && <GalleryThreeColumns images={images || []} postType={postType} />}
-        {layout === 'grid' && <GalleryGrid images={images || []} />}
-      </div>
+      </header>
+      <RichText
+        tagName="p"
+        className="page-section-description"
+        placeholder={__('Enter description', 'planet4-blocks-backend')}
+        value={gallery_block_description}
+        onChange={toAttribute('gallery_block_description')}
+        withoutInteractiveFormatting
+        allowedFormats={['core/bold', 'core/italic']}
+      />
+      {layout === 'slider' && <GalleryCarousel images={images || []} isEditing />}
+      {layout === 'three-columns' && <GalleryThreeColumns images={images || []} postType={postType} />}
+      {layout === 'grid' && <GalleryGrid images={images || []} />}
     </section>
   );
 }

--- a/assets/src/blocks/Gallery/GalleryFrontend.js
+++ b/assets/src/blocks/Gallery/GalleryFrontend.js
@@ -31,22 +31,20 @@ export const GalleryFrontend = ({
 
   return (
     <section className={`block ${GALLERY_BLOCK_CLASSES[layout]} ${className ?? ''}`}>
-      <div className='container'>
-        {gallery_block_title &&
-          <header>
-            <h2 className="page-section-header" dangerouslySetInnerHTML={{ __html: gallery_block_title }} />
-          </header>
-        }
+      {gallery_block_title &&
+        <header>
+          <h2 className="page-section-header" dangerouslySetInnerHTML={{ __html: gallery_block_title }} />
+        </header>
+      }
 
-        {gallery_block_description &&
-          <div className="page-section-description" dangerouslySetInnerHTML={{ __html: gallery_block_description }} />
-        }
-        {layout === 'slider' && <GalleryCarousel onImageClick={openLightbox} images={images || []} />}
-        {layout === 'three-columns' && <GalleryThreeColumns onImageClick={openLightbox} images={images || []} postType={postType} />}
-        {layout === 'grid' && <GalleryGrid onImageClick={openLightbox} images={images || []} />}
+      {gallery_block_description &&
+        <div className="page-section-description" dangerouslySetInnerHTML={{ __html: gallery_block_description }} />
+      }
+      {layout === 'slider' && <GalleryCarousel onImageClick={openLightbox} images={images || []} />}
+      {layout === 'three-columns' && <GalleryThreeColumns onImageClick={openLightbox} images={images || []} postType={postType} />}
+      {layout === 'grid' && <GalleryGrid onImageClick={openLightbox} images={images || []} />}
 
-        <Lightbox isOpen={isOpen} index={index} items={items} onClose={closeLightbox} />
-      </div>
+      <Lightbox isOpen={isOpen} index={index} items={items} onClose={closeLightbox} />
     </section>
   );
 }

--- a/assets/src/blocks/Media/MediaFrontend.js
+++ b/assets/src/blocks/Media/MediaFrontend.js
@@ -32,23 +32,21 @@ export const MediaFrontend = ( attributes ) => {
 
   return (
     <section className={`block media-block ${className ?? ''}`}>
-      <div className="container">
-        {
-          video_title &&
-          <header>
-            <h2 className="page-section-header">{ video_title }</h2>
-          </header>
-        }
-        {
-          description &&
-          <div className="page-section-description" dangerouslySetInnerHTML={{ __html: description }} />
-        }
-        {
-          media_url && media_url.endsWith('.mp4')
-          ? <MediaElementVideo videoURL={ media_url } videoPoster={ poster_url } />
-          : <div dangerouslySetInnerHTML={{ __html: wrapEmbedHTML(embed_html) || null }} />
-        }
-      </div>
+      {
+        video_title &&
+        <header>
+          <h2 className="page-section-header">{ video_title }</h2>
+        </header>
+      }
+      {
+        description &&
+        <div className="page-section-description" dangerouslySetInnerHTML={{ __html: description }} />
+      }
+      {
+        media_url && media_url.endsWith('.mp4')
+        ? <MediaElementVideo videoURL={ media_url } videoPoster={ poster_url } />
+        : <div dangerouslySetInnerHTML={{ __html: wrapEmbedHTML(embed_html) || null }} />
+      }
     </section>
   );
 };

--- a/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
+++ b/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
@@ -318,7 +318,7 @@ $medium-image-height: 600px;
       position: relative;
       top: 0;
       left: 0;
-      padding: 16px;
+      padding: 16px 0;
       background: $white;
       height: auto;
       width: 100%;
@@ -622,11 +622,15 @@ $medium-image-height: 600px;
     z-index: 3000;
 
     @include large-and-up {
-      margin-inline-start: 80px;
+      > .container {
+        margin-inline-start: 80px;
+      }
     }
 
     @include x-large-and-up {
-      margin-inline-start: auto;
+      > .container {
+        margin-inline-start: auto;
+      }
     }
 
     .carousel-indicators {

--- a/assets/src/styles/blocks/ENForm/components/_enform-full-width.scss
+++ b/assets/src/styles/blocks/ENForm/components/_enform-full-width.scss
@@ -1,4 +1,8 @@
 .enform-full-width {
+  .container {
+    padding: 0;
+  }
+
   .enform {
     color: white;
     padding: $space-lg;

--- a/assets/src/styles/blocks/ENForm/components/_enform.scss
+++ b/assets/src/styles/blocks/ENForm/components/_enform.scss
@@ -102,7 +102,6 @@
   margin-top: 36px;
   font-family: $roboto;
   height: inherit;
-  padding: $n20;
   background: $dark-blue;
   width: 100%;
 

--- a/assets/src/styles/blocks/Media.scss
+++ b/assets/src/styles/blocks/Media.scss
@@ -4,16 +4,6 @@
       object-fit: inherit;
     }
   }
-
-  .container {
-    padding-left: 0;
-    padding-right: 0;
-
-    @include medium-and-up {
-      padding-left: 15px;
-      padding-right: 15px;
-    }
-  }
 }
 
 .embed-container,

--- a/assets/src/styles/blocks/OldENForm/components/_enform-full-width.scss
+++ b/assets/src/styles/blocks/OldENForm/components/_enform-full-width.scss
@@ -1,4 +1,8 @@
 .enform-full-width {
+  .container {
+    padding: 0;
+  }
+
   .enform {
     color: white;
     padding: $space-lg;

--- a/assets/src/styles/blocks/OldENForm/components/_enform.scss
+++ b/assets/src/styles/blocks/OldENForm/components/_enform.scss
@@ -105,7 +105,6 @@
   }
   margin-top: 36px;
   height: inherit;
-  padding: $n20;
   width: 100%;
 
   form {

--- a/tests/acceptance/ColumnsImagesCept.php
+++ b/tests/acceptance/ColumnsImagesCept.php
@@ -42,8 +42,8 @@ $I->havePageInDatabase(
 $I->amOnPage( '/' . $slug );
 
 // Check the Tasks style
-$I->see( 'Images Columns', '.block-style-image > div > header > h2' );
-$I->see( 'Images Column Block description', '.block-style-image > div > div' );
+$I->see( 'Images Columns', '.block-style-image > header > h2' );
+$I->see( 'Images Column Block description', '.block-style-image > div.page-section-description' );
 
 // Column 1.
 $I->see( 'Column 1', 'h3 > a' );


### PR DESCRIPTION
### Description

We have some content width/padding issues in pages on mobile, which are due to our blocks having the `container` class but not the "non-blocks" items (paragraphs for example). Also because of this we had to manually add the page width to the `page-template` element, which doesn't make sense since we use the same ones as Bootstrap anyway so we might as well use that directly 🙂 So a solution would be to remove the `container` class from the blocks (except full-width ones) and add it to the `page-template` div instead (done in [this PR](https://github.com/greenpeace/planet4-master-theme/pull/1524))

### Testing

You can see the new layout in this [test instance](https://www-dev.greenpeace.org/test-uranus), everything should look pretty much the same except with a bit less padding than before on mobile. In all screen sizes, all elements (blocks and non-blocks) of the page content should be aligned.