### PR TITLE
PLANET-6650 Remove uniqueId from Happypoint instance id

### DIFF
--- a/assets/src/blocks/Happypoint/HappypointEditor.js
+++ b/assets/src/blocks/Happypoint/HappypointEditor.js
@@ -100,10 +100,6 @@ export const HappypointEditor = ({ attributes, setAttributes, isSelected }) => {
     setAttributes({ embed_code: code });
   }, 300);
 
-  const setCheckbox = attributeName => value => {
-    setAttributes({ [attributeName]: value });
-  };
-
   return (
     <Fragment>
       {isSelected && (
@@ -125,7 +121,7 @@ export const HappypointEditor = ({ attributes, setAttributes, isSelected }) => {
                 label={__('Override default form', 'planet4-blocks-backend')}
                 value={override_default_content}
                 checked={override_default_content}
-                onChange={setCheckbox('override_default_content')}
+                onChange={toAttribute('override_default_content')}
               />
               <OverrideFormHelp />
               {override_default_content &&

--- a/assets/src/blocks/Happypoint/HappypointEditor.js
+++ b/assets/src/blocks/Happypoint/HappypointEditor.js
@@ -121,7 +121,12 @@ export const HappypointEditor = ({ attributes, setAttributes, isSelected }) => {
                 label={__('Override default form', 'planet4-blocks-backend')}
                 value={override_default_content}
                 checked={override_default_content}
-                onChange={toAttribute('override_default_content')}
+                onChange={checked => {
+                  setAttributes({
+                    override_default_content: checked,
+                    embed_code: checked ? embedCode : null,
+                  });
+                }}
               />
               <OverrideFormHelp />
               {override_default_content &&

--- a/assets/src/blocks/Happypoint/HappypointFrontend.js
+++ b/assets/src/blocks/Happypoint/HappypointFrontend.js
@@ -1,7 +1,5 @@
 import { useHappypointImageData } from './useHappypointImageData';
 import { HubspotEmbed } from './useHubspotEmbedCode';
-import { useEffect } from '@wordpress/element';
-import { useScript } from '../../components/useScript/useScript';
 import { USE_IFRAME_URL, USE_EMBED_CODE, USE_NONE } from './HappyPointConstants';
 
 export const HappypointFrontend = ({
@@ -10,7 +8,6 @@ export const HappypointFrontend = ({
   mailing_list_iframe,
   iframe_url,
   id,
-  use_embed_code,
   embed_code,
   override_default_content,
   local_content_provider,

--- a/assets/src/blocks/Happypoint/HappypointFrontend.js
+++ b/assets/src/blocks/Happypoint/HappypointFrontend.js
@@ -51,12 +51,7 @@ export const HappypointFrontend = ({
   const code = embed_code || default_embed_code;
   const html_code = safeHTML(code || '');
 
-  const uniqueId = (prefix) => {
-    const r = Math.floor(Math.random() * 10000);
-    const t = Date.now();
-    return `${prefix}-${t}-${r}`;
-  }
-  const instanceId = uniqueId('happy-point');
+  const instanceId = 'happy-point';
 
   return (
     <section className={`block block-footer block-wide happy-point-block-wrap ${className ?? ''}`}>

--- a/assets/src/blocks/Happypoint/deprecated/HappyPointV1.js
+++ b/assets/src/blocks/Happypoint/deprecated/HappyPointV1.js
@@ -21,8 +21,6 @@ export const HappyPointV1 = {
     const override_default_content = true;
     const local_content_provider = attributes.mailing_list_iframe ? USE_IFRAME_URL : USE_NONE;
 
-    console.log('migrate', {override_default_content, local_content_provider});
-
     delete attributes.load_iframe;
     delete attributes.mailing_list_iframe;
 
@@ -30,9 +28,9 @@ export const HappyPointV1 = {
       ...attributes,
       override_default_content,
       local_content_provider,
-    }
+    };
   },
   save() {
     return null;
   }
-}
+};

--- a/assets/src/blocks/Happypoint/useHubspotEmbedCode.js
+++ b/assets/src/blocks/Happypoint/useHubspotEmbedCode.js
@@ -31,11 +31,12 @@ export const HubspotEmbed = ({params}) => {
       region: hbsptParams.region ?? '',
       portalId: hbsptParams.portalId ?? null,
       formId: hbsptParams.formId ?? null,
-      locale: document.getElementsByTagName('html')[0].getAttribute('lang')?.substr(0,2),
-      target: target,
+      locale: document.getElementsByTagName('html')[0].getAttribute('lang')?.substring(0,2),
+      target,
     });
   }
-  const [loaded, error] = useScript(hbsptScript, loadForm, [use_embed_code, embed_code]);
+
+  useScript(hbsptScript, loadForm, [use_embed_code, embed_code]);
 
   return null;
 };


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-6650
This is not needed because the block cannot be multiple times on a same page, and it was also sometimes causing loading issues because the container with id was not found. Hopefully this will solve the issue reported in the ticket, it's hard to know for sure because I couldn't reproduce it on local!

### Testing

You can test the changes on the pluto test instance's [Act page](https://www-dev.greenpeace.org/test-pluto/act/):
- In the backend, make sure that switching between the default content and the override works as expected (you can compare it to the previously broken behaviour on the [mars instance](https://www-dev.greenpeace.org/test-mars/act/) for example).
- In the frontend, make sure that the embed code is showing as expected.