### PR TITLE
PLANET-6623: Take Action Boxout - expand page limitation to Actions

### DIFF
--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -62,7 +62,22 @@ export const TakeActionBoxoutEditor = ({
       post_status: 'publish',
     };
 
-    const actPageList = select('core').getEntityRecords('postType', 'page', args) || [];
+    const actionsArgs = {
+      per_page: -1,
+      sort_order: 'asc',
+      sort_column: 'post_title',
+      post_status: 'publish',
+    };
+
+    const actPageList = [].concat(
+      select('core').getEntityRecords('postType', 'page', args) || [],
+      select('core').getEntityRecords('postType', 'p4_action', actionsArgs) || []
+    ).sort((a , b) => {
+      if (a.title.raw === b.title.raw) {
+        return 0;
+      }
+      return a.title.raw > b.title.raw ? 1 : -1;
+    });
     const actPage = actPageList.find(actPage => take_action_page === actPage.id);
 
     // Because `useSelect` does an API call to fetch data, the actPageList will be empty the first time it's called.


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6623

> Adjust the filter so besides the current limitation (Act children) it also fetches Action page types.
    Check if we need to rely on the [PLANET-6515](https://jira.greenpeace.org/browse/PLANET-6515) feature flag to make this work.

Include Action pages to available selection in Take action boxout block.

![Screenshot from 2022-03-02 19-04-04](https://user-images.githubusercontent.com/617346/156421405-793bde59-3c09-4c89-a30e-3689778cec0f.png)

## Test

- Create a post
- Check that the block works without _Action_ pages activated
- Activate _Action_ pages in _Planet 4 > Information architecture :: Enable Action post type_
- Create a new action, add an _Excerpt_ and a _Feature image_
- Create a post, add a _Take action boxout_, your Action page should be there
  - you can select it and see it in the editor and on the frontend