### PR TITLE
Allow multiple boxouts, remove id attribute

### DIFF
--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutBlock.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutBlock.js
@@ -11,7 +11,6 @@ export const registerTakeActionBoxoutBlock = () => registerBlockType(BLOCK_NAME,
   icon: 'welcome-widgets-menus',
   category: 'planet4-blocks',
   supports: {
-    multiple: false, // Use the block just once per post.
     html: false, // Disable "Edit as HTMl" block option.
   },
   // This attributes definition mimics the one in the PHP side.

--- a/templates/blocks/take-action-boxout.twig
+++ b/templates/blocks/take-action-boxout.twig
@@ -1,6 +1,6 @@
 {% block take_action_boxout %}
 	{% if ( boxout ) %}
-		<section id="action-card" class="boxout">
+		<section class="boxout">
 			<a
 				data-ga-category="Take Action Boxout"
 				data-ga-action="Image"


### PR DESCRIPTION
* Block now is inline so multiple should work.

[This master theme PR](https://github.com/greenpeace/planet4-master-theme/pull/1538) needs to be merged first.

Example on test instance: https://www-dev.greenpeace.org/test-iocaste/story/30102/the-story-of-plastic-is-an-eye-opener-on-the-global-plastic-pollution-crisis/