### PR TITLE
PLANET-6624 Remove Act page filter on Covers block

### DIFF
--- a/assets/src/components/PostSelector/PostSelector.js
+++ b/assets/src/components/PostSelector/PostSelector.js
@@ -39,10 +39,8 @@ class PostSelector extends Component {
         path: addQueryArgs('/wp/v2/pages', {
           per_page: -1,
           post_type: 'page',
-          post_parent: window.p4ge_vars.planet4_options.act_page,
           orderby: 'title',
           post_status: 'publish',
-
         })
       };
 

--- a/classes/blocks/class-covers.php
+++ b/classes/blocks/class-covers.php
@@ -186,35 +186,28 @@ class Covers extends Base_Block {
 	 * @return \WP_Post[]
 	 */
 	private static function filter_posts_for_act_pages( $fields ) {
-		$tag_ids       = $fields['tags'] ?? [];
-		$options       = get_option( 'planet4_options' );
-		$parent_act_id = $options['act_page'];
-		$layout        = $fields['layout'] ?? self::GRID_LAYOUT;
+		$tag_ids = $fields['tags'] ?? [];
+		$layout  = $fields['layout'] ?? self::GRID_LAYOUT;
 
-		if ( 0 !== absint( $parent_act_id ) ) {
-			$args = [
-				'post_type'        => 'page',
-				'post_status'      => 'publish',
-				'post_parent'      => $parent_act_id,
-				'orderby'          => [
-					'menu_order' => 'ASC',
-					'date'       => 'DESC',
-					'title'      => 'ASC',
-				],
-				'suppress_filters' => false,
-				'numberposts'      => self::CAROUSEL_LAYOUT === $layout ? self::POSTS_LIMIT_CAROUSEL_LAYOUT : self::POSTS_LIMIT,
-			];
-			// If user selected a tag to associate with the Take Action page covers.
-			if ( ! empty( $tag_ids ) ) {
-				$args['tag__in'] = $tag_ids;
-			}
-
-			// Ignore sniffer rule, arguments contain suppress_filters.
-			// phpcs:ignore
-			return get_posts( $args );
+		$args = [
+			'post_type'        => 'page',
+			'post_status'      => 'publish',
+			'orderby'          => [
+				'menu_order' => 'ASC',
+				'date'       => 'DESC',
+				'title'      => 'ASC',
+			],
+			'suppress_filters' => false,
+			'numberposts'      => self::CAROUSEL_LAYOUT === $layout ? self::POSTS_LIMIT_CAROUSEL_LAYOUT : self::POSTS_LIMIT,
+		];
+		// If user selected a tag to associate with the Take Action page covers.
+		if ( ! empty( $tag_ids ) ) {
+			$args['tag__in'] = $tag_ids;
 		}
 
-		return [];
+		// Ignore sniffer rule, arguments contain suppress_filters.
+		// phpcs:ignore
+		return get_posts( $args );
 	}
 
 	/**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6624

* This makes the block return all pages, making it pretty much useless.
* We probably should find an alternative so that existing content can
keep existing.
* Building out such an alternative in legacy, maintenance heavy code may
not be the most maintainable way forward.

<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
