### PR TITLE
Update Card's width from Covers for XXL viewports

### DIFF
--- a/assets/src/styles/blocks/Covers/styles/CampaignCovers.scss
+++ b/assets/src/styles/blocks/Covers/styles/CampaignCovers.scss
@@ -81,7 +81,6 @@
       }
 
       @include xx-large-and-up {
-        width: 416px;
         min-width: 416px;
       }
     }

--- a/assets/src/styles/blocks/Covers/styles/CampaignCovers.scss
+++ b/assets/src/styles/blocks/Covers/styles/CampaignCovers.scss
@@ -79,6 +79,11 @@
       @include x-large-and-up {
         min-width: 356px;
       }
+
+      @include xx-large-and-up {
+        width: 416px;
+        min-width: 416px;
+      }
     }
 
     .carousel-control-prev,

--- a/assets/src/styles/blocks/Covers/styles/ContentCovers.scss
+++ b/assets/src/styles/blocks/Covers/styles/ContentCovers.scss
@@ -26,6 +26,11 @@
         width: 261px;
         min-width: 261px;
       }
+
+      @include xx-large-and-up {
+        width: 306px;
+        min-width: 306px;
+      }
     }
 
     .carousel-control-prev,

--- a/assets/src/styles/blocks/Covers/styles/TakeActionCovers.scss
+++ b/assets/src/styles/blocks/Covers/styles/TakeActionCovers.scss
@@ -27,6 +27,11 @@
         width: 356px;
         min-width: 356px;
       }
+
+      @include xx-large-and-up {
+        width: 416px;
+        min-width: 416px;
+      }
     }
 
     .carousel-control-prev,


### PR DESCRIPTION
Update the new width from Card's Covers regarding the Design System.
Applied to the carousel layout of the Take Action, Content and Campaign Covers.

[Ticket](https://jira.greenpeace.org/browse/PLANET-6613)  
[Demo page](https://www-dev.greenpeace.org/test-proteus/carousel-layout-new-xxl-cards-width/)

Current layout
![Screenshot 2022-04-21 at 11 05 22](https://user-images.githubusercontent.com/77975803/164475874-a666acbc-dccd-42ea-b85a-35f406405411.png)

New layout
![Screenshot 2022-04-21 at 11 05 05](https://user-images.githubusercontent.com/77975803/164475951-fa998f11-7b42-4fe1-99dc-47563f24af3e.png)

