### PR TITLE
Fix excessive width of cards from Covers carousel layout

### DIFF
--- a/assets/src/styles/blocks/Covers/styles/CampaignCovers.scss
+++ b/assets/src/styles/blocks/Covers/styles/CampaignCovers.scss
@@ -58,6 +58,7 @@
 .campaign-covers-block {
   &.carousel-layout {
     .cover {
+      width: 260px;
       min-width: 260px;
 
       &:not(:last-child) {
@@ -65,6 +66,7 @@
       }
 
       @include medium-and-up {
+        width: 276px;
         min-width: 276px;
 
         &:not(:last-child) {
@@ -73,10 +75,12 @@
       }
 
       @include large-and-up {
+        width: 296px;
         min-width: 296px;
       }
 
       @include x-large-and-up {
+        width: 356px;
         min-width: 356px;
       }
     }

--- a/assets/src/styles/blocks/Covers/styles/ContentCovers.scss
+++ b/assets/src/styles/blocks/Covers/styles/ContentCovers.scss
@@ -1,6 +1,7 @@
 .content-covers-block {
   &.carousel-layout {
     .cover {
+      width: 154px;
       min-width: 154px;
 
       &:not(:last-child) {
@@ -8,6 +9,7 @@
       }
 
       @include medium-and-up {
+        width: 200px;
         min-width: 200px;
 
         &:not(:last-child) {
@@ -16,10 +18,12 @@
       }
 
       @include large-and-up {
+        width: 216px;
         min-width: 216px;
       }
 
       @include x-large-and-up {
+        width: 261px;
         min-width: 261px;
       }
     }


### PR DESCRIPTION
This [ticket](https://jira.greenpeace.org/browse/PLANET-6598) reported the issue usinf the Take Action Covers carousel layout, but I assume that it's happening the same with Content and Campaign Covers. 

The Take Action's issue has been solved through [this](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/775) PR.
