### PR TITLE
PLANET-5609 Fix existing Covers blocks in the backend

### DIFF
--- a/assets/src/blocks/Covers/deprecated/coversV1.js
+++ b/assets/src/blocks/Covers/deprecated/coversV1.js
@@ -1,3 +1,5 @@
+import { COVERS_LAYOUTS } from '../CoversConstants';
+
 const OLD_COVER_TYPES = {
   '1': 'take-action',
   '2': 'campaign',
@@ -32,10 +34,10 @@ export const coversV1 = {
       type: 'string',
     },
   },
-  isEligible({ covers_view, cover_type }) {
-    return covers_view || !isNaN(cover_type);
+  isEligible({ covers_view, cover_type, layout }) {
+    return covers_view || !isNaN(cover_type) || !layout;
   },
-  migrate( { covers_view, cover_type, ...attributes } ) {
+  migrate( { covers_view, cover_type, layout, ...attributes } ) {
     attributes.version = 1;
     attributes.initialRowsLimit = covers_view === '3' ? 0 : Number(covers_view);
 
@@ -43,6 +45,10 @@ export const coversV1 = {
       attributes.cover_type = OLD_COVER_TYPES[cover_type];
     } else {
       attributes.cover_type = cover_type;
+    }
+
+    if (!layout) {
+      attributes.layout = COVERS_LAYOUTS.grid;
     }
 
     return attributes;


### PR DESCRIPTION
### Description

In the frontend existing blocks do show the grid layout by default as expected, but in the backend they still didn't have a layout attribute which caused some design issues. Setting the new layout attribute to grid by default in the coversV1 file fixed that problem.

### Testing

On your local, you can go to a page that had a Covers block before releasing the new layout attribute (for example `/act`) and edit it, to see that in the backend no layout setting is selected and the preview looks weird 😬 If you then switch to this branch, the issue should be solved.