### PR TITLE
PLANET-5972  Prevent using PNG images for photographs

### DIFF
--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -24,6 +24,7 @@ export const EditableBackground = ({
       }}
       allowedTypes={['image/jpg','image/jpeg']}
       value={image_id}
+      title={"Select or Upload Photo (only jpg/jpeg)"}
       render={mediaUploadInstance => (
         <>
           <div className='background-holder'>

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -22,7 +22,7 @@ export const EditableBackground = ({
         const { id, alt_text, url, sizes } = image;
         changeSlideImage(index, id, url, alt_text, toSrcSet(Object.values(sizes)));
       }}
-      allowedTypes={['image']}
+      allowedTypes={['image/jpg','image/jpeg']}
       value={image_id}
       render={mediaUploadInstance => (
         <>

--- a/assets/src/blocks/Gallery/GalleryEditor.js
+++ b/assets/src/blocks/Gallery/GalleryEditor.js
@@ -70,8 +70,8 @@ const renderEdit = (attributes, setAttributes) => {
             instructions: __('Upload an image or select from the media library.', 'planet4-blocks-backend'),
           }}
           onSelect={onSelectImage}
-          accept="image/*"
           allowedTypes={["image"]}
+          accept={['image/jpg','image/jpeg']}
           multiple
           value={hasImages ? image_data : undefined}
         />

--- a/assets/src/blocks/Gallery/GalleryEditor.js
+++ b/assets/src/blocks/Gallery/GalleryEditor.js
@@ -67,7 +67,7 @@ const renderEdit = (attributes, setAttributes) => {
           addToGallery={hasImages}
           labels={{
             title: __('Select Gallery Images', 'planet4-blocks-backend'),
-            instructions: __('Upload an image or select from the media library.', 'planet4-blocks-backend'),
+            instructions: __('Upload an JPEG image or select one from the media library.', 'planet4-blocks-backend'),
           }}
           onSelect={onSelectImage}
           allowedTypes={["image"]}


### PR DESCRIPTION
[P4 Repo issue](https://github.com/greenpeace/planet4/issues/135)
[JIRA Issue](https://jira.greenpeace.org/browse/PLANET-5972)

This PR limits the ability of selecting/uploading PNG on certain blocks and provides pointers to editors about this restriction.

Carousel header
-[X] Limits selection to jpeg/jpg only
-[X] Adds ``(only jpeg/jpeg)`` to the media library modal
![image](https://user-images.githubusercontent.com/14031077/157568380-76ecb370-4592-4475-a7f6-0b0f5db944f8.png)

Gallery
~~-[ ] Limits upload to jpg/jpeg only~~ _In the current implementation this doesn't seem possible ATM_
-[X] Limits selection to jpg/jpg only
-[X] Adds ``jpeg`` to the media placeholder text
![image](https://user-images.githubusercontent.com/14031077/157568399-b3b85f99-829d-4f0a-878d-527efce834f6.png)
