### PR TITLE
Add variation for media and text pattern

### DIFF
--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -48,14 +48,6 @@ setupCustomSidebar();
 setUpCssVariables();
 blockEditorValidation();
 
-const innerBlocks = [
-  ['core/heading', { placeHolder: 'Enter title' }],
-  ['core/paragraph', { placeHolder: 'Enter description' }],
-  ['core/buttons', {}, [
-    ['core/button', { className: 'is-style-cta', placeHolder: 'Enter description' }]
-  ]],
-];
-
 wp.blocks.registerBlockVariation('core/media-text', {
   name: 'side-image-with-text-and-cta',
   title: 'Side Image with Text and CTA',
@@ -66,8 +58,15 @@ wp.blocks.registerBlockVariation('core/media-text', {
     // 'block',
     // 'transform',
   ],
-  innerBlocks,
+  innerBlocks: [
+    ['core/heading', { placeHolder: 'Enter title' }],
+    ['core/paragraph', { placeHolder: 'Enter description' }],
+    ['core/buttons', {}, [
+      ['core/button', { className: 'is-style-cta', placeHolder: 'Enter description' }]
+    ]],
+  ],
 });
+
 wp.blocks.registerBlockVariation('core/media-text', {
   name: 'red-media-and-text',
   title: 'Media and Text and a red background.',

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -47,3 +47,22 @@ replaceTaxonomyTermSelectors();
 setupCustomSidebar();
 setUpCssVariables();
 blockEditorValidation();
+
+wp.blocks.registerBlockVariation('core/media-text', {
+  name: 'side-image-with-text-and-cta',
+  title: 'Side Image with Text and CTA',
+  // Scope "block" only does something for blocks that support it (query and columns).
+  // Scope "transform" only changes the attributes (this variation has none) and not inner blocks.
+  scope: [
+    'inserter',
+    // 'block',
+    // 'transform',
+  ],
+  innerBlocks: [
+    ['core/heading', { placeHolder: 'Enter title' }],
+    ['core/paragraph', { placeHolder: 'Enter description' }],
+    ['core/buttons', {}, [
+      ['core/button', { className: 'is-style-cta', placeHolder: 'Enter description' }]
+    ]],
+  ],
+});

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -48,6 +48,14 @@ setupCustomSidebar();
 setUpCssVariables();
 blockEditorValidation();
 
+const innerBlocks = [
+  ['core/heading', { placeHolder: 'Enter title' }],
+  ['core/paragraph', { placeHolder: 'Enter description' }],
+  ['core/buttons', {}, [
+    ['core/button', { className: 'is-style-cta', placeHolder: 'Enter description' }]
+  ]],
+];
+
 wp.blocks.registerBlockVariation('core/media-text', {
   name: 'side-image-with-text-and-cta',
   title: 'Side Image with Text and CTA',
@@ -58,11 +66,19 @@ wp.blocks.registerBlockVariation('core/media-text', {
     // 'block',
     // 'transform',
   ],
-  innerBlocks: [
-    ['core/heading', { placeHolder: 'Enter title' }],
-    ['core/paragraph', { placeHolder: 'Enter description' }],
-    ['core/buttons', {}, [
-      ['core/button', { className: 'is-style-cta', placeHolder: 'Enter description' }]
-    ]],
+  innerBlocks,
+});
+wp.blocks.registerBlockVariation('core/media-text', {
+  name: 'red-media-and-text',
+  title: 'Media and Text and a red background.',
+  attributes: {
+    backgroundColor: 'vivid-red'
+  },
+  // Scope "block" only does something for blocks that support it (query and columns).
+  // Scope "transform" only changes the attributes (this variation has none) and not inner blocks.
+  scope: [
+    'inserter',
+    // 'block',
+    'transform',
   ],
 });


### PR DESCRIPTION
Just to test the differences between patterns and variations, as they have overlapping functionality.

Differences:
* Patterns are found in the patterns tab, variations can be shown in the blocks tab
* Variations can be accessed by typing "/" + a fragment of the variation name directly in the post.
* Variations can only contain 1 block at the top level (but any amount of inner blocks).
* You can transform an existing block to a variation. Only applies attributes, inner blocks not changed on transform.

Findings:
* The preview doesn't show the inner blocks like block patterns do. So it's indistinguishable from the block type's preview which is unfortunate if the whole point of the variation is to add just the inner blocks. Maybe will be fixed in core?
* I tried using `example` in the variation config, but couldn't get it to affect the preview of the inserter. Maybe I missed something.

For some reason WP opted to put [block pattern registration](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-patterns/#register_block_pattern) in PHP only, and [variation registration](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-variations/) in JS only. JS makes much more sense for this case as it's more suitable for block data, and is required anyway if you want to do something more advanced like with variations.

It's also convenient to not have to include block markup. The fact that block patterns require to include markup that needs to match the attributes really complicates things for no good reason. Patterns are only ever inserted in the editor which can always generate the right markup based on the attributes, like it happily does with variations.