### PR TITLE
PLANET-6496: Fix Happy Point default mode

### DIFF
--- a/assets/src/blocks/Happypoint/HappypointFrontend.js
+++ b/assets/src/blocks/Happypoint/HappypointFrontend.js
@@ -51,7 +51,7 @@ export const HappypointFrontend = ({
           {use_embed_code
             ? <div className="col-md-10 mt-5" id="happy-point" />
             : <>
-              {mailing_list_iframe && url && (
+              {url && (
                 <div className="col-md-10 happy-point" id="happy-point" data-src={url}>
                   <iframe
                     src={url}


### PR DESCRIPTION
Current version doesn't show any Happy Point content when no toggle is checked, which is the default state of most Happy Points we have.

## Fix

Restore mailing iframe as default mode when no toggle is checked

## Test

- Add a Happy Point to a page
- Don't check any toggle "mailing list iframe" or "hubspot embed"
- The Happy Point should use the "Happy point Subscribe Form URL" configuration from Planet4 > Default content and display its iframe
- Existing Happy points should still work properly