### PR TITLE
PLANET-6487 Avoid discarding data in an effect

### DIFF
--- a/assets/src/blocks/Covers/CoversEditor.js
+++ b/assets/src/blocks/Covers/CoversEditor.js
@@ -173,15 +173,13 @@ const renderView = (attributes, toAttribute) => {
 };
 
 export const CoversEditor = ({ attributes, setAttributes, isSelected }) => {
-  const { className, post_types } = attributes;
+  const { className } = attributes;
 
   useEffect(() => {
     const styleClass = getStyleFromClassName(className);
     if (styleClass) {
       setAttributes({
         cover_type: styleClass,
-        posts: [],
-        post_types: className.includes('content') ? post_types : [],
       });
     }
   }, [className]);


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6487

The previous code has 2 issues:
* 1: It needlessly discards user input. If our other styles shouldn't
use these attributes, they can simply ignore them.
* 2: An effect here is not the right tool for the job. Effects always
run when the component renders + when deps are updated. If we would want
to unset data (which we don't), it should happen in an event listener.

The solution is to remove `post_types` and `posts` from the effect so they're preserved. See comments for caveat.

New behavior when switching styles:

https://user-images.githubusercontent.com/7604138/148570601-b93e914c-d2de-41bd-b437-48b77c553410.mp4

The previous code didn't have this flashing bug because it unsets the user input immediately which makes the block empty. The new code doesn't do this, but it takes some time before it did the API query with the new attributes.

This is hard to solve in the current implementation, rethinking the UX of the block makes more sense. The current behavior is also a problem for editors because they can never switch the style, it doesn't work without entering new content. Maybe the styles are so different they could be separate blocks?