### PR TITLE
Bump theme editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2305,9 +2305,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -4759,30 +4759,30 @@
       }
     },
     "babel-plugin-styled-components": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.13.3.tgz",
-      "integrity": "sha512-meGStRGv+VuKA/q0/jXxrPNWEm4LPfYIqxooDTdmh8kFsP/Ph7jJG5rUPwUPX3QHUvggwdbgdGpo88P/rRYsVw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.2.tgz",
+      "integrity": "sha512-7eG5NE8rChnNTDxa6LQfynwgHTVOYYaHJbUYSlOhk8QBXIQiMBKq4gyfHBBKPrxUcVBXVJL61ihduCpCQbuNbw==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.15.4",
-        "@babel/helper-module-imports": "^7.15.4",
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-module-imports": "^7.16.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
         "lodash": "^4.17.11"
       },
       "dependencies": {
         "@babel/helper-annotate-as-pure": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
-          "integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz",
+          "integrity": "sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==",
           "requires": {
-            "@babel/types": "^7.15.4"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-module-imports": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
-          "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
+          "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
           "requires": {
-            "@babel/types": "^7.15.4"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-validator-identifier": {
@@ -4791,11 +4791,11 @@
           "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
         },
         "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
+            "@babel/helper-validator-identifier": "^7.15.7",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -6608,9 +6608,9 @@
       },
       "dependencies": {
         "postcss-value-parser": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-          "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+          "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
         }
       }
     },
@@ -19142,15 +19142,15 @@
       "dev": true
     },
     "use-theme-editor": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/use-theme-editor/-/use-theme-editor-1.2.8.tgz",
-      "integrity": "sha512-HL9k8UZCg0Ey3UBq7/Y9QqVMPZju+piOAIA2H6oXFBftt7S9FkdTtgjhijnToO5OyyCsWU4UHI4PDuDgMQQOVA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/use-theme-editor/-/use-theme-editor-1.3.7.tgz",
+      "integrity": "sha512-knnmTuV4DEU11M18Ux1mNU2lp4NHJAU0pwIPxGaR+lMw+BOoH1CYTli/QCGmzkz9frjbxzLHUPD0eQuvVXOfpw==",
       "requires": {
         "balanced-match": "^2.0.0",
         "font-picker-react": "^3.5.2",
         "react-color": "^2.19.3",
         "react-hotkeys-hook": "^3.0.3",
-        "react-shadow-picker": "^1.0.5",
+        "react-shadow-picker": "^1.0.6",
         "specificity": "^0.4.1",
         "tinycolor2": "^1.4.2"
       }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "jest-environment-node": "^26.0.1",
     "photoswipe": "^4.1.3",
     "react-dom": "^17.0.2",
-    "use-theme-editor": "^1.2.8"
+    "use-theme-editor": "^1.3.7"
   }
 }


### PR DESCRIPTION
* Better editor UI positioning.
* Allows linking to your IDE per variable.
* Various fixes.

You can only use the links to open stuff in your IDE after doing the following:
1) Install this protocol handler https://github.com/sanduhrs/phpstorm-url-handler. You can technically also use another IDE by changing the [handler file included in that repo](https://github.com/sanduhrs/phpstorm-url-handler/blob/master/phpstorm-url-handler#L20-L23) to use a command to open in your IDE instead. But for now the protocol name is hard coded to `phpstorm`.
2) Add the path mappings for each repo to the local storage.
* The key is `repo-paths`. If you're on a test instance, you need to prefix it with the instance name + `/`.
* The key of this object will be searched for in a stylesheet name, and if it matches it will use the value as the base path.
For the test instance this looks like this:
```js
localStorage.setItem('test-neptune/repo-paths', {

  'planet4-master-theme': '/foo/bar/baz',
  'planet4-plugin-gutenberg-blocks': '/buz/biz/bza'
})
```

Relevant changes: https://github.com/Inwerpsel/use-theme-editor/compare/2f526286c1ab9cb8c81b70e9110eb5e9a22b86a6..cefd49e7920e86240dbb98c68c2d1462232b8d71