### PR TITLE
PLANET-6599: Fix arrow issue from Carousel Take Action block

### DIFF
--- a/assets/src/blocks/Covers/useCovers.js
+++ b/assets/src/blocks/Covers/useCovers.js
@@ -16,15 +16,13 @@ export const useCovers = ({ post_types, tags, cover_type, initialRowsLimit, post
   const [error, setError] = useState(null);
 
   const updateRowCoversAmount = () => {
-    switch (cover_type) {
-    case COVERS_TYPES.campaign:
+    if(cover_type === COVERS_TYPES.campaign || cover_type === COVERS_TYPES.takeAction) {
       if (layout === COVERS_LAYOUTS.carousel) {
         setAmountOfCoversPerRow(3);
       } else {
         setAmountOfCoversPerRow(isSmallWindow() ? 2 : 3);
       }
-      break;
-    case COVERS_TYPES.content:
+    } else {
       if (layout === COVERS_LAYOUTS.carousel) {
         setAmountOfCoversPerRow(4);
       } else {
@@ -34,16 +32,6 @@ export const useCovers = ({ post_types, tags, cover_type, initialRowsLimit, post
           setAmountOfCoversPerRow(isMediumWindow() ? 3 : 4);
         }
       }
-      break;
-    case COVERS_TYPES.takeAction:
-      if (layout === COVERS_LAYOUTS.carousel) {
-        setAmountOfCoversPerRow(4);
-      } else {
-        setAmountOfCoversPerRow(isSmallWindow() ? 2 : 3);
-      }
-      break;
-    default:
-      break;
     }
   };
 


### PR DESCRIPTION
[Ticket](https://jira.greenpeace.org/browse/PLANET-6599)

[Demo page](https://www-dev.greenpeace.org/test-proteus/carousel-layout/)

**Problem**
The arrows are not visible when the Covers has set just 4 cards.

**What is fixed**
Set to 3 rows to Carousel layout the same as it's set to `grid`.
