### PR TITLE
Fix block search query default parameters

### DIFF
--- a/classes/search/block/sql/class-sqlquery.php
+++ b/classes/search/block/sql/class-sqlquery.php
@@ -57,8 +57,8 @@ class SqlQuery implements Block\Query {
 		$order  = [];
 		foreach ( $params_list as $params ) {
 			$regex[] = ( new Regex( $params ) )->__toString();
-			$status  = array_merge( $status, $params->post_status() );
-			$order   = array_merge( $order, $params->order() );
+			$status  = array_merge( $status, $params->post_status() ?? [] );
+			$order   = array_merge( $order, $params->order() ?? [] );
 		}
 		$status = array_unique( array_filter( $status ) );
 		$order  = $this->parse_order( array_unique( array_filter( $order ) ) );


### PR DESCRIPTION
A basic use of the block search fails when these parameters are not provided

Cf. https://app.circleci.com/pipelines/github/greenpeace/planet4-master-theme/4971/workflows/b8fc56ee-5057-4f85-90fa-9fd2df98f3e2/jobs/29904/parallel-runs/0/steps/0-104

Required for https://github.com/greenpeace/planet4-master-theme/pull/1624