### PR TITLE
PLANET-6603 Use default Cookies copy in Cookies block

### DIFF
--- a/assets/src/blocks/Cookies/CookiesBlock.js
+++ b/assets/src/blocks/Cookies/CookiesBlock.js
@@ -24,27 +24,21 @@ export class CookiesBlock {
         },
         necessary_cookies_name: {
           type: 'string',
-          default: ''
         },
         necessary_cookies_description: {
           type: 'string',
-          default: ''
         },
         all_cookies_name: {
           type: 'string',
-          default: ''
         },
         all_cookies_description: {
           type: 'string',
-          default: ''
         },
         analytical_cookies_name: {
           type: 'string',
-          default: ''
         },
         analytical_cookies_description: {
           type: 'string',
-          default: ''
         },
       },
       edit: CookiesEditor,

--- a/assets/src/blocks/Cookies/CookiesFieldResetButton.js
+++ b/assets/src/blocks/Cookies/CookiesFieldResetButton.js
@@ -1,0 +1,27 @@
+const { __ } = wp.i18n;
+
+import { Tooltip } from '@wordpress/components';
+
+const COOKIES_DEFAULT_COPY = window.p4bk_vars.cookies_default_copy || {};
+
+export const CookiesFieldResetButton = ({ fieldName, toAttribute, currentValue }) => {
+  const defaultValue = COOKIES_DEFAULT_COPY[fieldName] || '';
+
+  if (!currentValue || !defaultValue || currentValue === defaultValue) {
+    return null;
+  }
+
+  return (
+    <div className='field-reset-button'>
+      <span
+        className='cta'
+        onClick={() => toAttribute(fieldName)(undefined)}
+      >
+        {__('Use default value', 'planet4-blocks-backend')}
+      </span>
+      <Tooltip text={__('This value is defined in the settings, in Planet 4 > Cookies', 'planet4-blocks-backend')}>
+        <span className='info'>i</span>
+      </Tooltip>
+    </div>
+  );
+}

--- a/assets/src/blocks/Cookies/CookiesFrontend.js
+++ b/assets/src/blocks/Cookies/CookiesFrontend.js
@@ -1,7 +1,7 @@
-import { Fragment } from '@wordpress/element';
 import { FrontendRichText } from '../../components/FrontendRichText/FrontendRichText';
 import { removeCookie, useCookie, writeCookie } from './useCookie';
 import { useState, useEffect } from 'react';
+import { CookiesFieldResetButton } from './CookiesFieldResetButton';
 
 const { __ } = wp.i18n;
 const CONSENT_COOKIE = 'greenpeace';
@@ -11,6 +11,8 @@ const NECESSARY_ANALYTICAL = '3';
 const NECESSARY_ANALYTICAL_MARKETING = '4';
 
 const dataLayer = window.dataLayer || [];
+
+const COOKIES_DEFAULT_COPY = window.p4bk_vars.cookies_default_copy || {};
 
 function gtag() {
   dataLayer.push(arguments);
@@ -112,196 +114,256 @@ export const CookiesFrontend = props => {
       hideCookieNotice();
     }
   }
-  useEffect(updateActiveConsentChoice, [allCookiesChecked, analyticalCookiesChecked])
+  useEffect(updateActiveConsentChoice, [allCookiesChecked, analyticalCookiesChecked]);
 
-  return <Fragment>
-    <section className={`block cookies-block ${className ?? ''}`}>
-      {(isEditing || title) &&
-      <header>
-        <FrontendRichText
-          tagName="h2"
-          className="page-section-header"
-          placeholder={__('Enter title', 'planet4-blocks-backend')}
-          value={title}
-          onChange={toAttribute('title')}
-          withoutInteractiveFormatting
-          multiline="false"
-          editable={isEditing}
-          allowedFormats={[]}
-        />
-      </header>
-      }
-      {(isEditing || description) &&
-      <FrontendRichText
-        tagName="p"
-        className="page-section-description"
-        placeholder={__('Enter description', 'planet4-blocks-backend')}
-        value={description}
-        onChange={toAttribute('description')}
-        withoutInteractiveFormatting
-        editable={isEditing}
-        allowedFormats={['core/bold', 'core/italic']}
-      />
-      }
-      {(isEditing || (necessary_cookies_name && necessary_cookies_description)) &&
-      <Fragment>
-        <label className="custom-control"
-               style={isSelected ? { pointerEvents: 'none' } : null}>
-          <input
-            type="checkbox"
-            tabIndex={isSelected ? '-1' : null}
-            name="necessary_cookies"
-            onChange={ () => {
-              if (necessaryCookiesChecked) {
-                if (allCookiesChecked) {
-                  updateConsent('ad_storage', false);
-                }
-                if (analyticalCookiesChecked) {
-                  updateConsent('analytics_storage', false);
-                }
-                setUserRevokedNecessary(true);
-                setUserRevokedAllCookies(true);
-                removeConsentCookie();
-              } else {
-                if (ENABLE_ANALYTICAL_COOKIES && analyticalCookiesChecked) {
-                  setConsentCookie(NECESSARY_ANALYTICAL);
-                } else {
-                  setConsentCookie(ONLY_NECESSARY);
-                }
-              }
-            } }
-            checked={necessaryCookiesChecked}
-            className="p4-custom-control-input"
-          />
+  const getFieldValue = fieldName => {
+    if (props[fieldName] === undefined) {
+      return COOKIES_DEFAULT_COPY[fieldName] || '';
+    }
+    return props[fieldName];
+  }
+
+  return (
+    <>
+      <section className={`block cookies-block ${className ?? ''}`}>
+        {(isEditing || title) &&
+        <header>
           <FrontendRichText
-            tagName="span"
-            className="custom-control-description"
-            placeholder={__('Enter necessary cookies name', 'planet4-blocks-backend')}
-            value={necessary_cookies_name}
-            onChange={toAttribute('necessary_cookies_name')}
+            tagName="h2"
+            className="page-section-header"
+            placeholder={__('Enter title', 'planet4-blocks-backend')}
+            value={title}
+            onChange={toAttribute('title')}
             withoutInteractiveFormatting
             multiline="false"
             editable={isEditing}
             allowedFormats={[]}
           />
-        </label>
+        </header>
+        }
+        {(isEditing || description) &&
         <FrontendRichText
           tagName="p"
-          className="cookies-checkbox-description"
-          placeholder={__('Enter necessary cookies description', 'planet4-blocks-backend')}
-          value={necessary_cookies_description}
-          onChange={toAttribute('necessary_cookies_description')}
+          className="page-section-description"
+          placeholder={__('Enter description', 'planet4-blocks-backend')}
+          value={description}
+          onChange={toAttribute('description')}
           withoutInteractiveFormatting
           editable={isEditing}
           allowedFormats={['core/bold', 'core/italic']}
         />
-      </Fragment>
-      }
-      {((ENABLE_ANALYTICAL_COOKIES) && (isEditing || (analytical_cookies_name && analytical_cookies_description))) &&
-      <Fragment>
-        <label className="custom-control"
-              style={isSelected ? { pointerEvents: 'none' } : null}>
-          <input
-            type="checkbox"
-            tabIndex={isSelected ? '-1' : null}
-            name="analytical_cookies"
-            onChange={() => {
-              updateConsent('analytics_storage', !analyticalCookiesChecked);
-              if (analyticalCookiesChecked) {
-                setUserRevokedAnalytical(true);
-                setUserRevokedAllCookies(true);
-                if (allCookiesChecked) {
-                  setConsentCookie(ALL_COOKIES);
-                } else {
-                  setConsentCookie(ONLY_NECESSARY);
-                }
-              } else {
-                if (allCookiesChecked) {
-                  setConsentCookie(NECESSARY_ANALYTICAL_MARKETING);
-                } else {
-                  setConsentCookie(NECESSARY_ANALYTICAL);
-                }
+        }
+        {(isEditing || (necessary_cookies_name !== '' && necessary_cookies_description !== '')) &&
+          <>
+            <div className='d-flex align-items-center'>
+              <label className="custom-control" style={isSelected ? { pointerEvents: 'none' } : null}>
+                <input
+                  type="checkbox"
+                  tabIndex={isSelected ? '-1' : null}
+                  name="necessary_cookies"
+                  onChange={ () => {
+                    if (necessaryCookiesChecked) {
+                      if (allCookiesChecked) {
+                        updateConsent('ad_storage', false);
+                      }
+                      if (analyticalCookiesChecked) {
+                        updateConsent('analytics_storage', false);
+                      }
+                      setUserRevokedNecessary(true);
+                      setUserRevokedAllCookies(true);
+                      removeConsentCookie();
+                    } else {
+                      if (ENABLE_ANALYTICAL_COOKIES && analyticalCookiesChecked) {
+                        setConsentCookie(NECESSARY_ANALYTICAL);
+                      } else {
+                        setConsentCookie(ONLY_NECESSARY);
+                      }
+                    }
+                  } }
+                  checked={necessaryCookiesChecked}
+                  className="p4-custom-control-input"
+                />
+                <FrontendRichText
+                  tagName="span"
+                  className="custom-control-description"
+                  placeholder={__('Enter necessary cookies name', 'planet4-blocks-backend')}
+                  value={getFieldValue('necessary_cookies_name')}
+                  onChange={toAttribute('necessary_cookies_name')}
+                  withoutInteractiveFormatting
+                  multiline="false"
+                  editable={isEditing}
+                  allowedFormats={[]}
+                />
+              </label>
+              {isEditing &&
+                <CookiesFieldResetButton
+                  fieldName='necessary_cookies_name'
+                  currentValue={necessary_cookies_name}
+                  toAttribute={toAttribute}
+                />
               }
-            } }
-            checked={analyticalCookiesChecked}
-            className="p4-custom-control-input"
-          />
-          <FrontendRichText
-            tagName="span"
-            className="custom-control-description"
-            placeholder={__('Enter analytical cookies name', 'planet4-blocks-backend')}
-            value={analytical_cookies_name}
-            onChange={toAttribute('analytical_cookies_name')}
-            withoutInteractiveFormatting
-            multiline="false"
-            editable={isEditing}
-            allowedFormats={[]}
-          />
-        </label>
-        <FrontendRichText
-          tagName="p"
-          className="cookies-checkbox-description"
-          placeholder={__('Enter analytical cookies description', 'planet4-blocks-backend')}
-          value={analytical_cookies_description}
-          onChange={toAttribute('analytical_cookies_description')}
-          withoutInteractiveFormatting
-          editable={isEditing}
-          allowedFormats={['core/bold', 'core/italic']}
-        />
-      </Fragment>
-      }
-      {(isEditing || (all_cookies_name && all_cookies_description)) &&
-      <Fragment>
-        <label className="custom-control"
-               style={isSelected ? { pointerEvents: 'none' } : null}>
-          <input
-            type="checkbox"
-            tabIndex={isSelected ? '-1' : null}
-            onChange={ () => {
-              updateConsent('ad_storage', !allCookiesChecked);
-              if (allCookiesChecked) {
-                setUserRevokedAllCookies(true);
-                if (ENABLE_ANALYTICAL_COOKIES && analyticalCookiesChecked) {
-                  setConsentCookie(NECESSARY_ANALYTICAL);
-                } else {
-                  setConsentCookie(ONLY_NECESSARY);
-                }
-              } else {
-                if (ENABLE_ANALYTICAL_COOKIES && analyticalCookiesChecked) {
-                  setConsentCookie(NECESSARY_ANALYTICAL_MARKETING);
-                } else {
-                  setConsentCookie(ALL_COOKIES);
-                }
+            </div>
+            <div className='d-flex align-items-center'>
+              <FrontendRichText
+                tagName="p"
+                className="cookies-checkbox-description"
+                placeholder={__('Enter necessary cookies description', 'planet4-blocks-backend')}
+                value={getFieldValue('necessary_cookies_description')}
+                onChange={toAttribute('necessary_cookies_description')}
+                withoutInteractiveFormatting
+                editable={isEditing}
+                allowedFormats={['core/bold', 'core/italic']}
+              />
+              {isEditing &&
+                <CookiesFieldResetButton
+                  fieldName='necessary_cookies_description'
+                  currentValue={necessary_cookies_description}
+                  toAttribute={toAttribute}
+                />
               }
-            } }
-            name="all_cookies"
-            checked={allCookiesChecked}
-            className="p4-custom-control-input"
-          />
-          <FrontendRichText
-            tagName="span"
-            className="custom-control-description"
-            placeholder={__('Enter all cookies name', 'planet4-blocks-backend')}
-            value={all_cookies_name}
-            onChange={toAttribute('all_cookies_name')}
-            withoutInteractiveFormatting
-            multiline="false"
-            editable={isEditing}
-            allowedFormats={[]}
-          />
-        </label>
-        <FrontendRichText
-          tagName="p"
-          className="cookies-checkbox-description"
-          placeholder={__('Enter all cookies description', 'planet4-blocks-backend')}
-          value={all_cookies_description}
-          onChange={toAttribute('all_cookies_description')}
-          withoutInteractiveFormatting
-          editable={isEditing}
-          allowedFormats={['core/bold', 'core/italic']}
-        />
-      </Fragment>
-      }
-    </section>
-  </Fragment>;
+            </div>
+          </>
+        }
+        {(ENABLE_ANALYTICAL_COOKIES && (isEditing || (analytical_cookies_name !== '' && analytical_cookies_description !== ''))) &&
+          <>
+            <div className='d-flex align-items-center'>
+              <label className="custom-control" style={isSelected ? { pointerEvents: 'none' } : null}>
+                <input
+                  type="checkbox"
+                  tabIndex={isSelected ? '-1' : null}
+                  name="analytical_cookies"
+                  onChange={() => {
+                    updateConsent('analytics_storage', !analyticalCookiesChecked);
+                    if (analyticalCookiesChecked) {
+                      setUserRevokedAnalytical(true);
+                      setUserRevokedAllCookies(true);
+                      if (allCookiesChecked) {
+                        setConsentCookie(ALL_COOKIES);
+                      } else {
+                        setConsentCookie(ONLY_NECESSARY);
+                      }
+                    } else {
+                      if (allCookiesChecked) {
+                        setConsentCookie(NECESSARY_ANALYTICAL_MARKETING);
+                      } else {
+                        setConsentCookie(NECESSARY_ANALYTICAL);
+                      }
+                    }
+                  } }
+                  checked={analyticalCookiesChecked}
+                  className="p4-custom-control-input"
+                />
+                <FrontendRichText
+                  tagName="span"
+                  className="custom-control-description"
+                  placeholder={__('Enter analytical cookies name', 'planet4-blocks-backend')}
+                  value={getFieldValue('analytical_cookies_name')}
+                  onChange={toAttribute('analytical_cookies_name')}
+                  withoutInteractiveFormatting
+                  multiline="false"
+                  editable={isEditing}
+                  allowedFormats={[]}
+                />
+              </label>
+              {isEditing &&
+                <CookiesFieldResetButton
+                  fieldName='analytical_cookies_name'
+                  currentValue={analytical_cookies_name}
+                  toAttribute={toAttribute}
+                />
+              }
+            </div>
+            <div className='d-flex align-items-center'>
+              <FrontendRichText
+                tagName="p"
+                className="cookies-checkbox-description"
+                placeholder={__('Enter analytical cookies description', 'planet4-blocks-backend')}
+                value={getFieldValue('analytical_cookies_description')}
+                onChange={toAttribute('analytical_cookies_description')}
+                withoutInteractiveFormatting
+                editable={isEditing}
+                allowedFormats={['core/bold', 'core/italic']}
+              />
+              {isEditing &&
+                <CookiesFieldResetButton
+                  fieldName='analytical_cookies_description'
+                  currentValue={analytical_cookies_description}
+                  toAttribute={toAttribute}
+                />
+              }
+            </div>
+          </>
+        }
+        {(isEditing || (all_cookies_name !== '' && all_cookies_description !== '')) &&
+          <>
+            <div className='d-flex align-items-center'>
+              <label className="custom-control" style={isSelected ? { pointerEvents: 'none' } : null}>
+                <input
+                  type="checkbox"
+                  tabIndex={isSelected ? '-1' : null}
+                  onChange={ () => {
+                    updateConsent('ad_storage', !allCookiesChecked);
+                    if (allCookiesChecked) {
+                      setUserRevokedAllCookies(true);
+                      if (ENABLE_ANALYTICAL_COOKIES && analyticalCookiesChecked) {
+                        setConsentCookie(NECESSARY_ANALYTICAL);
+                      } else {
+                        setConsentCookie(ONLY_NECESSARY);
+                      }
+                    } else {
+                      if (ENABLE_ANALYTICAL_COOKIES && analyticalCookiesChecked) {
+                        setConsentCookie(NECESSARY_ANALYTICAL_MARKETING);
+                      } else {
+                        setConsentCookie(ALL_COOKIES);
+                      }
+                    }
+                  } }
+                  name="all_cookies"
+                  checked={allCookiesChecked}
+                  className="p4-custom-control-input"
+                />
+                <FrontendRichText
+                  tagName="span"
+                  className="custom-control-description"
+                  placeholder={__('Enter all cookies name', 'planet4-blocks-backend')}
+                  value={getFieldValue('all_cookies_name')}
+                  onChange={toAttribute('all_cookies_name')}
+                  withoutInteractiveFormatting
+                  multiline="false"
+                  editable={isEditing}
+                  allowedFormats={[]}
+                />
+              </label>
+              {isEditing &&
+                <CookiesFieldResetButton
+                  fieldName='all_cookies_name'
+                  currentValue={all_cookies_name}
+                  toAttribute={toAttribute}
+                />
+              }
+            </div>
+            <div className='d-flex align-items-center'>
+              <FrontendRichText
+                tagName="p"
+                className="cookies-checkbox-description"
+                placeholder={__('Enter all cookies description', 'planet4-blocks-backend')}
+                value={getFieldValue('all_cookies_description')}
+                onChange={toAttribute('all_cookies_description')}
+                withoutInteractiveFormatting
+                editable={isEditing}
+                allowedFormats={['core/bold', 'core/italic']}
+              />
+              {isEditing &&
+                <CookiesFieldResetButton
+                  fieldName='all_cookies_description'
+                  currentValue={all_cookies_description}
+                  toAttribute={toAttribute}
+                />
+              }
+            </div>
+          </>
+        }
+      </section>
+    </>
+  );
 }

--- a/assets/src/styles/blocks/CookiesEditor.scss
+++ b/assets/src/styles/blocks/CookiesEditor.scss
@@ -1,0 +1,33 @@
+.cookies-block {
+  .cookies-checkbox-description.rich-text {
+    display: inline-block;
+  }
+
+  .field-reset-button {
+    display: inline-block;
+    color: $link-color;
+    margin-inline-start: 16px;
+    font-family: $roboto;
+    font-size: 14px;
+    vertical-align: middle;
+    white-space: nowrap;
+
+    .cta {
+      cursor: pointer;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+
+    .info {
+      margin-inline-start: 8px;
+      border-radius: 50%;
+      width: 18px;
+      height: 18px;
+      display: inline-block;
+      text-align: center;
+      border: solid 1px $link-color;
+    }
+  }
+}

--- a/assets/src/styles/editorStyle.scss
+++ b/assets/src/styles/editorStyle.scss
@@ -21,6 +21,7 @@
 @import "blocks/HappypointEditor";
 @import "blocks/OldENForm/ENFormEditor";
 @import "blocks/TakeActionBoxout/edit";
+@import "blocks/CookiesEditor";
 
 @import "components/LayoutSelector";
 @import "components/EmptyMessage";

--- a/classes/blocks/class-cookies.php
+++ b/classes/blocks/class-cookies.php
@@ -21,8 +21,6 @@ class Cookies extends Base_Block {
 	 * Cookies constructor.
 	 */
 	public function __construct() {
-		// - Register the block for the editor
-		// in the PHP side.
 		register_block_type(
 			self::get_full_block_name(),
 			[
@@ -38,28 +36,22 @@ class Cookies extends Base_Block {
 						'default' => '',
 					],
 					'necessary_cookies_name'         => [
-						'type'    => 'string',
-						'default' => '',
+						'type' => 'string',
 					],
 					'necessary_cookies_description'  => [
-						'type'    => 'string',
-						'default' => '',
+						'type' => 'string',
 					],
 					'all_cookies_name'               => [
-						'type'    => 'string',
-						'default' => '',
+						'type' => 'string',
 					],
 					'all_cookies_description'        => [
-						'type'    => 'string',
-						'default' => '',
+						'type' => 'string',
 					],
 					'analytical_cookies_name'        => [
-						'type'    => 'string',
-						'default' => '',
+						'type' => 'string',
 					],
 					'analytical_cookies_description' => [
-						'type'    => 'string',
-						'default' => '',
+						'type' => 'string',
 					],
 				],
 			]

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -360,6 +360,7 @@ final class Loader {
 			'themeUrl'                       => get_template_directory_uri(),
 			'enable_analytical_cookies'      => $option_values['enable_analytical_cookies'] ?? '',
 			'take_action_covers_button_text' => $option_values['take_action_covers_button_text'] ?? '',
+			'cookies_default_copy'           => self::get_cookies_default_copy(),
 		];
 		wp_localize_script( 'planet4-blocks-editor-script', 'p4bk_vars', $reflection_vars );
 
@@ -410,6 +411,7 @@ final class Loader {
 			'themeUrl'                   => get_template_directory_uri(),
 			'enable_analytical_cookies'  => $option_values['enable_analytical_cookies'] ?? '',
 			'enable_google_consent_mode' => $option_values['enable_google_consent_mode'] ?? '',
+			'cookies_default_copy'       => self::get_cookies_default_copy(),
 		];
 		wp_localize_script( 'planet4-blocks-script', 'p4bk_vars', $reflection_vars );
 
@@ -434,6 +436,26 @@ final class Loader {
 				false
 			);
 		}
+	}
+
+	/**
+	 * Get the cookies default copy from the settings (Planet 4 > Cookies)
+	 *
+	 * @return array The various cookies text fields.
+	 */
+	private static function get_cookies_default_copy(): array {
+		$option_values = get_option( 'planet4_options' );
+
+		$cookies_default_copy = [
+			'necessary_cookies_name'         => $option_values['necessary_cookies_name'] ?? '',
+			'necessary_cookies_description'  => $option_values['necessary_cookies_description'] ?? '',
+			'analytical_cookies_name'        => $option_values['analytical_cookies_name'] ?? '',
+			'analytical_cookies_description' => $option_values['analytical_cookies_description'] ?? '',
+			'all_cookies_name'               => $option_values['all_cookies_name'] ?? '',
+			'all_cookies_description'        => $option_values['all_cookies_description'] ?? '',
+		];
+
+		return $cookies_default_copy;
 	}
 
 	/**


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-6603

Related master-theme PR: https://github.com/greenpeace/planet4-master-theme/pull/1586

**Note**: the code is very repetitive, we could create some components to improve that, but maybe in a separate PR for simplicity's sake 🙂 

### Testing

You can check the new settings on local (`Planet 4 > Cookies`), or on the [neptune test instance](https://www-dev.greenpeace.org/test-neptune/wp-admin/admin.php?page=planet4_settings_cookies_text). Then once you set some values there, you can add a Cookies block to a page and see those values appear as default in the various fields. I've also added some reset buttons for the fields, so that editors can easily revert custom values to the default ones defined in the settings.