### PR TITLE
Deprecate tying JS logic to style

### DIFF
--- a/assets/src/blocks/getStyleFromClassName.js
+++ b/assets/src/blocks/getStyleFromClassName.js
@@ -1,4 +1,7 @@
 /**
+ * @deprecated Blocks should not attach any further logic to WP's block style mechanism. It leads
+ * to infinite loops, performance issues, buggy editor previews, and more.
+ *
  * Get the name of the block style used from the classname string
  * given by Gutenberg
  *


### PR DESCRIPTION
* WordPress's block style API is only intended to toggle a class. The
problem is because it's changed outside the component render flow,
currently implementations use "useEffect" directly inside of the
component. This causes tons of issues with WordPress block previews,
which get stuck in a render loop.

I'm still checking if it makes sense to deprecate the entire function. The current usages mostly use `useEffect`, which causes the problems. The block renders an additional time, and the first time it has an invalid state (the block already has the new class but the effect still needs to run).