### PR TITLE
PLANET-6627 Add block template with 2 blocks(paragraph and articles block) for pagetype post

### DIFF
--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -390,6 +390,19 @@ function p4_blocks_en_forms_twig_filters( $twig ) {
 	return $twig;
 }
 
+/**
+ * Adds a block template with 2 blocks(paragraph and articles block) on pagetype post.
+ */
+function p4_register_template() {
+	$post_type_object           = get_post_type_object( 'post' );
+	$post_type_object->template = [
+		[ 'core/paragraph' ],
+		[ 'planet4-blocks/articles' ],
+	];
+}
+
+add_action( 'init', 'p4_register_template' );
+
 /*
 ==========================
 	L O A D  P L U G I N


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-6627

---
The block templates can be declared in JS or in PHP as an array of blockTypes (block name and optional attributes) -

_PHP example:_
```
/**
 * Adds a block template with 2 blocks(paragraph and articles block) on pagetype post.
 */
function p4_register_template() {
	$post_type_object           = get_post_type_object( 'post' );
	$post_type_object->template = [
		[ 'core/paragraph' ],
		[ 'planet4-blocks/articles' ],
	];
}

add_action( 'init', 'p4_register_template' );
```

The following example in JavaScript creates a new block using [InnerBlocks](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inner-blocks/README.md) and templates, when inserted creates a set of blocks based off the template.

```
const el = wp.element.createElement;
const { registerBlockType } = wp.blocks;
const { InnerBlocks } = wp.blockEditor;
 
const BLOCKS_TEMPLATE = [
    [ 'core/image', {} ],
    [ 'core/paragraph', { placeholder: 'Image Details' } ],
];
 
registerBlockType( 'myplugin/template', {
    title: 'My Template Block',
    category: 'widgets',
    edit: ( props ) => {
        return el( InnerBlocks, {
            template: BLOCKS_TEMPLATE,
            templateLock: false,
        } );
    },
    save: ( props ) => {
        return el( InnerBlocks.Content, {} );
    },
} );
```

**In our use case, the PHP way of defining a block template looks more suitable.**

**Template Locking:**
We can add a template locking(if needs), like a below -
```
$post_type_object->template_lock = 'all';
//Options:
//    all — prevents all operations. It is not possible to insert new blocks, move existing blocks, or delete blocks.
//    insert — prevents inserting or removing blocks, but allows moving existing blocks.
```

**Block Attributes:**
We can predefine attributes in block template, if needed.
example:
```
$post_type_object->template = [
		[ 'core/paragraph', [ 'placeholder' => 'lorem ipsum' ] ],
		[ 'planet4-blocks/articles', [ 'article_heading' => 'Read more' ] ],
	];
```

**Testing:**
- Go to [test instance](https://www-dev.greenpeace.org/test-rhea/wp-admin/post-new.php), add new Post
- The Post has pre-added 2 blocks (Paragraph & articles) as per the block template definition.
