### PR TITLE
PLANET-6667 Create Reality Check block pattern

### DIFF
--- a/classes/patterns/class-block-pattern.php
+++ b/classes/patterns/class-block-pattern.php
@@ -35,6 +35,7 @@ abstract class Block_Pattern {
 		$patterns = [
 			SideImageWithTextAndCta::class,
 			HighlightedCta::class,
+			RealityCheck::class,
 		];
 
 		/**

--- a/classes/patterns/class-realitycheck.php
+++ b/classes/patterns/class-realitycheck.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Reality Check pattern class.
+ *
+ * @package P4GBKS
+ * @since 0.1
+ */
+
+namespace P4GBKS\Patterns;
+
+/**
+ * Class Reality Check.
+ *
+ * @package P4GBKS\Patterns
+ */
+class RealityCheck extends Block_Pattern {
+
+	/**
+	 * Returns the pattern name.
+	 */
+	public static function get_name(): string {
+		return 'p4/reality-check';
+	}
+
+	/**
+	 * Returns the template for one column.
+	 */
+	public static function get_column_template(): string {
+		return '
+			<!-- wp:column -->
+				<div class="wp-block-column">
+					<!-- wp:image {"align":"center","className":"mb-0 force-no-lightbox"} -->
+						<div class="wp-block-image mb-0 force-no-lightbox">
+							<figure class="aligncenter">
+								<img alt="" />
+							</figure>
+						</div>
+					<!-- /wp:image -->
+					<!-- wp:heading {"style":{"typography":{"fontSize":"4rem"}},"align":"center","className":"has-text-align-center mb-0","placeholder":"' . __( 'Enter title', 'planet4-blocks-backend' ) . '"} -->
+						<h2 style="font-size:4rem;" class="has-text-align-center mb-0"></h2>
+					<!-- /wp:heading -->
+					<!-- wp:paragraph {"align":"center","className":"has-text-align-center","placeholder":"' . __( 'Enter description', 'planet4-blocks-backend' ) . '"} -->
+						<p class="has-text-align-center"></p>
+					<!-- /wp:paragraph -->
+					<!-- wp:spacer {"height":"8px"} -->
+						<div style="height:8px" aria-hidden="true" class="wp-block-spacer"></div>
+					<!-- /wp:spacer -->
+				</div>
+			<!-- /wp:column -->
+		';
+	}
+
+	/**
+	 * Returns the pattern config.
+	 * We start with 3 columns, but editors can easily remove and/or duplicate them.
+	 */
+	public static function get_config(): array {
+		return [
+			'title'      => __( 'Reality Check', 'planet4-blocks-backend' ),
+			'categories' => [ 'planet4' ],
+			'content'    => '
+				<!-- wp:columns {"className":"block"} -->
+					<div class="wp-block-columns block">
+						' . self::get_column_template() . '
+						' . self::get_column_template() . '
+						' . self::get_column_template() . '
+					</div>
+				<!-- /wp:columns -->
+			',
+		];
+	}
+}


### PR DESCRIPTION
### Description

See [PLANET-6667](https://jira.greenpeace.org/browse/PLANET-6667), the [example page](https://www-dev.greenpeace.org/gutenberg/block-patterns/) and the [designs](https://www.figma.com/file/leueo1LMrlPabJkZYs2NgW/IA%26nav_Final-mockups?node-id=1%3A1650).
This is basically a Columns block with specific blocks per column (image, title and description). Houssam asked that we initialise the pattern with 3 columns so that is how it's implemented here, but editors can easily remove and/or duplicate columns.

### Testing

You can either test the new pattern on local, or on [this page](https://www-dev.greenpeace.org/test-titan/reality-check-tests/) I created for UAT. Also make sure to try adding a new one in the backend so that you can see the initial state.