### PR TITLE
PLANET-6000 Remove Lightbox from images with links

### DIFF
--- a/assets/src/components/Lightbox/setupLightboxForImages.js
+++ b/assets/src/components/Lightbox/setupLightboxForImages.js
@@ -37,8 +37,13 @@ export const setupLightboxForImages = function() {
 
   document.body.appendChild(lightBoxNode);
 
-  const imageBlocks = document.querySelectorAll('.wp-block-image:not(.force-no-lightbox)');
-  imageBlocks.forEach(setupImageAndCaption(lightBoxNode, 'img', 'figcaption'));
+  const imageBlocks = [...document.querySelectorAll('.wp-block-image:not(.force-no-lightbox)')];
+  // Images that are links should not have the lightbox
+  const imageBlocksWithoutLinks = imageBlocks.filter(imageBlock => {
+    const image = imageBlock.querySelector('img');
+    return image.parentElement.tagName !== 'A';
+  });
+  imageBlocksWithoutLinks.forEach(setupImageAndCaption(lightBoxNode, 'img', 'figcaption'));
 
   const imagesWithCaptions = document.querySelectorAll('.post-content .wp-caption, .page-content .wp-caption');
   imagesWithCaptions.forEach(setupImageAndCaption(lightBoxNode, 'img', '.wp-caption-text'));


### PR DESCRIPTION
### Description

See [PLANET-6000](https://jira.greenpeace.org/browse/PLANET-6000)
Adding the lightbox to these images causes a glitch when clicking on the image, where the lightbox is briefly shown before opening the link. Therefore images that are links should not have the lightbox functionality.

### Testing

You can test the changes on [this page](https://www-dev.greenpeace.org/test-rhea/lightbox-tests/) I created, the first image should not have the lightbox and open the link directly whereas the second one that doesn't have a link should have the lightbox. You can compare it to [this broken version](https://www-dev.greenpeace.org/test-mars/lightbox-tests/) where both images show the lightbox despite the potential link.