### PR TITLE
Fix small typo in Settings panel title

### DIFF
--- a/assets/src/blocks/Accordion/AccordionEditor.js
+++ b/assets/src/blocks/Accordion/AccordionEditor.js
@@ -123,7 +123,7 @@ const renderEdit = ({ tabs }, setAttributes, updateTabAttribute) => {
 
   return (
     <InspectorControls>
-      <PanelBody title={__('Setting', 'planet4-blocks-backend')}>
+      <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
         {tabs.map((tab, index) => {
           const { button } = tab;
           if (!button) {

--- a/assets/src/blocks/Articles/ArticlesEditor.js
+++ b/assets/src/blocks/Articles/ArticlesEditor.js
@@ -25,7 +25,7 @@ const renderEdit = (attributes, toAttribute) => {
   return (
     <Fragment>
       <InspectorControls>
-        <PanelBody title={__('Setting', 'planet4-blocks-backend')}>
+        <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
           <TextControl
             label={__('Button Text', 'planet4-blocks-backend')}
             placeholder={__('Override button text', 'planet4-blocks-backend')}

--- a/assets/src/blocks/CarouselHeader/Sidebar.js
+++ b/assets/src/blocks/CarouselHeader/Sidebar.js
@@ -150,7 +150,7 @@ export const Sidebar = ({
   }, [ dragTarget ]);
 
   return <InspectorControls>
-    <PanelBody title={__('Setting', 'planet4-blocks-backend')}>
+    <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
       <CheckboxControl
         label={__('Carousel Autoplay', 'planet4-blocks-backend')}
         help={__('Select to trigger images autoslide', 'planet4-blocks-backend')}

--- a/assets/src/blocks/Columns/ColumnsEditor.js
+++ b/assets/src/blocks/Columns/ColumnsEditor.js
@@ -44,7 +44,7 @@ const renderEdit = (attributes, toAttribute, setAttributes, isSelected) => {
   return (
     <>
       <InspectorControls>
-        <PanelBody title={__('Setting', 'planet4-blocks-backend')}>
+        <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
           <RangeControl
             label={__('Columns', 'planet4-blocks-backend')}
             value={columns.length}

--- a/assets/src/blocks/Counter/CounterEditor.js
+++ b/assets/src/blocks/Counter/CounterEditor.js
@@ -33,7 +33,7 @@ export class CounterEditor extends Component {
     return (
       <Fragment>
         <InspectorControls>
-          <PanelBody title={__('Setting', 'planet4-blocks-backend')}>
+          <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
             <div>
               <TextControl
                 label={__('Completed', 'planet4-blocks-backend')}

--- a/assets/src/blocks/Covers/CoversEditor.js
+++ b/assets/src/blocks/Covers/CoversEditor.js
@@ -26,7 +26,7 @@ const renderEdit = (attributes, toAttribute) => {
 
   return (
     <InspectorControls>
-      <PanelBody title={__('Setting', 'planet4-blocks-backend')}>
+      <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
         <SelectControl
           label='Rows to display'
           value={initialRowsLimit}

--- a/assets/src/blocks/Gallery/GalleryEditor.js
+++ b/assets/src/blocks/Gallery/GalleryEditor.js
@@ -78,7 +78,7 @@ const renderEdit = (attributes, setAttributes) => {
       </MediaUploadCheck>
       {hasImages && (
         <InspectorControls>
-          <PanelBody title={__('Setting', 'planet4-blocks-backend')}>
+          <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
             <div className="wp-block-master-theme-gallery__FocalPointPicker">
               <p>{__('Select gallery image focal point', 'planet4-blocks-backend')}</p>
               <ul>

--- a/assets/src/blocks/Happypoint/HappypointEditor.js
+++ b/assets/src/blocks/Happypoint/HappypointEditor.js
@@ -89,7 +89,7 @@ export const HappypointEditor = ({ attributes, setAttributes, isSelected }) => {
       {isSelected && (
         <div>
           <InspectorControls>
-            <PanelBody title={__('Setting', 'planet4-blocks-backend')}>
+            <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
               <div className="wp-block-master-theme-happypoint__RangeControl">
                 <RangeControl
                   label={__('Opacity', 'planet4-blocks-backend')}

--- a/assets/src/blocks/Media/MediaEditor.js
+++ b/assets/src/blocks/Media/MediaEditor.js
@@ -43,7 +43,7 @@ const MediaInspectorOptions = ({ attributes, setAttributes }) => {
   }
 
   return <InspectorControls>
-      <PanelBody title={__('Setting', 'planet4-blocks-backend')}>
+      <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
         <TextControl
           label={__('Media URL/ID', 'planet4-blocks-backend')}
           placeholder={__('Enter URL', 'planet4-blocks-backend')}

--- a/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
@@ -182,7 +182,7 @@ export const SocialMediaEditor = ({
 
   const renderSidebar = () => (
     <InspectorControls>
-      <PanelBody title={__('Setting', 'planet4-blocks-backend')}>
+      <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
         <RadioControl
           label={__('Embed type', 'planet4-blocks-backend')}
           options={[

--- a/assets/src/blocks/Splittwocolumns/SplittwocolumnsSettings.js
+++ b/assets/src/blocks/Splittwocolumns/SplittwocolumnsSettings.js
@@ -115,7 +115,7 @@ export const SplittwocolumnsSettings = ({attributes, charLimit, setAttributes}) 
 
   return (
     <InspectorControls>
-      <PanelBody title={__('Setting', 'planet4-blocks-backend')}>
+      <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
         <div>
           {issueOptions &&
             <SelectControl

--- a/assets/src/blocks/Spreadsheet/SpreadsheetEditorScript.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetEditorScript.js
@@ -74,7 +74,7 @@ export class SpreadsheetEditor extends Component {
     return (
       <Fragment>
         <InspectorControls>
-          <PanelBody title={__('Setting', 'planet4-blocks-backend')}>
+          <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
             <ColorPaletteControl
               label={__('Table Color', 'planet4-blocks-backend')}
               value={ attributes.css_variables['block-spreadsheet--odd-row--background'] }

--- a/assets/src/blocks/Submenu/SubmenuEditor.js
+++ b/assets/src/blocks/Submenu/SubmenuEditor.js
@@ -51,7 +51,7 @@ const renderEdit = (attributes, setAttributes) => {
 
   return (
     <InspectorControls>
-      <PanelBody title={__('Setting', 'planet4-blocks-backend')}>
+      <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
         {attributes.levels.map((level, i) => (
           <SubmenuLevel
             {...level}

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -172,7 +172,7 @@ export const TakeActionBoxoutEditor = ({
   const renderSidebar = () => (
     <Fragment>
       <InspectorControls>
-        <PanelBody title={__('Setting', 'planet4-blocks-backend')}>
+        <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
           <SelectControl
             label={__('Select Take Action Page:', 'planet4-blocks-backend')}
             value={take_action_page}

--- a/assets/src/blocks/Timeline/TimelineEditorScript.js
+++ b/assets/src/blocks/Timeline/TimelineEditorScript.js
@@ -52,7 +52,7 @@ const renderEdit = (
 ) => {
   return (
     <InspectorControls>
-      <PanelBody title={__('Setting', 'planet4-blocks-backend')}>
+      <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
         <URLInput
           label={__('Google Sheets URL', 'planet4-blocks-backend')}
           placeholder={__('Enter URL', 'planet4-blocks-backend')}

--- a/tests/js/articles.editor.spec.js
+++ b/tests/js/articles.editor.spec.js
@@ -85,7 +85,7 @@ describe( 'Articles block', () => {
     await typeInInputWithPlaceholderLabel( 'Enter text', 'More News' );
 
     // Add Setting inputs
-    await openSidebarPanelWithTitle( 'Setting' );
+    await openSidebarPanelWithTitle( 'Settings' );
     await clearPreviousTextWithLabel( 'Button Text' );
     await typeInInputWithLabel( 'Button Text', 'Read more' );
     await typeInInputWithLabel( 'Button Link', 'https://www.greenpeace.org' );
@@ -110,7 +110,7 @@ describe( 'Articles block', () => {
   } );
 
   it ( 'should use only the manually chosen posts if any are entered', async () => {
-    await openSidebarPanelWithTitle( 'Setting' );
+    await openSidebarPanelWithTitle( 'Settings' );
 
     // The below posts are added randomly in "Manual override" field,
     // but on frontend it should appear order by publication date.

--- a/tests/js/articles.frontend.spec.js
+++ b/tests/js/articles.frontend.spec.js
@@ -48,7 +48,7 @@ describe( 'Articles block frontend', () => {
 
     await selectBlockByName( 'planet4-blocks/articles' );
 
-    await openSidebarPanelWithTitle( 'Setting' );
+    await openSidebarPanelWithTitle( 'Settings' );
 
     // Manually add post(without thumbnail img) in articles blocks.
     await typeInDropdownWithLabel( 'Manual override', 'Test Articles with no thumbnail' );

--- a/tests/js/counter.spec.js
+++ b/tests/js/counter.spec.js
@@ -51,7 +51,7 @@ describe( 'Counter block', () => {
     await selectStyleByName( 'Text Only' );
 
     // Select the Text only counter style
-    await openSidebarPanelWithTitle( 'Setting' );
+    await openSidebarPanelWithTitle( 'Settings' );
     await typeInInputWithLabel( 'Completed', '60' );
     await typeInInputWithLabel( 'Target', '100' );
     await typeInTextareaWithLabel( 'Text', '%completed% out of %target%, %remaining% remaining' );
@@ -71,7 +71,7 @@ describe( 'Counter block', () => {
     await selectStyleByName( 'Progress Bar' );
 
     // Add Setting inputs
-    await openSidebarPanelWithTitle( 'Setting' );
+    await openSidebarPanelWithTitle( 'Settings' );
     await typeInInputWithLabel( 'Completed', '70' );
     await typeInInputWithLabel( 'Target', '100' );
     await typeInTextareaWithLabel( 'Text', '%completed% out of %target%, %remaining% remaining' );
@@ -94,7 +94,7 @@ describe( 'Counter block', () => {
     await selectStyleByName( 'Progress Dial' );
 
     // Add Setting inputs
-    await openSidebarPanelWithTitle( 'Setting' );
+    await openSidebarPanelWithTitle( 'Settings' );
     await typeInInputWithLabel( 'Completed', '75' );
     await typeInInputWithLabel( 'Target', '100' );
     await typeInTextareaWithLabel( 'Text', '%completed% out of %target%, %remaining% remaining' );
@@ -117,7 +117,7 @@ describe( 'Counter block', () => {
     await selectStyleByName( 'Progress Dial' );
 
     // Add Setting inputs
-    await openSidebarPanelWithTitle( 'Setting' );
+    await openSidebarPanelWithTitle( 'Settings' );
     await typeInInputWithLabel( 'Completed API URL', COUNTER_API_URL );
 
     await typeInInputWithLabel( 'Target', '5000000' );

--- a/tests/js/spreadsheet.spec.js
+++ b/tests/js/spreadsheet.spec.js
@@ -67,7 +67,7 @@ describe( 'Spreadsheet block', () => {
     await selectBlockByName( 'planet4-blocks/spreadsheet' );
 
     // Change background color
-    await openSidebarPanelWithTitle( 'Setting' );
+    await openSidebarPanelWithTitle( 'Settings' );
     await selectColorByName( 'green' );
 
     expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/tests/js/submenu.spec.js
+++ b/tests/js/submenu.spec.js
@@ -79,7 +79,7 @@ describe( 'Submenu block', () => {
     await selectStyleByName( 'Long full-width' );
 
     // Add Setting inputs
-    await openSidebarPanelWithTitle( 'Setting' );
+    await openSidebarPanelWithTitle( 'Settings' );
 
     // Add 3 levels inputs of submenu.
     for (let i = 0; i < 3; i++) {
@@ -109,7 +109,7 @@ describe( 'Submenu block', () => {
     await selectStyleByName( 'Short full-width' );
 
     // Add Setting inputs
-    await openSidebarPanelWithTitle( 'Setting' );
+    await openSidebarPanelWithTitle( 'Settings' );
 
     // Add 3 levels inputs of submenu.
     for (let i = 0; i < 3; i++) {
@@ -139,7 +139,7 @@ describe( 'Submenu block', () => {
     await selectStyleByName( 'Short sidebar' );
 
     // Add Setting inputs
-    await openSidebarPanelWithTitle( 'Setting' );
+    await openSidebarPanelWithTitle( 'Settings' );
 
     // Add 3 levels inputs of submenu.
     for (let i = 0; i < 3; i++) {


### PR DESCRIPTION
### Description

For WYSIWYG blocks, in the sidebar the panel was called `Setting` instead of `Settings` which is more accurate as there's usually several settings 🙃 