### PR TITLE
PLANET-6075 Always enable necessary cookies

### DIFF
--- a/assets/src/blocks/Cookies/CookiesFrontend.js
+++ b/assets/src/blocks/Cookies/CookiesFrontend.js
@@ -57,14 +57,12 @@ export const CookiesFrontend = props => {
   } = props;
 
   // Whether consent was revoked by the user since current page load.
-  const [userRevokedNecessary, setUserRevokedNecessary] = useState(false);
   const [userRevokedAllCookies, setUserRevokedAllCookies] = useState(false);
   const [userRevokedAnalytical, setUserRevokedAnalytical] = useState(false);
-  const [consentCookie, setConsentCookie, removeConsentCookie] = useCookie(CONSENT_COOKIE);
-  const necessaryCookiesChecked = [ONLY_NECESSARY, NECESSARY_ANALYTICAL, ALL_COOKIES, NECESSARY_ANALYTICAL_MARKETING].includes(consentCookie);
+  const [consentCookie, setConsentCookie] = useCookie(CONSENT_COOKIE);
   const analyticalCookiesChecked = [NECESSARY_ANALYTICAL, NECESSARY_ANALYTICAL_MARKETING].includes(consentCookie);
   const allCookiesChecked = ALL_COOKIES === consentCookie || NECESSARY_ANALYTICAL_MARKETING === consentCookie;
-  const hasConsent = allCookiesChecked || necessaryCookiesChecked || analyticalCookiesChecked;
+  const hasConsent = allCookiesChecked || analyticalCookiesChecked;
 
   const updateNoTrackCookie = () => {
     if (hasConsent) {
@@ -78,13 +76,9 @@ export const CookiesFrontend = props => {
         writeCookie('active_consent_choice', '1');
         hideCookieNotice();
       }
-    } else if (userRevokedNecessary) {
-      writeCookie('no_track', 'true');
-      removeCookie('active_consent_choice');
-      showCookieNotice();
     }
   };
-  useEffect(updateNoTrackCookie, [hasConsent, userRevokedNecessary, userRevokedAnalytical]);
+  useEffect(updateNoTrackCookie, [hasConsent, userRevokedAnalytical]);
 
   const updateConsent = (key, granted) => {
     if (!ENABLE_GOOGLE_CONSENT_MODE) {
@@ -156,45 +150,18 @@ export const CookiesFrontend = props => {
         {(isEditing || (necessary_cookies_name !== '' && necessary_cookies_description !== '')) &&
           <>
             <div className='d-flex align-items-center'>
-              <label className="custom-control" style={isSelected ? { pointerEvents: 'none' } : null}>
-                <input
-                  type="checkbox"
-                  tabIndex={isSelected ? '-1' : null}
-                  name="necessary_cookies"
-                  onChange={ () => {
-                    if (necessaryCookiesChecked) {
-                      if (allCookiesChecked) {
-                        updateConsent('ad_storage', false);
-                      }
-                      if (analyticalCookiesChecked) {
-                        updateConsent('analytics_storage', false);
-                      }
-                      setUserRevokedNecessary(true);
-                      setUserRevokedAllCookies(true);
-                      removeConsentCookie();
-                    } else {
-                      if (ENABLE_ANALYTICAL_COOKIES && analyticalCookiesChecked) {
-                        setConsentCookie(NECESSARY_ANALYTICAL);
-                      } else {
-                        setConsentCookie(ONLY_NECESSARY);
-                      }
-                    }
-                  } }
-                  checked={necessaryCookiesChecked}
-                  className="p4-custom-control-input"
-                />
-                <FrontendRichText
-                  tagName="span"
-                  className="custom-control-description"
-                  placeholder={__('Enter necessary cookies name', 'planet4-blocks-backend')}
-                  value={getFieldValue('necessary_cookies_name')}
-                  onChange={toAttribute('necessary_cookies_name')}
-                  withoutInteractiveFormatting
-                  multiline="false"
-                  editable={isEditing}
-                  allowedFormats={[]}
-                />
-              </label>
+              <FrontendRichText
+                tagName="span"
+                className="custom-control-description"
+                placeholder={__('Enter necessary cookies name', 'planet4-blocks-backend')}
+                value={getFieldValue('necessary_cookies_name')}
+                onChange={toAttribute('necessary_cookies_name')}
+                withoutInteractiveFormatting
+                multiline="false"
+                editable={isEditing}
+                allowedFormats={[]}
+              />
+              <span className="always-enabled">{__('Always enabled', 'planet4-master-theme')}</span>
               {isEditing &&
                 <CookiesFieldResetButton
                   fieldName='necessary_cookies_name'

--- a/assets/src/blocks/Cookies/useCookie.js
+++ b/assets/src/blocks/Cookies/useCookie.js
@@ -39,9 +39,6 @@ export const useCookie = name => {
   return [
     value,
     setValue,
-    () => {
-      setValue(null);
-    }
   ];
 };
 

--- a/assets/src/styles/blocks/Cookies.scss
+++ b/assets/src/styles/blocks/Cookies.scss
@@ -1,9 +1,22 @@
 .cookies-block {
-  .custom-control input[type="checkbox"] + .custom-control-description {
+  .custom-control-description,
+  .custom-control input[type="checkbox"] ~ .custom-control-description {
     font-size: $font-size-sm;
+    font-family: $roboto;
 
     @include x-large-and-up {
       font-size: $font-size-md;
     }
+  }
+
+  .always-enabled {
+    background: $grey-80;
+    color: white;
+    font-weight: 700;
+    border-radius: 4px;
+    padding: $sp-x;
+    font-size: 12px;
+    margin-inline-start: $sp-1;
+    font-family: $roboto;
   }
 }


### PR DESCRIPTION
### Description

See [PLANET-6075](https://jira.greenpeace.org/browse/PLANET-6075)
This is to be compliant with our new cookies policy and be consistent with the cookies box behaviour with the settings built-in. I still need to double check when to show/hide the box depending on the cookies that are selected, for that I'm waiting for Julia to confirm the expected behaviour.

**Related PR**: [master-theme](https://github.com/greenpeace/planet4-master-theme/pull/1580)

### Testing

There's already a Cookies block on the [privacy page](https://www-dev.greenpeace.org/test-jupiter/privacy/) of the jupiter test instance, you can check there that the checkbox is gone for first-party cookies and the `Always enabled` label has been added. It's also the case in the editor. 