### PR TITLE
PLANET-6500 Gallery: Adjust image widths for XXL container

### DIFF
--- a/assets/src/styles/blocks/Gallery/styles/GalleryThreeColumns.scss
+++ b/assets/src/styles/blocks/Gallery/styles/GalleryThreeColumns.scss
@@ -33,7 +33,7 @@
       cursor: pointer;
 
       @include mobile-only {
-        width: 200px;
+        width: 260px;
       }
 
       @include medium-and-up {
@@ -48,7 +48,11 @@
       @include x-large-and-up {
         left: -30%;
         height: 430px;
-        width: 500px;
+        width: 530px;
+      }
+
+      @include xx-large-and-up {
+        width: 620px;
       }
 
       html[dir="rtl"] & {
@@ -115,11 +119,11 @@
     overflow: hidden;
 
     img {
-      width: 600px;
-
+      width: 660px;
       transform: skew(-25deg);
+
       @include mobile-only {
-        width: 200px;
+        width: 280px;
         left: -50px;
       }
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6500

---

Expanding the images in the 3-column style to align with the wider XXL container. Also did some adjustments in mobile, where similar issues are visible.

### Testing

- Current probably can be seen in live sites on XXL screens.
- After switching to this branch images should split properly with no gaps and no overlaps on all breakpoints.