### PR TITLE
Enable GravityForms Gutenberg block

### DIFF
--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -115,6 +115,7 @@ const POST_BLOCK_TYPES = [
 	'planet4-blocks/take-action-boxout',
 	'planet4-blocks/timeline',
 	'leadin/hubspot-form-block',
+	'gravityforms/form',
 ];
 
 // pages allow all block types.
@@ -137,6 +138,7 @@ const PAGE_BLOCK_TYPES = [
 	'planet4-blocks/enform',
 	'planet4-blocks/guestbook',
 	'leadin/hubspot-form-block',
+	'gravityforms/form',
 ];
 
 const BETA_PAGE_BLOCK_TYPES = [
@@ -162,6 +164,7 @@ const CAMPAIGN_BLOCK_TYPES = [
 	'planet4-blocks/enform',
 	'planet4-blocks/guestbook',
 	'leadin/hubspot-form-block',
+	'gravityforms/form',
 ];
 
 const BETA_CAMPAIGN_BLOCK_TYPES = [


### PR DESCRIPTION
This will allow editors to add a form from a dropdown as a block instead of using shortcode.