### PR TITLE
PLANET-6482 Fix Accordion block button width in the editor

### DIFF
--- a/assets/src/styles/blocks/Accordion/AccordionEditorStyle.scss
+++ b/assets/src/styles/blocks/Accordion/AccordionEditorStyle.scss
@@ -29,7 +29,7 @@
   }
 }
 
-.accordion-content .button-container {
+.accordion-block .accordion-content .button-container {
   position: relative;
   width: 80%;
 


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-6482

Because the CSS code was not specific enough, the width attribute for the button was overridden, resulting in a really ugly input 😬 

### Testing 

Create an Accordion block in the editor, before the fix you should see the button as shown on the ticket (in one long vertical line) and after the fix it should look as expected 🙂 I've tested it on both Chrome, FF and Safari and it seems to work fine in all of these!