### PR TITLE
PLANET-6624: Covers - expand page limitation to Actions

### DIFF
--- a/assets/src/blocks/Articles/ArticlesEditor.js
+++ b/assets/src/blocks/Articles/ArticlesEditor.js
@@ -8,7 +8,7 @@ import {
 import { InspectorControls } from '@wordpress/block-editor';
 import withCharacterCounter from '../../components/withCharacterCounter/withCharacterCounter';
 import TagSelector from '../../components/TagSelector/TagSelector';
-import PostSelector from '../../components/PostSelector/PostSelector';
+import { PostSelector } from '../../components/PostSelector/PostSelector';
 import PostTypeSelector from '../../components/PostTypeSelector/PostTypeSelector';
 import { URLInput } from "../../components/URLInput/URLInput";
 import { ArticlesList } from "./ArticlesList";
@@ -83,12 +83,13 @@ const renderEdit = (attributes, toAttribute) => {
               <hr />
               <label>{__('Manual override', 'planet4-blocks-backend')}</label>
               <PostSelector
-                value={attributes.posts}
-                onChange={toAttribute('posts')}
                 label={__('CAUTION: Adding articles individually will override the automatic functionality of this block. For good user experience, please include at least three articles so that spacing and alignment of the design remains intact.', 'planet4-blocks-backend')}
+                selected={attributes.posts || []}
+                onChange={toAttribute('posts')}
+                postType='post'
+                placeholder={__('Select articles', 'planet4-blocks-backend')}
                 maxLength={10}
                 maxSuggestions={20}
-                postType='post'
               />
             </div>
           }

--- a/assets/src/blocks/Covers/CoversEditor.js
+++ b/assets/src/blocks/Covers/CoversEditor.js
@@ -82,11 +82,11 @@ const renderEdit = (attributes, toAttribute, setAttributes) => {
           <div>
             <label>{__('Manual override', 'planet4-blocks-backend')}</label>
             <PostSelector
-              label={__('Select articles', 'planet4-blocks-backend')}
+              label={__('Select pages', 'planet4-blocks-backend')}
               selected={posts || []}
               onChange={toAttribute('posts')}
               postType={cover_type === COVERS_TYPES.content ? 'post' : 'act_page'}
-              placeholder={__('Select articles', 'planet4-blocks-backend')}
+              placeholder={__('Select pages', 'planet4-blocks-backend')}
               maxLength={layout === COVERS_LAYOUTS.carousel ? CAROUSEL_LAYOUT_COVERS_LIMIT : null}
             />
           </div>

--- a/assets/src/blocks/Covers/CoversEditor.js
+++ b/assets/src/blocks/Covers/CoversEditor.js
@@ -7,7 +7,7 @@ import { useEffect } from '@wordpress/element';
 
 import { InspectorControls } from '@wordpress/block-editor';
 import TagSelector from '../../components/TagSelector/TagSelector';
-import PostSelector from '../../components/PostSelector/PostSelector';
+import { PostSelector } from '../../components/PostSelector/PostSelector';
 import PostTypeSelector from '../../components/PostTypeSelector/PostTypeSelector';
 import { Covers } from './Covers';
 import { COVERS_TYPES, COVERS_LAYOUTS, CAROUSEL_LAYOUT_COVERS_LIMIT } from './CoversConstants';
@@ -82,10 +82,11 @@ const renderEdit = (attributes, toAttribute, setAttributes) => {
           <div>
             <label>{__('Manual override', 'planet4-blocks-backend')}</label>
             <PostSelector
-              value={posts}
+              label={__('Select articles', 'planet4-blocks-backend')}
+              selected={posts || []}
               onChange={toAttribute('posts')}
-              placeholder={__('Select articles', 'planet4-blocks-backend')}
               postType={cover_type === COVERS_TYPES.content ? 'post' : 'act_page'}
+              placeholder={__('Select articles', 'planet4-blocks-backend')}
               maxLength={layout === COVERS_LAYOUTS.carousel ? CAROUSEL_LAYOUT_COVERS_LIMIT : null}
             />
           </div>

--- a/assets/src/components/PostSelector/PostSelector.js
+++ b/assets/src/components/PostSelector/PostSelector.js
@@ -1,5 +1,6 @@
 import { FormTokenField } from '@wordpress/components';
 import { dispatch, useSelect } from '@wordpress/data';
+const { __ } = wp.i18n;
 
 // Allows to query a custom endpoint with select('core') tools
 dispatch('core').addEntities( [{
@@ -27,9 +28,10 @@ export const PostSelector = (attributes) => {
   /**
    * Fetch relevant posts for autosuggestions
    */
+  const act_parent = window.p4ge_vars.planet4_options.act_page || null;
   const args = { per_page: -1, orderby: 'title', post_status: 'publish' };
   const act_args = {
-    post_parent: window.p4ge_vars.planet4_options.act_page,
+    post_parent: act_parent,
     ...args,
   };
   const posts = useSelect((select) => {
@@ -46,7 +48,9 @@ export const PostSelector = (attributes) => {
         select('core').getEntityRecords('postType', 'p4_action', {'include': selected}) || [],
       );
       const actions = select('core').getEntityRecords('postType', 'p4_action', args) || [];
-      const pages = select('core').getEntityRecords('postType', 'page', act_args) || [];
+      const pages = act_parent
+        ? (select('core').getEntityRecords('postType', 'page', act_args) || [])
+        : [];
       return [].concat(selectedPosts, actions, pages);
     }
 
@@ -83,19 +87,17 @@ export const PostSelector = (attributes) => {
   /**
    * Get field initial value
    */
-  const getValue = () => {
-    return getPostsTitlesFromIds(selected);
-  }
+  const getValue = () => getPostsTitlesFromIds(selected);
 
   return (
     <FormTokenField
-      label={ label || 'Select Posts' }
+      label={ label || __('Select posts', 'planet4-blocks-backend') }
       value={ getValue() || null }
       suggestions={ options.map(post => post.title) }
       onChange={ value => {
         setPostsIdsFromTitles(value);
       } }
-      placeholder={ placeholder || 'Select Posts' }
+      placeholder={ placeholder || __('Select posts', 'planet4-blocks-backend') }
       maxLength={ maxLength }
       maxSuggestions={ maxSuggestions || 50 }
     />

--- a/classes/blocks/class-covers.php
+++ b/classes/blocks/class-covers.php
@@ -205,7 +205,7 @@ class Covers extends Base_Block {
 					'title'      => 'ASC',
 				],
 				'suppress_filters' => false,
-				'numberposts'      => self::CAROUSEL_LAYOUT === $layout ? self::POSTS_LIMIT_CAROUSEL_LAYOUT : self::POSTS_LIMIT,
+				'numberposts'      => self::numberposts( $layout ),
 			];
 			// If user selected a tag to associate with the Take Action page covers.
 			if ( ! empty( $tag_ids ) ) {
@@ -239,9 +239,7 @@ class Covers extends Base_Block {
 				'title' => 'ASC',
 			],
 			'suppress_filters' => false,
-			'numberposts'      => self::CAROUSEL_LAYOUT === $layout
-				? self::POSTS_LIMIT_CAROUSEL_LAYOUT
-				: self::POSTS_LIMIT,
+			'numberposts'      => self::numberposts( $layout ),
 		];
 		// If user selected a tag to associate with the Take Action page covers.
 		if ( ! empty( $tag_ids ) ) {
@@ -272,7 +270,7 @@ class Covers extends Base_Block {
 				'post_status'      => 'publish',
 				'post__in'         => $post_ids,
 				'suppress_filters' => false,
-				'numberposts'      => self::CAROUSEL_LAYOUT === $layout ? self::POSTS_LIMIT_CAROUSEL_LAYOUT : self::POSTS_LIMIT,
+				'numberposts'      => self::numberposts( $layout ),
 			];
 
 			// If cover type is take action pages set post_type to page.
@@ -308,7 +306,7 @@ class Covers extends Base_Block {
 				'title' => 'ASC',
 			],
 			'no_found_rows'  => true,
-			'posts_per_page' => self::CAROUSEL_LAYOUT === $layout ? self::POSTS_LIMIT_CAROUSEL_LAYOUT : self::POSTS_LIMIT,
+			'posts_per_page' => self::numberposts( $layout ),
 		];
 
 		// Get all posts with the specific tags.
@@ -430,6 +428,13 @@ class Covers extends Base_Block {
 					self::filter_posts_for_action_pages( $fields ),
 					$actions
 				);
+				// Sort by published date, recent first.
+				usort(
+					$actions,
+					function ( $a, $b ) {
+						return $b->post_date <=> $a->post_date;
+					}
+				);
 			}
 		}
 
@@ -510,5 +515,18 @@ class Covers extends Base_Block {
 		}
 
 		return $posts_array;
+	}
+
+	/**
+	 * @param string $layout Covers block layout.
+	 *
+	 * @return int Number of posts to fetch.
+	 */
+	private static function numberposts( string $layout ): int {
+		if ( self::CAROUSEL_LAYOUT === $layout ) {
+			return self::POSTS_LIMIT_CAROUSEL_LAYOUT;
+		}
+
+		return self::POSTS_LIMIT;
 	}
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6624

> Use the same feature flag as [PLANET-6515](https://jira.greenpeace.org/browse/PLANET-6515)
    When enabled expand the filter to also show latest Actions

On toggle feature, fetch Action pages with Act pages

![Screenshot from 2022-03-02 19-42-02](https://user-images.githubusercontent.com/617346/156427187-3ebba20a-f601-48bd-ba32-07dd6a7439f0.png)

## Changes

[`PostSelector.js`](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/803/files#diff-54849c17e7f32a9780b25839fb6d00ac21666dbe4bc5163ea72655a1e03f06cc) was rewritten as a function component, and converted to use WP hooks.

## Test

- Activate Action pages in _Planet 4 > Information architecture :: Enable Action post type_
- Create a new action, add an _Excerpt_ and a _Feature image_
- Create a new Page, add a _Cover_ block, use the _Take action covers_ style
  - Your Action page should appear, in the editor and on the frontend
  - Using the _Manual override_ field to select specific pages should also allow to select an _Action_ page