### PR TITLE
PLANET-6106 Use block examples for Covers styles

### DIFF
--- a/assets/src/blocks/Covers/CampaignCovers.js
+++ b/assets/src/blocks/Covers/CampaignCovers.js
@@ -1,3 +1,4 @@
+import { CoversImagePlaceholder } from './CoversImagePlaceholder';
 import { IMAGE_SIZES } from './imageSizes';
 
 const { __ } = wp.i18n;
@@ -9,6 +10,7 @@ export const CampaignCovers = ({
   inEditor = false,
   isCarouselLayout,
   amountOfCoversPerRow,
+  isExample,
 }) => (
   <div className='covers'>
     {covers.map((cover, index) => {
@@ -31,7 +33,7 @@ export const CampaignCovers = ({
             aria-label={__('Check our campaign about ' + name, 'planet4-blocks')}
           >
             <div className='thumbnail-large'>
-              {image && image[0] &&
+              {image && image[0] && !isExample &&
                 <img
                   loading='lazy'
                   sizes={IMAGE_SIZES.campaign}
@@ -41,6 +43,7 @@ export const CampaignCovers = ({
                   title={alt_text}
                 />
               }
+              {isExample && <CoversImagePlaceholder height={150} />}
               <span className='yellow-cta'><span aria-label='hashtag'>#</span>{name}</span>
             </div>
           </a>

--- a/assets/src/blocks/Covers/CampaignCovers.js
+++ b/assets/src/blocks/Covers/CampaignCovers.js
@@ -14,7 +14,7 @@ export const CampaignCovers = ({
 }) => (
   <div className='covers'>
     {covers.map((cover, index) => {
-      const { href, image, alt_text, name, src_set } = cover;
+      const { href, image, alt_text, name, src_set, id } = cover;
       const hideCover = !isCarouselLayout && !!initialRowsLimit && index >= row * amountOfCoversPerRow;
 
       if (hideCover) {
@@ -24,7 +24,7 @@ export const CampaignCovers = ({
       const campaignLink = inEditor ? null : href;
 
       return (
-        <div key={name} className='campaign-card-column cover'>
+        <div key={id} className='campaign-card-column cover'>
           <a
             href={campaignLink}
             data-ga-category='Campaign Covers'

--- a/assets/src/blocks/Covers/ContentCovers.js
+++ b/assets/src/blocks/Covers/ContentCovers.js
@@ -1,3 +1,4 @@
+import { CoversImagePlaceholder } from './CoversImagePlaceholder';
 import { IMAGE_SIZES } from './imageSizes';
 
 const { __ } = wp.i18n;
@@ -8,7 +9,8 @@ export const ContentCovers = ({
   row,
   inEditor = false,
   isCarouselLayout,
-  amountOfCoversPerRow
+  amountOfCoversPerRow,
+  isExample,
 }) => (
   <div className='covers'>
     {covers.map((cover, index) => {
@@ -34,8 +36,8 @@ export const ContentCovers = ({
         <div key={post_title} className='post-column cover'>
           <div className='content-covers-block-wrap clearfix'>
             <div className='content-covers-block-info'>
-              <div className='content-covers-block-image'>
-                {thumbnail &&
+              <div className='content-covers-block-image' {...isExample && { style: { height: 120 } }}>
+                {thumbnail && !isExample &&
                   <a
                     href={contentLink}
                     data-ga-category='Content Covers'
@@ -53,6 +55,7 @@ export const ContentCovers = ({
                     />
                   </a>
                 }
+                {isExample && <CoversImagePlaceholder height='100%' />}
               </div>
               <div className='content-covers-block-information'>
                 {post_title &&

--- a/assets/src/blocks/Covers/ContentCovers.js
+++ b/assets/src/blocks/Covers/ContentCovers.js
@@ -22,6 +22,7 @@ export const ContentCovers = ({
         alt_text,
         date_formatted,
         post_excerpt,
+        id,
       } = cover;
 
       const hideCover = !isCarouselLayout && !!initialRowsLimit && index >= row * amountOfCoversPerRow;
@@ -33,7 +34,7 @@ export const ContentCovers = ({
       const contentLink = inEditor ? null : link;
 
       return (
-        <div key={post_title} className='post-column cover'>
+        <div key={id} className='post-column cover'>
           <div className='content-covers-block-wrap clearfix'>
             <div className='content-covers-block-info'>
               <div className='content-covers-block-image' {...isExample && { style: { height: 120 } }}>

--- a/assets/src/blocks/Covers/CoversEditor.js
+++ b/assets/src/blocks/Covers/CoversEditor.js
@@ -96,49 +96,63 @@ const renderEdit = (attributes, toAttribute, setAttributes) => {
 };
 
 const renderView = (attributes, toAttribute) => {
-  const { initialRowsLimit, cover_type, title, description, className, layout } = attributes;
+  const {
+    initialRowsLimit,
+    cover_type,
+    title,
+    description,
+    className,
+    layout,
+    isExample,
+    exampleCovers
+  } = attributes;
 
   const { covers, loading, row, amountOfCoversPerRow } = useCovers(attributes);
 
   const isCarouselLayout = layout === COVERS_LAYOUTS.carousel;
 
   const coversProps = {
-    covers,
+    covers: isExample ? exampleCovers[cover_type] : covers,
     initialRowsLimit,
     row,
     showMoreCovers: () => {},
     cover_type,
     inEditor: true,
     isCarouselLayout,
-    amountOfCoversPerRow
+    amountOfCoversPerRow,
+    isExample,
   };
 
   const showLoadMoreButton = !isCarouselLayout && !!initialRowsLimit && covers.length > (amountOfCoversPerRow * row);
 
   return (
     <section className={`block covers-block ${cover_type}-covers-block ${className ?? ''} ${layout}-layout`}>
-      <header>
-        <RichText
-          tagName='h2'
-          className='page-section-header'
-          placeholder={__('Enter title', 'planet4-blocks-backend')}
-          value={title}
-          onChange={toAttribute('title')}
-          withoutInteractiveFormatting
-          multiline='false'
-          allowedFormats={[]}
-        />
-      </header>
-      <RichText
-        tagName='p'
-        className='page-section-description'
-        placeholder={__('Enter description', 'planet4-blocks-backend')}
-        value={description}
-        onChange={toAttribute('description')}
-        withoutInteractiveFormatting
-        allowedFormats={['core/bold', 'core/italic']}
-      />
-      {!loading && !covers.length ?
+      {!isExample &&
+        <>
+          <header>
+            <RichText
+              tagName='h2'
+              className='page-section-header'
+              placeholder={__('Enter title', 'planet4-blocks-backend')}
+              value={title}
+              onChange={toAttribute('title')}
+              withoutInteractiveFormatting
+              multiline='false'
+              allowedFormats={[]}
+            />
+          </header>
+          <RichText
+            tagName='p'
+            className='page-section-description'
+            placeholder={__('Enter description', 'planet4-blocks-backend')}
+            value={description}
+            onChange={toAttribute('description')}
+            withoutInteractiveFormatting
+            allowedFormats={['core/bold', 'core/italic']}
+          />
+        </>
+      }
+      {!loading && !covers.length && !isExample ?
         <div className='EmptyMessage'>
           {__('Block content is empty. Check the block\'s settings or remove it.', 'planet4-blocks-backend')}
         </div> :

--- a/assets/src/blocks/Covers/CoversEditorScript.js
+++ b/assets/src/blocks/Covers/CoversEditorScript.js
@@ -3,6 +3,7 @@ import { frontendRendered } from '../frontendRendered';
 import { Tooltip } from '@wordpress/components';
 import { coversV1 } from './deprecated/coversV1';
 import { COVERS_TYPES, COVERS_LAYOUTS } from './CoversConstants';
+import { example } from './example.js';
 
 const { __ } = wp.i18n;
 
@@ -67,6 +68,13 @@ const registerCoversBlock = () => {
         type: 'string',
         default: COVERS_LAYOUTS.grid,
       },
+      isExample: {
+        type: 'boolean',
+        default: false,
+      },
+      exampleCovers: { // Used for the block's preview, which can't extract items from anything.
+        type: 'object',
+      }
     },
     edit: CoversEditor,
     save: frontendRendered(BLOCK_NAME),
@@ -97,7 +105,8 @@ const registerCoversBlock = () => {
     ],
     deprecated: [
       coversV1,
-    ]
+    ],
+    example,
   });
 }
 

--- a/assets/src/blocks/Covers/CoversImagePlaceholder.js
+++ b/assets/src/blocks/Covers/CoversImagePlaceholder.js
@@ -1,0 +1,7 @@
+import { ImagePlaceholderIcon } from '../../components/ImagePlaceholderIcon';
+
+export const CoversImagePlaceholder = ({ height }) => (
+  <div className='covers-image-placeholder' style={{ height }}>
+    <ImagePlaceholderIcon width={20} height={20} fill={'#ffffff'}/>
+  </div>
+);

--- a/assets/src/blocks/Covers/TakeActionCovers.js
+++ b/assets/src/blocks/Covers/TakeActionCovers.js
@@ -23,6 +23,7 @@ export const TakeActionCovers = ({
         alt_text,
         excerpt,
         button_text,
+        id,
       } = cover;
       const hideCover = !isCarouselLayout && !!initialRowsLimit && index >= row * amountOfCoversPerRow;
 
@@ -33,7 +34,7 @@ export const TakeActionCovers = ({
       const buttonLink = inEditor ? null : button_link;
 
       return (
-        <div key={title} className='cover-card cover'>
+        <div key={id} className='cover-card cover'>
           <a
             className='cover-card-overlay'
             data-ga-category='Take Action Covers'

--- a/assets/src/blocks/Covers/TakeActionCovers.js
+++ b/assets/src/blocks/Covers/TakeActionCovers.js
@@ -1,3 +1,4 @@
+import { CoversImagePlaceholder } from './CoversImagePlaceholder';
 import { IMAGE_SIZES } from './imageSizes';
 
 const { __ } = wp.i18n;
@@ -9,6 +10,7 @@ export const TakeActionCovers = ({
   inEditor = false,
   isCarouselLayout,
   amountOfCoversPerRow,
+  isExample,
 }) => (
   <div className='covers'>
     {covers.map((cover, index) => {
@@ -47,12 +49,15 @@ export const TakeActionCovers = ({
             href={buttonLink}
             aria-label={__('Take action cover, link to ' + title, 'planet4-blocks')}
           >
-            <img
-              alt={alt_text}
-              src={image}
-              srcSet={srcset}
-              sizes={IMAGE_SIZES.takeAction}
-            />
+            {isExample ?
+              <CoversImagePlaceholder height={220} /> :
+              <img
+                alt={alt_text}
+                src={image}
+                srcSet={srcset}
+                sizes={IMAGE_SIZES.takeAction}
+              />
+            }
           </a>
           <div className='cover-card-content'>
             {/* Regardless of how many tags there are, we only show the first one */}

--- a/assets/src/blocks/Covers/example.js
+++ b/assets/src/blocks/Covers/example.js
@@ -1,0 +1,63 @@
+export const example = {
+  attributes: {
+    isExample: true,
+    title: 'Covers block',
+    exampleCovers: {
+      content: [
+        {
+          post_title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+          post_excerpt: 'Etiam et turpis et tortor congue interdum quis in leo. Donec vel eros eget mauris aliquam commodo.',
+        },
+        {
+          post_title: 'Vivamus ornare varius neque at posuere',
+          post_excerpt: 'Cras suscipit velit nec gravida auctor. Suspendisse et enim a ex feugiat interdum laoreet vel lorem.',
+        },
+        {
+          post_title: 'Vestibulum vitae purus neque',
+          post_excerpt: 'In egestas mollis leo. Suspendisse in iaculis mauris. Duis sagittis arcu vel sodales bibendum. Ut sed sagittis lectus. ',
+        },
+        {
+          post_title: 'In egestas mollis leo',
+          post_excerpt: 'Suspendisse in iaculis mauris. Duis sagittis arcu vel sodales bibendum. Ut sed sagittis lectus.',
+        },
+      ],
+      campaign: [
+        {
+          name: 'Tag1',
+        },
+        {
+          name: 'Tag2',
+        },
+        {
+          name: 'Tag3'
+        },
+      ],
+      'take-action': [
+        {
+          title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+          excerpt: 'Etiam et turpis et tortor congue interdum quis in leo. Donec vel eros eget mauris aliquam commodo.',
+          button_text: 'Take action',
+          tags: [{
+            name: 'Tag1'
+          }],
+        },
+        {
+          title: 'Vivamus ornare varius neque at posuere',
+          excerpt: 'Cras suscipit velit nec gravida auctor. Suspendisse et enim a ex feugiat interdum laoreet vel lorem.',
+          button_text: 'Take action',
+          tags: [{
+            name: 'Tag2'
+          }],
+        },
+        {
+          title: 'Vitae purus neque',
+          excerpt: 'In egestas mollis leo. Suspendisse in iaculis mauris. Duis sagittis arcu vel sodales bibendum.',
+          button_text: 'Take action',
+          tags: [{
+            name: 'Tag3'
+          }],
+        },
+      ],
+    }
+  },
+};

--- a/assets/src/blocks/Covers/example.js
+++ b/assets/src/blocks/Covers/example.js
@@ -5,35 +5,43 @@ export const example = {
     exampleCovers: {
       content: [
         {
+          id: 'content-1',
           post_title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
           post_excerpt: 'Etiam et turpis et tortor congue interdum quis in leo. Donec vel eros eget mauris aliquam commodo.',
         },
         {
+          id: 'content-2',
           post_title: 'Vivamus ornare varius neque at posuere',
           post_excerpt: 'Cras suscipit velit nec gravida auctor. Suspendisse et enim a ex feugiat interdum laoreet vel lorem.',
         },
         {
+          id: 'content-3',
           post_title: 'Vestibulum vitae purus neque',
           post_excerpt: 'In egestas mollis leo. Suspendisse in iaculis mauris. Duis sagittis arcu vel sodales bibendum. Ut sed sagittis lectus. ',
         },
         {
+          id: 'content-4',
           post_title: 'In egestas mollis leo',
           post_excerpt: 'Suspendisse in iaculis mauris. Duis sagittis arcu vel sodales bibendum. Ut sed sagittis lectus.',
         },
       ],
       campaign: [
         {
+          id: 'campaign-1',
           name: 'Tag1',
         },
         {
+          id: 'campaign-2',
           name: 'Tag2',
         },
         {
+          id: 'campaign-3',
           name: 'Tag3'
         },
       ],
       'take-action': [
         {
+          id: 'take-action-1',
           title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
           excerpt: 'Etiam et turpis et tortor congue interdum quis in leo. Donec vel eros eget mauris aliquam commodo.',
           button_text: 'Take action',
@@ -42,6 +50,7 @@ export const example = {
           }],
         },
         {
+          id: 'take-action-2',
           title: 'Vivamus ornare varius neque at posuere',
           excerpt: 'Cras suscipit velit nec gravida auctor. Suspendisse et enim a ex feugiat interdum laoreet vel lorem.',
           button_text: 'Take action',
@@ -50,6 +59,7 @@ export const example = {
           }],
         },
         {
+          id: 'take-action-3',
           title: 'Vitae purus neque',
           excerpt: 'In egestas mollis leo. Suspendisse in iaculis mauris. Duis sagittis arcu vel sodales bibendum.',
           button_text: 'Take action',

--- a/assets/src/styles/blocks/Covers/CoversEditorStyle.scss
+++ b/assets/src/styles/blocks/Covers/CoversEditorStyle.scss
@@ -1,0 +1,9 @@
+@import "../../master-theme/assets/src/scss/base/colors";
+
+.covers-image-placeholder {
+  background: $grey-20;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+}

--- a/classes/blocks/class-covers.php
+++ b/classes/blocks/class-covers.php
@@ -359,6 +359,7 @@ class Covers extends Base_Block {
 				'name' => html_entity_decode( $tag->name ),
 				'slug' => $tag->slug,
 				'href' => get_tag_link( $tag ),
+				'id'   => self::CAMPAIGN_COVER_TYPE . '-' . $tag->term_id,
 			];
 			$attachment_id = get_term_meta( $tag->term_id, 'tag_attachment_id', true );
 
@@ -412,6 +413,7 @@ class Covers extends Base_Block {
 				$img_id = get_post_thumbnail_id( $action );
 
 				$covers[] = [
+					'id'          => self::TAKE_ACTION_COVER_TYPE . '-' . $action->ID,
 					'tags'        => $tags ?? [],
 					'title'       => html_entity_decode( get_the_title( $action ) ),
 					'excerpt'     => $action->post_excerpt,
@@ -447,6 +449,7 @@ class Covers extends Base_Block {
 		$posts_array = [];
 		foreach ( $posts as $post ) {
 			$post_data = [
+				'id'             => self::CONTENT_COVER_TYPE . '-' . $post->ID,
 				'post_title'     => $post->post_title,
 				'post_excerpt'   => $post->post_excerpt,
 				'alt_text'       => '',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,6 +90,7 @@ const cssConfig = {
     SocialMediaStyle: './assets/src/styles/blocks/SocialMedia/SocialMediaStyle.scss',
     SocialMediaEditorStyle: './assets/src/styles/blocks/SocialMedia/SocialMediaEditorStyle.scss',
     CoversStyle: './assets/src/styles/blocks/Covers/CoversStyle.scss',
+    CoversEditorStyle: './assets/src/styles/blocks/Covers/CoversEditorStyle.scss',
     GalleryStyle: './assets/src/styles/blocks/Gallery/GalleryStyle.scss',
     GalleryEditorStyle: './assets/src/styles/blocks/Gallery/GalleryEditorStyle.scss',
     HubspotFormStyle: './assets/src/styles/blocks/HubspotForm/HubspotFormStyles.scss',


### PR DESCRIPTION
### Description

See [PLANET-6106](https://jira.greenpeace.org/browse/PLANET-6106)
This is to give a better idea of the block styles when the block is empty. This PR also solves the missing keys console warnings that showed up when switching styles, by adding an id to all covers instead of using a different attribute per style such as `name` or `post_title`. This new id also makes sure that there are no duplicates, whereas before the fix there could have been some edge cases with the same post title for example.

### Testing

On your local, you can add a Covers block to a page and check the new styles in the editor, in the sidebar. Otherwise you can check it out on the test instance, for instance on the [Act page](https://www-dev.greenpeace.org/test-nix/act) that already has a Covers block 🙂  