### PR TITLE
Revert "PLANET-6503 Workaround to prevent local images CarouselHeader"

### DIFF
--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -4,39 +4,6 @@ import { Button, Dropdown } from '@wordpress/components';
 import { toSrcSet } from './CarouselHeaderEditor';
 const { __ } = wp.i18n;
 
-const usesCdn = window.p4ge_vars.uses_cdn;
-
-// If the site uses CDN through the stateless plugin, it should never have the local folder in the URL.
-const isWrongSource = src => {
-  return usesCdn && src.includes('wp-content/uploads');
-}
-
-const ALERT_TEXT = `
-An issue with the image path was detected. This usually happens on the largest version of the image.
-Please try removing and re-adding the images until you don't get this alert anymore.
-If the alert persists, please provide the prior steps you did (including upload of image) to the Planet 4 team.
-`;
-
-// Due to a yet unidentified bug, it sometimes happens that the URL and the largest size don't use the CDN URL.
-// This has a nasty consequence: the URL on the server exists, but only temporary. It is removed on deploy. So an editor
-// can not see that this issue will occur. It's probably related to WPML.
-const preventLocalImage = (url, sizes) => {
-  const fixedSizes = sizes.filter(size => !isWrongSource(size.url || size.source_url));
-  let fixedUrl = url;
-  if (isWrongSource(url)) {
-    console.warn(`An image with "wp-content-uploads" in the URL was detected, excluding: ${url}`);
-    alert(ALERT_TEXT);
-    const largest = fixedSizes.reduce((largest, size) => {
-      if (!largest) {
-        return size;
-      }
-      return size.width < largest.width ? largest : size;
-    })
-    fixedUrl = largest.url;
-  }
-  return [fixedUrl, fixedSizes];
-}
-
 export const EditableBackground = ({
   image_url,
   image_alt,
@@ -53,8 +20,7 @@ export const EditableBackground = ({
     <MediaUpload
       onSelect={image => {
         const { id, alt_text, url, sizes } = image;
-        const [fixedUrl, fixedSizes] = preventLocalImage(url, Object.values(sizes));
-        changeSlideImage(index, id, fixedUrl, alt_text, toSrcSet(fixedSizes));
+        changeSlideImage(index, id, url, alt_text, toSrcSet(Object.values(sizes)));
       }}
       allowedTypes={['image']}
       value={image_id}

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -337,15 +337,12 @@ final class Loader {
 		$en_active = ! MigrationLog::from_wp_options()->already_ran( M001EnableEnFormFeature::get_id() )
 					|| Features::is_active( Features::ENGAGING_NETWORKS );
 
-		$uses_cdn = is_plugin_active( 'wp-stateless/wp-stateless-media.php' ) && get_option( 'sm_custom_domain' );
-
 		$reflection_vars = [
 			'home'            => P4GBKS_PLUGIN_URL . '/public/',
 			'planet4_options' => $option_values,
 			'features'        => [
 				'feature_engaging_networks' => $en_active,
 			],
-			'uses_cdn'        => $uses_cdn,
 		];
 		wp_localize_script( 'planet4-blocks-editor-script', 'p4ge_vars', $reflection_vars );
 


### PR DESCRIPTION
This reverts commit a85abc9ac317d8fb0bc34b9fc64a023533279132.

It was not the block after all, the post content was being modified directly by a WPML plugin.
