### PR TITLE
Add Media and Text code block to blocks usage report

### DIFF
--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -432,6 +432,7 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 				'spacer',
 				'shortcode',
 				'group',
+				'media-text',
 			];
 
 			return array_merge( $p4_block_types, $core_block_types );


### PR DESCRIPTION
This is to keep track of how much this newly allowed block is used in all P4 sites, in this [sheet](https://docs.google.com/spreadsheets/d/1uAmZLIWYsxrBByqbhoF_vVtSM7WGebYWIc0xftPRPwE/edit#gid=359432436).