### PR TITLE
PLANET-6598: Fix carousel Layout excessive width of cards from Covers

### DIFF
--- a/assets/src/styles/blocks/Covers/styles/ContentCovers.scss
+++ b/assets/src/styles/blocks/Covers/styles/ContentCovers.scss
@@ -1,6 +1,7 @@
 .content-covers-block {
   &.carousel-layout {
     .cover {
+      width: 154px;
       min-width: 154px;
 
       &:not(:last-child) {
@@ -8,6 +9,7 @@
       }
 
       @include medium-and-up {
+        width: 200px;
         min-width: 200px;
 
         &:not(:last-child) {
@@ -16,10 +18,12 @@
       }
 
       @include large-and-up {
+        width: 216px;
         min-width: 216px;
       }
 
       @include x-large-and-up {
+        width: 261px;
         min-width: 261px;
       }
     }

--- a/assets/src/styles/blocks/Covers/styles/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/styles/TakeActionCovers.scss
@@ -7,6 +7,7 @@
     }
 
     .cover {
+      width: 300px;
       min-width: 300px;
 
       &:not(:last-child) {
@@ -14,6 +15,7 @@
       }
 
       @include medium-and-up {
+        width: 296px;
         min-width: 296px;
 
         &:not(:last-child) {
@@ -22,6 +24,7 @@
       }
 
       @include x-large-and-up {
+        width: 356px;
         min-width: 356px;
       }
     }


### PR DESCRIPTION
[Ticket](https://jira.greenpeace.org/browse/PLANET-6598)

[Demo page](https://www-dev.greenpeace.org/test-proteus/carousel-layout-excessive-width-on-two-cards/)

**Reported issue**

![Screenshot 2022-01-21 at 10 49 26 - Kelli Tolen](https://user-images.githubusercontent.com/77975803/151990139-5b04801f-6b46-44ad-b2e6-36762cb3002f.png)

