### PR TITLE
Use consistent attribute names for all Covers styles 

### DIFF
--- a/assets/src/blocks/Covers/CampaignCovers.js
+++ b/assets/src/blocks/Covers/CampaignCovers.js
@@ -14,37 +14,41 @@ export const CampaignCovers = ({
 }) => (
   <div className='covers'>
     {covers.map((cover, index) => {
-      const { href, image, alt_text, name, src_set } = cover;
+      const { image, alt_text } = cover;
       const hideCover = !isCarouselLayout && !!initialRowsLimit && index >= row * amountOfCoversPerRow;
 
       if (hideCover) {
         return null;
       }
 
-      const campaignLink = inEditor ? null : href;
+      const link = cover.link || cover.href;
+      const srcset = cover.srcset || cover.src_set;
+      const title = cover.title || cover.name;
+
+      const campaignLink = inEditor ? null : link;
 
       return (
-        <div key={href} className='campaign-card-column cover'>
+        <div key={link} className='campaign-card-column cover'>
           <a
             href={campaignLink}
             data-ga-category='Campaign Covers'
             data-ga-action='Image'
             data-ga-label='n/a'
-            aria-label={__('Check our campaign about ' + name, 'planet4-blocks')}
+            aria-label={__('Check our campaign about ' + title, 'planet4-blocks')}
           >
             <div className='thumbnail-large'>
               {image && image[0] && !isExample &&
                 <img
                   loading='lazy'
                   sizes={IMAGE_SIZES.campaign}
-                  srcSet={src_set}
+                  srcSet={srcset}
                   src={image[0]}
                   alt={alt_text}
                   title={alt_text}
                 />
               }
               {isExample && <CoversImagePlaceholder height={150} />}
-              <span className='yellow-cta'><span aria-label='hashtag'>#</span>{name}</span>
+              <span className='yellow-cta'><span aria-label='hashtag'>#</span>{title}</span>
             </div>
           </a>
         </div>

--- a/assets/src/blocks/Covers/ContentCovers.js
+++ b/assets/src/blocks/Covers/ContentCovers.js
@@ -15,13 +15,10 @@ export const ContentCovers = ({
   <div className='covers'>
     {covers.map((cover, index) => {
       const {
-        thumbnail,
         link,
-        post_title,
         srcset,
         alt_text,
         date_formatted,
-        post_excerpt,
       } = cover;
 
       const hideCover = !isCarouselLayout && !!initialRowsLimit && index >= row * amountOfCoversPerRow;
@@ -30,6 +27,10 @@ export const ContentCovers = ({
         return null;
       }
 
+      const title = cover.title || cover.post_title;
+      const image = cover.image || cover.thumbnail;
+      const excerpt = cover.excerpt || cover.post_excerpt;
+
       const contentLink = inEditor ? null : link;
 
       return (
@@ -37,17 +38,17 @@ export const ContentCovers = ({
           <div className='content-covers-block-wrap clearfix'>
             <div className='content-covers-block-info'>
               <div className='content-covers-block-image' {...isExample && { style: { height: 120 } }}>
-                {thumbnail && !isExample &&
+                {image && !isExample &&
                   <a
                     href={contentLink}
                     data-ga-category='Content Covers'
                     data-ga-action='Image'
                     data-ga-label='n/a'
-                    aria-label={__('Cover image, link to ' + post_title, 'planet4-blocks')}
+                    aria-label={__('Cover image, link to ' + title, 'planet4-blocks')}
                   >
                     <img
                       loading='lazy'
-                      src={thumbnail}
+                      src={image}
                       alt={alt_text}
                       title={alt_text}
                       srcSet={srcset}
@@ -58,7 +59,7 @@ export const ContentCovers = ({
                 {isExample && <CoversImagePlaceholder height='100%' />}
               </div>
               <div className='content-covers-block-information'>
-                {post_title &&
+                {title &&
                   <h5>
                     <a
                       href={contentLink}
@@ -66,15 +67,15 @@ export const ContentCovers = ({
                       data-ga-action='Title'
                       data-ga-label='n/a'
                     >
-                      {post_title}
+                      {title}
                     </a>
                   </h5>
                 }
                 {date_formatted &&
                   <p className='publication-date'>{date_formatted}</p>
                 }
-                {post_excerpt &&
-                  <p className='post-excerpt' dangerouslySetInnerHTML={{ __html: post_excerpt }} />
+                {excerpt &&
+                  <p className='post-excerpt' dangerouslySetInnerHTML={{ __html: excerpt }} />
                 }
               </div>
             </div>

--- a/assets/src/blocks/Covers/TakeActionCovers.js
+++ b/assets/src/blocks/Covers/TakeActionCovers.js
@@ -15,7 +15,6 @@ export const TakeActionCovers = ({
   <div className='covers'>
     {covers.map((cover, index) => {
       const {
-        button_link,
         title,
         tags,
         image,
@@ -30,10 +29,12 @@ export const TakeActionCovers = ({
         return null;
       }
 
-      const buttonLink = inEditor ? null : button_link;
+      const link = cover.link || cover.button_link;
+
+      const buttonLink = inEditor ? null : link;
 
       return (
-        <div key={button_link} className='cover-card cover'>
+        <div key={link} className='cover-card cover'>
           <a
             className='cover-card-overlay'
             data-ga-category='Take Action Covers'

--- a/assets/src/blocks/Covers/example.js
+++ b/assets/src/blocks/Covers/example.js
@@ -6,41 +6,56 @@ export const example = {
       content: [
         {
           link: 'page-1',
+          title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+          excerpt: 'Etiam et turpis et tortor congue interdum quis in leo. Donec vel eros eget mauris aliquam commodo.',
           post_title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
           post_excerpt: 'Etiam et turpis et tortor congue interdum quis in leo. Donec vel eros eget mauris aliquam commodo.',
         },
         {
           link: 'page-2',
+          title: 'Vivamus ornare varius neque at posuere',
+          excerpt: 'Cras suscipit velit nec gravida auctor. Suspendisse et enim a ex feugiat interdum laoreet vel lorem.',
           post_title: 'Vivamus ornare varius neque at posuere',
           post_excerpt: 'Cras suscipit velit nec gravida auctor. Suspendisse et enim a ex feugiat interdum laoreet vel lorem.',
         },
         {
           link: 'page-3',
+          title: 'Vestibulum vitae purus neque',
+          excerpt: 'In egestas mollis leo. Suspendisse in iaculis mauris. Duis sagittis arcu vel sodales bibendum. Ut sed sagittis lectus. ',
           post_title: 'Vestibulum vitae purus neque',
           post_excerpt: 'In egestas mollis leo. Suspendisse in iaculis mauris. Duis sagittis arcu vel sodales bibendum. Ut sed sagittis lectus. ',
         },
         {
           link: 'page-4',
+          title: 'In egestas mollis leo',
+          excerpt: 'Suspendisse in iaculis mauris. Duis sagittis arcu vel sodales bibendum. Ut sed sagittis lectus.',
           post_title: 'In egestas mollis leo',
           post_excerpt: 'Suspendisse in iaculis mauris. Duis sagittis arcu vel sodales bibendum. Ut sed sagittis lectus.',
         },
       ],
       campaign: [
         {
+          link: 'Tag1',
+          title: 'Tag1',
           href: 'Tag1',
           name: 'Tag1',
         },
         {
+          link: 'Tag2',
+          title: 'Tag2',
           href: 'Tag2',
           name: 'Tag2',
         },
         {
+          link: 'Tag3',
+          title: 'Tag3',
           href: 'Tag3',
-          name: 'Tag3'
+          name: 'Tag3',
         },
       ],
       'take-action': [
         {
+          link: 'Page1',
           button_link: 'Page1',
           title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
           excerpt: 'Etiam et turpis et tortor congue interdum quis in leo. Donec vel eros eget mauris aliquam commodo.',
@@ -50,6 +65,7 @@ export const example = {
           }],
         },
         {
+          link: 'Page2',
           button_link: 'Page2',
           title: 'Vivamus ornare varius neque at posuere',
           excerpt: 'Cras suscipit velit nec gravida auctor. Suspendisse et enim a ex feugiat interdum laoreet vel lorem.',
@@ -59,6 +75,7 @@ export const example = {
           }],
         },
         {
+          link: 'Page3',
           button_link: 'Page3',
           title: 'Vitae purus neque',
           excerpt: 'In egestas mollis leo. Suspendisse in iaculis mauris. Duis sagittis arcu vel sodales bibendum.',

--- a/classes/blocks/class-covers.php
+++ b/classes/blocks/class-covers.php
@@ -356,15 +356,15 @@ class Covers extends Base_Block {
 
 		foreach ( $tags as $tag ) {
 			$tag_remapped  = [
-				'name' => html_entity_decode( $tag->name ),
-				'slug' => $tag->slug,
-				'href' => get_tag_link( $tag ),
+				'title' => html_entity_decode( $tag->name ),
+				'slug'  => $tag->slug,
+				'href'  => get_tag_link( $tag ),
 			];
 			$attachment_id = get_term_meta( $tag->term_id, 'tag_attachment_id', true );
 
 			if ( ! empty( $attachment_id ) ) {
 				$tag_remapped['image']    = wp_get_attachment_image_src( $attachment_id, 'medium_large' );
-				$tag_remapped['src_set']  = wp_get_attachment_image_srcset( $attachment_id, 'medium_large' ) ?? 'false';
+				$tag_remapped['srcset']   = wp_get_attachment_image_srcset( $attachment_id, 'medium_large' ) ?? 'false';
 				$tag_remapped['alt_text'] = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
 			}
 
@@ -419,7 +419,7 @@ class Covers extends Base_Block {
 					'srcset'      => wp_get_attachment_image_srcset( $img_id, 'articles-medium-large' ) ?? 'false',
 					'alt_text'    => get_the_post_thumbnail_url( $action, 'large' ),
 					'button_text' => $cover_button_text,
-					'button_link' => get_permalink( $action->ID ),
+					'link'        => get_permalink( $action->ID ),
 				];
 			}
 		}
@@ -447,21 +447,21 @@ class Covers extends Base_Block {
 		$posts_array = [];
 		foreach ( $posts as $post ) {
 			$post_data = [
-				'post_title'     => $post->post_title,
-				'post_excerpt'   => $post->post_excerpt,
+				'title'          => $post->post_title,
+				'excerpt'        => $post->post_excerpt,
 				'alt_text'       => '',
-				'thumbnail'      => '',
+				'image'          => '',
 				'srcset'         => '',
 				'link'           => get_permalink( $post ),
 				'date_formatted' => get_the_date( '', $post->ID ),
 			];
 
 			if ( has_post_thumbnail( $post ) ) {
-				$post_data['thumbnail'] = get_the_post_thumbnail_url( $post, 'medium' );
-				$img_id                 = get_post_thumbnail_id( $post );
-				$srcset                 = wp_get_attachment_image_srcset( $img_id, 'full', wp_get_attachment_metadata( $img_id ) );
-				$post_data['srcset']    = is_string( $srcset ) ? $srcset : 'false';
-				$post_data['alt_text']  = get_post_meta( $img_id, '_wp_attachment_image_alt', true );
+				$post_data['image']    = get_the_post_thumbnail_url( $post, 'medium' );
+				$img_id                = get_post_thumbnail_id( $post );
+				$srcset                = wp_get_attachment_image_srcset( $img_id, 'full', wp_get_attachment_metadata( $img_id ) );
+				$post_data['srcset']   = is_string( $srcset ) ? $srcset : 'false';
+				$post_data['alt_text'] = get_post_meta( $img_id, '_wp_attachment_image_alt', true );
 			}
 
 			$posts_array[] = $post_data;


### PR DESCRIPTION
### Description

This was causing console warnings for missing keys issues. It also makes more sense to use the same names everywhere as the style of Covers should only impact the CSS and not the data used.