### PR TITLE
PLANET-6496: Allow HTML code in Happy Point embed

### DIFF
--- a/assets/src/blocks/Happypoint/HappypointFrontend.js
+++ b/assets/src/blocks/Happypoint/HappypointFrontend.js
@@ -1,5 +1,6 @@
 import { useHappypointImageData } from './useHappypointImageData';
 import { HubspotEmbed } from './useHubspotEmbedCode';
+import { safeHTML } from '@wordpress/dom';
 import { useEffect } from '@wordpress/element';
 import { useScript } from '../../components/useScript/useScript';
 
@@ -40,6 +41,7 @@ export const HappypointFrontend = ({
   }
 
   const url = iframe_url || engaging_network_id;
+  const html_code = safeHTML(embed_code || default_embed_code || '');
 
   return (
     <section className={`block block-footer block-wide happy-point-block-wrap ${className ?? ''}`}>
@@ -49,7 +51,7 @@ export const HappypointFrontend = ({
       <div className="container">
         <div className="row justify-content-md-center">
           {use_embed_code
-            ? <div className="col-md-10 mt-5" id="happy-point" />
+            ? <div className="col-md-10 mt-5" id="happy-point" dangerouslySetInnerHTML={{ __html: html_code }} />
             : <>
               {mailing_list_iframe && url && (
                 <div className="col-md-10 happy-point" id="happy-point" data-src={url}>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6496

Filter code using [`safeHTML`](https://github.com/WordPress/gutenberg/blob/71635329224c3dcc148258b7b0e855acf3b5d733/packages/dom/README.md#safehtml) gutenberg function and insert HTML code in Happy Point div.

## Test

- Add a Happy Point to a page
- Check the "Use HusSpot embed code", add some HTML in the box
- The HTML should appear in the Happy Point, in the editor and on the frontend