### PR TITLE
PLANET-6635: Fix missing EN Form custom donate URL

### DIFF
--- a/assets/src/blocks/ENForm/ENFormSettings.js
+++ b/assets/src/blocks/ENForm/ENFormSettings.js
@@ -19,6 +19,7 @@ export const ENFormSettings = ({attributes, setAttributes}) => {
     background_image_sizes,
     background_image_focus,
     donate_button_checkbox,
+    custom_donate_url,
     thankyou_url,
     campaign_logo,
   } = attributes;
@@ -142,8 +143,18 @@ export const ENFormSettings = ({attributes, setAttributes}) => {
           onChange={toAttribute('donate_button_checkbox')}
         />
 
+        {! donate_button_checkbox &&
+          <URLInput
+            label={ __( 'Donate button URL', 'planet4-engagingnetworks-backend' ) }
+            placeholder={ __( 'Enter "Donate" button url', 'planet4-engagingnetworks-backend' ) }
+            value={custom_donate_url}
+            onChange={toAttribute('custom_donate_url')}
+            help={ __('If left empty, your Donate button link from "Planet4 > Donate button" will be used', 'planet4-engagingnetworks-backend') }
+          />
+        }
+
         <URLInput
-          label={ __( 'Page URL', 'planet4-engagingnetworks-backend' ) }
+          label={ __( 'Thank you page URL', 'planet4-engagingnetworks-backend' ) }
           placeholder={ __( 'Enter "Thank you page" url', 'planet4-engagingnetworks-backend' ) }
           value={thankyou_url}
           onChange={toAttribute('thankyou_url')}

--- a/classes/blocks/class-enform.php
+++ b/classes/blocks/class-enform.php
@@ -159,6 +159,10 @@ class ENForm extends Base_Block {
 		$attributes['social_accounts'] = self::get_social_accounts();
 		$attributes['social']          = $post_id ? self::get_shareable_data( $post_id ) : [];
 
+		$attributes['donatelink'] = ! empty( $attributes['custom_donate_url'] )
+			? $attributes['custom_donate_url']
+			: planet4_get_option( 'donate_button', '' );
+
 		return $attributes;
 	}
 

--- a/tests/acceptance/ENFormCest.php
+++ b/tests/acceptance/ENFormCest.php
@@ -583,6 +583,8 @@ class ENFormCest {
 			'post_content' => $generated_enformblock
 		]);
 
+		// Skip cookies box
+		$I->setCookie('greenpeace', '1');
 		// Navigate to the newly created page
 		$I->amOnPage('/' . $slug);
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6635

> A field to change the Donate URL for the Donate button in the Thank you message is missing.

![Screenshot from 2022-02-11 20-09-25](https://user-images.githubusercontent.com/617346/153654372-e41556be-9179-49cf-8671-85ac4b3c8b92.png)

Use `custom_donate_url` attribute to define `donatelink`.
Hide field if Donate button is hidden.

## Test

- Add an EN Form block to a page
- Check on preview/published page the Donate button links to the _Planet 4 > Donate button_ link configured
- Add a custom Donate URL in the sidebar 
- Check that the Donate button now links to that custom URL
  - To easily display the "Thank you" section, using the [React developer tools](https://addons.mozilla.org/en-US/firefox/addon/react-devtools/) you can edit the state of the block on the frontend from `signup` to `thankyou`
![Screenshot from 2022-02-17 08-55-32](https://user-images.githubusercontent.com/617346/154430557-e4487004-f847-4f25-816b-fd0bf5ae303d.png)

  