### PR TITLE
PLANET-6658 Fix WPML RTL mayhem

### DIFF
--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -397,3 +397,16 @@ function p4_blocks_en_forms_twig_filters( $twig ) {
 */
 P4GBKS\Loader::get_instance();
 \P4GBKS\Rest\Rest_Api::add_endpoints();
+
+$remove_rtl_fix = function (): void {
+	global $sitepress;
+	// This RTL fix does not seem a good idea. Probably it was a bad attempt at solving the issues `url_to_postid`
+	// creates.
+	remove_action( 'wp_head', [ $sitepress, 'rtl_fix' ] );
+	remove_action( 'admin_print_styles', [ $sitepress, 'rtl_fix' ] );
+
+	// This caused `switch_lang` to get called. As a result the RTL fix messed up.
+	remove_filter( 'url_to_postid', [ $sitepress, 'url_to_postid' ] );
+};
+$remove_rtl_fix();
+add_action( 'wpml_after_startup', $remove_rtl_fix, 10, 0 );


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6658

* Remove "rtl_fix" which only makes things worse.
* Remove filter that caused WPML to call `switch_lang` when it's not
supposed to.

Likely WPML added `url_to_postid` assuming it would only be called in a context where it's safe to switch the language.

Maybe this used to be the case for the REST API. However WordPress calls the REST API "internally" to prevent the editor being delayed by an actual HTTP request. As a result WPML's `url_to_postid` filter will run on every revision that contains any embed block.

After some investigation I found `url_to_postid` is a super old part of WordPress and only used in a few leftover edge cases.

The only usage that could "break" if we remove WPML's filter is when you [embed a post from the same site](https://developer.wordpress.org/reference/classes/wp_oembed_controller/get_item/), which probably no one does anyway.

This branch is pinned on the `ummah` instance ([example page](https://www-dev.ummah4earth.org/wp-admin/post.php?post=1146&action=edit) that had the issue, you can compare with [same page on production](https://ummah4earth.org/wp-admin/post.php?post=1146&action=edit)).