### PR TITLE
PLANET-6657 Fix CarouselHeader RTL slide transitions

### DIFF
--- a/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
+++ b/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
@@ -113,6 +113,10 @@ $medium-image-height: 600px;
     opacity: 0;
     z-index: 3500;
 
+    html[dir="rtl"] & {
+      margin-right: auto;
+    }
+
     @include medium-and-up {
       height: $medium-image-height;
     }


### PR DESCRIPTION
### Description

See [PLANET-6657](https://jira.greenpeace.org/browse/PLANET-6657)
This was due to a -100% margin right set in Bootstrap's CSS to the carousel items, it is fixed by overriding this value.

**Note**: at some point in the future we might want to investigate [Bootstrap's RTL support](https://getbootstrap.com/docs/5.0/getting-started/rtl/), but it's still experimental so maybe not now 🙃 

### Testing

On your local you can manually set `dir="rtl"` to the html element on a page with a CarouselHeader block (such as the homepage) and then switch slides, on `master` branch you will see it's broken with some "white slides" in between but on this branch it should look fine.
You can also see the previously broken version on the [example page](https://www.greenpeace.org/mena/ar/) from the ticket description, and the fixed version on the [umbriel test instance](https://www-dev.greenpeace.org/test-umbriel/).