### PR TITLE
Bump theme submodule for spacing variables

### DIFF
--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -309,7 +309,7 @@
         }
 
         .card-block {
-          padding: calc(#{$sp-4} - #{$sp-2}) $sp-3x $sp-4;
+          padding: $sp-2 $sp-3x $sp-4;
           border-bottom: none;
 
           p {


### PR DESCRIPTION
Bump to changes introduced in https://github.com/greenpeace/planet4-master-theme/pull/1550

Also simplify a rule to not use `calc`.