### PR TITLE
Prepare for features in new classes 

### DIFF
--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -9,6 +9,8 @@
 namespace P4GBKS;
 
 use P4\MasterTheme\Features;
+use P4\MasterTheme\Features\Dev\ThemeEditor;
+use P4\MasterTheme\Features\EngagingNetworks;
 use P4\MasterTheme\MigrationLog;
 use P4\MasterTheme\Migrations\M001EnableEnFormFeature;
 use P4GBKS\Controllers;
@@ -350,7 +352,7 @@ final class Loader {
 		$option_values = get_option( 'planet4_options' );
 
 		$en_active = ! MigrationLog::from_wp_options()->already_ran( M001EnableEnFormFeature::get_id() )
-					|| Features::is_active( Features::ENGAGING_NETWORKS );
+					|| Features::is_active( 'feature_engaging_networks' );
 
 		$reflection_vars = [
 			'home'            => P4GBKS_PLUGIN_URL . '/public/',
@@ -479,15 +481,8 @@ final class Loader {
 	 * @return bool Whether the theme editor will be included.
 	 */
 	private static function can_include_theme_editor(): bool {
-		if ( ! Features::is_active( Features::THEME_EDITOR ) ) {
-			return false;
-		}
 
-		if ( is_user_logged_in() ) {
-			return true;
-		}
-
-		return Features::is_active( Features::THEME_EDITOR_NON_LOGGED_IN );
+		return Features::is_active( 'theme_editor' ) && is_user_logged_in();
 	}
 
 	/**

--- a/classes/controller/menu/class-en-settings-controller.php
+++ b/classes/controller/menu/class-en-settings-controller.php
@@ -10,6 +10,7 @@
 namespace P4GBKS\Controllers\Menu;
 
 use P4\MasterTheme\Features;
+use P4\MasterTheme\Features\EngagingNetworks;
 use P4\MasterTheme\MigrationLog;
 use P4\MasterTheme\Migrations\M001EnableEnFormFeature;
 
@@ -25,7 +26,7 @@ class En_Settings_Controller extends Controller {
 		// We need to check if the migration already ran, as the EN block is on by default, but we cannot give an option
 		// that was added using CMB2 a default value of 'on', because then it can't be turned off.
 		$migration_ran     = MigrationLog::from_wp_options()->already_ran( M001EnableEnFormFeature::get_id() );
-		$feature_is_active = ! $migration_ran || Features::is_active( Features::ENGAGING_NETWORKS );
+		$feature_is_active = ! $migration_ran || Features::is_active( 'feature_engaging_networks' );
 
 		if ( $feature_is_active && current_user_can( 'manage_options' ) ) {
 			add_menu_page(
@@ -154,18 +155,5 @@ class En_Settings_Controller extends Controller {
 				$settings[ $name ] = sanitize_text_field( $setting );
 			}
 		}
-	}
-
-	/**
-	 * Sets selected language.
-	 *
-	 * @param string $locale Current locale.
-	 *
-	 * @return string The new locale.
-	 */
-	public function set_locale( $locale ) : string {
-		$main_settings = get_option( 'p4en_main_settings' );
-		$locale        = $main_settings['p4en_lang'] ?? '';
-		return $locale;
 	}
 }

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -266,23 +266,23 @@ function set_allowed_block_types( $allowed_block_types, $context ) {
 
 	$migration_ran = MigrationLog::from_wp_options()->already_ran( M001EnableEnFormFeature::get_id() );
 
-	$enform_active = ! $migration_ran || Features::is_active( Features::ENGAGING_NETWORKS );
+	$enform_active = ! $migration_ran || Features::is_active( 'allow_all_blocks' );
 
 	$page_block_types = array_merge(
 		PAGE_BLOCK_TYPES,
-		! Features::is_active( Features::BETA_BLOCKS ) ? [] : BETA_PAGE_BLOCK_TYPES,
+		! Features::is_active( 'beta_blocks' ) ? [] : BETA_PAGE_BLOCK_TYPES,
 		! $enform_active ? [] : [ 'planet4-blocks/enform' ],
 	);
 
 	$campaign_block_types = array_merge(
 		CAMPAIGN_BLOCK_TYPES,
-		! Features::is_active( Features::BETA_BLOCKS ) ? [] : BETA_CAMPAIGN_BLOCK_TYPES,
+		! Features::is_active( 'beta_blocks' ) ? [] : BETA_CAMPAIGN_BLOCK_TYPES,
 		! $enform_active ? [] : [ 'planet4-blocks/enform' ],
 	);
 
 	$action_block_types = array_merge(
 		ACTION_BLOCK_TYPES,
-		! Features::is_active( Features::BETA_BLOCKS ) ? [] : BETA_ACTION_BLOCK_TYPES,
+		! Features::is_active( 'beta_blocks' ) ? [] : BETA_ACTION_BLOCK_TYPES,
 		! $enform_active ? [] : [ 'planet4-blocks/enform' ],
 	);
 


### PR DESCRIPTION
* In the theme PR the constants are removed. To unblock that PR's tests,
I'm making it use string literals, which we can afterwards update to
thenew classes. All these things we wouldn't have to do in a monorepo.
* Remove "theme editor non logged in" feature check as it's not worth
the complexity.

This depends on https://github.com/greenpeace/planet4-master-theme/pull/1650