### PR TITLE
PLANET-6502 Rename "Columns" to "Planet 4 Columns" and add core Columns block

### DIFF
--- a/assets/src/blocks/Columns/ColumnsBlock.js
+++ b/assets/src/blocks/Columns/ColumnsBlock.js
@@ -19,7 +19,7 @@ const getStyleLabel = (label, help) => {
 
 export const registerColumnsBlock = () =>
   registerBlockType('planet4-blocks/columns', {
-    title: __('Columns', 'planet4-blocks-backend'),
+    title: __('Planet 4 Columns', 'planet4-blocks-backend'),
     icon: 'grid-view',
     category: 'planet4-blocks',
     attributes: {

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -201,6 +201,8 @@ function set_allowed_block_types( $allowed_block_types, $post ) {
 		'core/spacer',
 		'core/shortcode',
 		'core/group',
+		'core/columns',
+		'core/column',
 		'core/embed',
 		'core-embed/twitter',
 		'core-embed/youtube',


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6502

Title says it all. It didn't require additional code changes yet.

Only found 1 minor issue so far:
* If you choose a background color then it looks off because the column doesn't add padding. Can be worked around using a group block, but maybe something we can improve in a follow up. ([example](https://www-dev.greenpeace.org/test-rhea/columns-core-and-planet-4/))