### PR TITLE
Remove obsolete config option

### DIFF
--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -450,9 +450,7 @@ final class Loader {
 			return true;
 		}
 
-		return defined( 'ALLOW_EXPERIMENTAL_FEATURES' )
-			&& ALLOW_EXPERIMENTAL_FEATURES
-			&& Features::is_active( Features::THEME_EDITOR_NON_LOGGED_IN );
+		return Features::is_active( Features::THEME_EDITOR_NON_LOGGED_IN );
 	}
 
 	/**


### PR DESCRIPTION
Just a follow up from https://github.com/greenpeace/planet4-master-theme/pull/1589

Simplifying this since we now rely on `WP_APP_ENV` for this feature flag.