### PR TITLE
Fix entire classic block content used for Anchor

### DIFF
--- a/assets/src/blocks/Submenu/getHeadingsFromBlocks.js
+++ b/assets/src/blocks/Submenu/getHeadingsFromBlocks.js
@@ -49,7 +49,7 @@ export const getHeadingsFromBlocks = (blocks, selectedLevels) => {
         const blockLevel = parseInt(h.tagName.replace('H', ''));
         const levelConfig = selectedLevels.find(selected => selected.heading === blockLevel);
 
-        const anchor = h.id || generateAnchor(block.attributes.content, headings.map(h => h.anchor));
+        const anchor = h.id || generateAnchor(h.innerText, headings.map(h => h.anchor));
 
         return ({
           level: blockLevel,


### PR DESCRIPTION
* This resulted in duplicate key errors once two headings are in a
classic block. Also the key was really large.

<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
