### PR TITLE
PLANET-6654 Fix editor previews

### DIFF
--- a/assets/src/blocks/Columns/example.js
+++ b/assets/src/blocks/Columns/example.js
@@ -1,4 +1,5 @@
 export const example = {
+  viewportWidth: 992,
   attributes: {
     isExample: true,
     exampleColumns: [

--- a/assets/src/blocks/Covers/example.js
+++ b/assets/src/blocks/Covers/example.js
@@ -1,4 +1,5 @@
 export const example = {
+  viewportWidth: 992,
   attributes: {
     isExample: true,
     title: 'Covers block',

--- a/assets/src/blocks/Submenu/example.js
+++ b/assets/src/blocks/Submenu/example.js
@@ -1,4 +1,5 @@
 export const example = {
+  viewportWidth: 992,
   attributes: {
     isExample: true,
     title: 'The block title',

--- a/assets/src/styles/editorStyle.scss
+++ b/assets/src/styles/editorStyle.scss
@@ -1,16 +1,8 @@
-@import "~bootstrap/scss/bootstrap-reboot";
-@import "~bootstrap/scss/bootstrap-grid";
-@import "~bootstrap/scss/carousel";
-@import "~bootstrap/scss/tooltip";
-@import "~bootstrap/scss/buttons";
-
 @import "master-theme/assets/src/scss/base/variables";
 @import "master-theme/assets/src/scss/base/colors";
 @import "master-theme/assets/src/scss/base/functions";
 @import "master-theme/assets/src/scss/base/mixins";
 @import "master-theme/assets/src/scss/base/fonts";
-@import "master-theme/assets/src/scss/components/buttons";
-@import "master-theme/assets/src/scss/components/share-buttons";
 
 @import "blocks";
 

--- a/classes/blocks/class-base-block.php
+++ b/classes/blocks/class-base-block.php
@@ -102,8 +102,8 @@ abstract class Base_Block {
 	 */
 	public static function enqueue_editor_assets() {
 		static::enqueue_editor_script();
-		static::enqueue_editor_style();
 		static::enqueue_frontend_style();
+		static::enqueue_editor_style();
 	}
 
 	/**
@@ -156,7 +156,8 @@ abstract class Base_Block {
 		wp_enqueue_style(
 			static::get_full_block_name() . '-editor-style',
 			static::get_url_path() . 'EditorStyle.min.css',
-			[],
+			// Ensure loaded both after main stylesheet and block's front end styles.
+			[ 'planet4-editor-style', static::get_full_block_name() . '-style' ],
 			\P4GBKS\Loader::file_ver( $filepath ),
 		);
 	}

--- a/classes/blocks/class-covers.php
+++ b/classes/blocks/class-covers.php
@@ -74,6 +74,8 @@ class Covers extends Base_Block {
 			'planet4-blocks/covers',
 			[  // - Register the block for the editor
 				'editor_script'   => 'planet4-blocks',
+				'style'           => static::get_full_block_name() . '-style',
+				'editor_style'    => static::get_full_block_name() . '-editor-style',
 				'render_callback' => static function ( $attributes ) {
 					if ( isset( $attributes['covers_view'] ) ) {
 						$attributes['initialRowsLimit'] = '3' === $attributes['covers_view'] ? 0 : intval( $attributes['covers_view'] );


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6654

The block editor now puts each block preview into an iframe, which it [provides with the editor stylesheets](https://github.com/WordPress/gutenberg/blob/8536f6f1aa1df9daa98193964aa8e62cc196cb7a/packages/block-editor/src/components/block-preview/auto.js#L73-L74).

WordPress provides these to the editor in PHP, by checking each block type for registered styles/editor styles.
https://github.com/WordPress/gutenberg/blob/8536f6f1aa1df9daa98193964aa8e62cc196cb7a/lib/client-assets.php#L627-L639
(It's not the actual same file in WordPress but similar enough).

Additionally WP now allows you to specify the screen size which it will apply to the preview iframe with scaling so that it takes up the same amount of sidebar space.

**Needs to be merged after https://github.com/greenpeace/planet4-master-theme/pull/1643**

TODO:
- [x] ~~Check the previous issue of registering a style causing it to be served on the front end even if the block is not on the page. Likely solved in core by now.~~ Should be fine, we don't register the script if it's not on the page so passing the handle doesn't change the front end.
- [x] Apply to other blocks, maybe reduce duplication.
- [x] Determine the right viewport width for each block type

### Findings

- Preview accuracy significantly improves in most cases.
- The font size gets a bit small, but hard to get around this. I used the minimum preview screen size that resulted in the same layout as our old previews. The reason our previews had larger text in 5.8 with this layout is actually because they're inaccurate.
- Some of our blocks have wildly different styles on mobile, to the point that we should really be showing a preview of the style on each screen for someone to make a reasonable choice. We could look at ways to make this more intuitive.
- Columns block previews not worth investing more time in because people should use the core Columns block, which does not even need a preview.
- Similar for Covers.