### PR TITLE
Remove covers ids

### DIFF
--- a/assets/src/blocks/Covers/CampaignCovers.js
+++ b/assets/src/blocks/Covers/CampaignCovers.js
@@ -24,7 +24,7 @@ export const CampaignCovers = ({
       const campaignLink = inEditor ? null : href;
 
       return (
-        <div key={name} className='campaign-card-column cover'>
+        <div key={href} className='campaign-card-column cover'>
           <a
             href={campaignLink}
             data-ga-category='Campaign Covers'

--- a/assets/src/blocks/Covers/CampaignCovers.js
+++ b/assets/src/blocks/Covers/CampaignCovers.js
@@ -14,7 +14,7 @@ export const CampaignCovers = ({
 }) => (
   <div className='covers'>
     {covers.map((cover, index) => {
-      const { href, image, alt_text, name, src_set, id } = cover;
+      const { href, image, alt_text, name, src_set } = cover;
       const hideCover = !isCarouselLayout && !!initialRowsLimit && index >= row * amountOfCoversPerRow;
 
       if (hideCover) {
@@ -24,7 +24,7 @@ export const CampaignCovers = ({
       const campaignLink = inEditor ? null : href;
 
       return (
-        <div key={id} className='campaign-card-column cover'>
+        <div key={name} className='campaign-card-column cover'>
           <a
             href={campaignLink}
             data-ga-category='Campaign Covers'

--- a/assets/src/blocks/Covers/ContentCovers.js
+++ b/assets/src/blocks/Covers/ContentCovers.js
@@ -22,7 +22,6 @@ export const ContentCovers = ({
         alt_text,
         date_formatted,
         post_excerpt,
-        id,
       } = cover;
 
       const hideCover = !isCarouselLayout && !!initialRowsLimit && index >= row * amountOfCoversPerRow;
@@ -34,7 +33,7 @@ export const ContentCovers = ({
       const contentLink = inEditor ? null : link;
 
       return (
-        <div key={id} className='post-column cover'>
+        <div key={post_title} className='post-column cover'>
           <div className='content-covers-block-wrap clearfix'>
             <div className='content-covers-block-info'>
               <div className='content-covers-block-image' {...isExample && { style: { height: 120 } }}>

--- a/assets/src/blocks/Covers/ContentCovers.js
+++ b/assets/src/blocks/Covers/ContentCovers.js
@@ -33,7 +33,7 @@ export const ContentCovers = ({
       const contentLink = inEditor ? null : link;
 
       return (
-        <div key={post_title} className='post-column cover'>
+        <div key={link} className='post-column cover'>
           <div className='content-covers-block-wrap clearfix'>
             <div className='content-covers-block-info'>
               <div className='content-covers-block-image' {...isExample && { style: { height: 120 } }}>

--- a/assets/src/blocks/Covers/TakeActionCovers.js
+++ b/assets/src/blocks/Covers/TakeActionCovers.js
@@ -33,7 +33,7 @@ export const TakeActionCovers = ({
       const buttonLink = inEditor ? null : button_link;
 
       return (
-        <div key={title} className='cover-card cover'>
+        <div key={button_link} className='cover-card cover'>
           <a
             className='cover-card-overlay'
             data-ga-category='Take Action Covers'

--- a/assets/src/blocks/Covers/TakeActionCovers.js
+++ b/assets/src/blocks/Covers/TakeActionCovers.js
@@ -23,7 +23,6 @@ export const TakeActionCovers = ({
         alt_text,
         excerpt,
         button_text,
-        id,
       } = cover;
       const hideCover = !isCarouselLayout && !!initialRowsLimit && index >= row * amountOfCoversPerRow;
 
@@ -34,7 +33,7 @@ export const TakeActionCovers = ({
       const buttonLink = inEditor ? null : button_link;
 
       return (
-        <div key={id} className='cover-card cover'>
+        <div key={title} className='cover-card cover'>
           <a
             className='cover-card-overlay'
             data-ga-category='Take Action Covers'

--- a/assets/src/blocks/Covers/example.js
+++ b/assets/src/blocks/Covers/example.js
@@ -5,43 +5,35 @@ export const example = {
     exampleCovers: {
       content: [
         {
-          id: 'content-1',
           post_title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
           post_excerpt: 'Etiam et turpis et tortor congue interdum quis in leo. Donec vel eros eget mauris aliquam commodo.',
         },
         {
-          id: 'content-2',
           post_title: 'Vivamus ornare varius neque at posuere',
           post_excerpt: 'Cras suscipit velit nec gravida auctor. Suspendisse et enim a ex feugiat interdum laoreet vel lorem.',
         },
         {
-          id: 'content-3',
           post_title: 'Vestibulum vitae purus neque',
           post_excerpt: 'In egestas mollis leo. Suspendisse in iaculis mauris. Duis sagittis arcu vel sodales bibendum. Ut sed sagittis lectus. ',
         },
         {
-          id: 'content-4',
           post_title: 'In egestas mollis leo',
           post_excerpt: 'Suspendisse in iaculis mauris. Duis sagittis arcu vel sodales bibendum. Ut sed sagittis lectus.',
         },
       ],
       campaign: [
         {
-          id: 'campaign-1',
           name: 'Tag1',
         },
         {
-          id: 'campaign-2',
           name: 'Tag2',
         },
         {
-          id: 'campaign-3',
           name: 'Tag3'
         },
       ],
       'take-action': [
         {
-          id: 'take-action-1',
           title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
           excerpt: 'Etiam et turpis et tortor congue interdum quis in leo. Donec vel eros eget mauris aliquam commodo.',
           button_text: 'Take action',
@@ -50,7 +42,6 @@ export const example = {
           }],
         },
         {
-          id: 'take-action-2',
           title: 'Vivamus ornare varius neque at posuere',
           excerpt: 'Cras suscipit velit nec gravida auctor. Suspendisse et enim a ex feugiat interdum laoreet vel lorem.',
           button_text: 'Take action',
@@ -59,7 +50,6 @@ export const example = {
           }],
         },
         {
-          id: 'take-action-3',
           title: 'Vitae purus neque',
           excerpt: 'In egestas mollis leo. Suspendisse in iaculis mauris. Duis sagittis arcu vel sodales bibendum.',
           button_text: 'Take action',

--- a/assets/src/blocks/Covers/example.js
+++ b/assets/src/blocks/Covers/example.js
@@ -5,35 +5,43 @@ export const example = {
     exampleCovers: {
       content: [
         {
+          link: 'page-1',
           post_title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
           post_excerpt: 'Etiam et turpis et tortor congue interdum quis in leo. Donec vel eros eget mauris aliquam commodo.',
         },
         {
+          link: 'page-2',
           post_title: 'Vivamus ornare varius neque at posuere',
           post_excerpt: 'Cras suscipit velit nec gravida auctor. Suspendisse et enim a ex feugiat interdum laoreet vel lorem.',
         },
         {
+          link: 'page-3',
           post_title: 'Vestibulum vitae purus neque',
           post_excerpt: 'In egestas mollis leo. Suspendisse in iaculis mauris. Duis sagittis arcu vel sodales bibendum. Ut sed sagittis lectus. ',
         },
         {
+          link: 'page-4',
           post_title: 'In egestas mollis leo',
           post_excerpt: 'Suspendisse in iaculis mauris. Duis sagittis arcu vel sodales bibendum. Ut sed sagittis lectus.',
         },
       ],
       campaign: [
         {
+          href: 'Tag1',
           name: 'Tag1',
         },
         {
+          href: 'Tag2',
           name: 'Tag2',
         },
         {
+          href: 'Tag3',
           name: 'Tag3'
         },
       ],
       'take-action': [
         {
+          button_link: 'Page1',
           title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
           excerpt: 'Etiam et turpis et tortor congue interdum quis in leo. Donec vel eros eget mauris aliquam commodo.',
           button_text: 'Take action',
@@ -42,6 +50,7 @@ export const example = {
           }],
         },
         {
+          button_link: 'Page2',
           title: 'Vivamus ornare varius neque at posuere',
           excerpt: 'Cras suscipit velit nec gravida auctor. Suspendisse et enim a ex feugiat interdum laoreet vel lorem.',
           button_text: 'Take action',
@@ -50,6 +59,7 @@ export const example = {
           }],
         },
         {
+          button_link: 'Page3',
           title: 'Vitae purus neque',
           excerpt: 'In egestas mollis leo. Suspendisse in iaculis mauris. Duis sagittis arcu vel sodales bibendum.',
           button_text: 'Take action',

--- a/classes/blocks/class-covers.php
+++ b/classes/blocks/class-covers.php
@@ -359,7 +359,6 @@ class Covers extends Base_Block {
 				'name' => html_entity_decode( $tag->name ),
 				'slug' => $tag->slug,
 				'href' => get_tag_link( $tag ),
-				'id'   => self::CAMPAIGN_COVER_TYPE . '-' . $tag->term_id,
 			];
 			$attachment_id = get_term_meta( $tag->term_id, 'tag_attachment_id', true );
 
@@ -413,7 +412,6 @@ class Covers extends Base_Block {
 				$img_id = get_post_thumbnail_id( $action );
 
 				$covers[] = [
-					'id'          => self::TAKE_ACTION_COVER_TYPE . '-' . $action->ID,
 					'tags'        => $tags ?? [],
 					'title'       => html_entity_decode( get_the_title( $action ) ),
 					'excerpt'     => $action->post_excerpt,
@@ -449,7 +447,6 @@ class Covers extends Base_Block {
 		$posts_array = [];
 		foreach ( $posts as $post ) {
 			$post_data = [
-				'id'             => self::CONTENT_COVER_TYPE . '-' . $post->ID,
 				'post_title'     => $post->post_title,
 				'post_excerpt'   => $post->post_excerpt,
 				'alt_text'       => '',


### PR DESCRIPTION
We can use the URLs of the results as a key instead of adding an ID.

This avoids complicating the front end code even further to support the editor. We should really keep front end and editor separate so that we don't have "Swiss army knife" style files that do everything and are very hard to change.

This should again result in console warnings, but those are harmless and just noisy.

The root cause is that the data for each cover type is different. The URL is called `href`, `link` and `button_link` in the 3 styles.

The styles in the sidebar are using WP's `registerBlockStyle` API, which is only intended to affect which class is used for CSS.

The current code [adds an effect to the class name](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/d77070ac49a5116e3b8d3139cb9226a9567adccc/assets/src/blocks/Covers/CoversEditor.js#L175-L187), which then, in [another effect](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/d77070ac49a5116e3b8d3139cb9226a9567adccc/assets/src/blocks/Covers/useCovers.js#L81-L85), results in an effect with new API call to get the matching results and data format.