### PR TITLE
Ensure class is not needed to use style

### DIFF
--- a/assets/src/styles/blocks/Articles.scss
+++ b/assets/src/styles/blocks/Articles.scss
@@ -28,7 +28,7 @@
 }
 
 .article-list-item-image-max-width {
-  .topicwise-article-image {
+  img {
     width: 100%;
     height: 190px;
     object-fit: cover;


### PR DESCRIPTION
* The code can just as well target img, which allows to use the same CSS
for the Query Loop block. That block doesn't allow putting a class on
the img it outputs.

For now it's the only modification that was needed.
