### PR TITLE
PLANET-6668 Remove dark green color from palette and lightbox from icon

### DIFF
--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -628,11 +628,6 @@ DEFERREDCSS;
 					'slug'  => 'yellow',
 					'color' => '#ffd204',
 				],
-				[
-					'name'  => __( 'Dark Green', 'planet4-blocks-backend' ),
-					'slug'  => 'dark-green',
-					'color' => '#019433',
-				],
 			]
 		);
 

--- a/classes/patterns/class-highlightedcta.php
+++ b/classes/patterns/class-highlightedcta.php
@@ -34,8 +34,8 @@ class HighlightedCta extends Block_Pattern {
 					<div class="wp-block-columns block has-dark-blue-background-color has-text-color has-background has-white-color">
 						<!-- wp:column -->
 							<div class="wp-block-column">
-								<!-- wp:image {"align":"center"} -->
-									<div class="wp-block-image">
+								<!-- wp:image {"align":"center","className":"force-no-lightbox"} -->
+									<div class="wp-block-image force-no-lightbox">
 										<figure class="aligncenter">
 											<img alt=""/>
 										</figure>

--- a/classes/patterns/class-highlightedcta.php
+++ b/classes/patterns/class-highlightedcta.php
@@ -30,8 +30,8 @@ class HighlightedCta extends Block_Pattern {
 			'title'      => __( 'Highlighted CTA', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],
 			'content'    => '
-				<!-- wp:columns {"className":"block","textColor":"white","backgroundColor":"dark-green"} -->
-					<div class="wp-block-columns block has-dark-green-background-color has-text-color has-background has-white-color">
+				<!-- wp:columns {"className":"block","textColor":"white","backgroundColor":"dark-blue"} -->
+					<div class="wp-block-columns block has-dark-blue-background-color has-text-color has-background has-white-color">
 						<!-- wp:column -->
 							<div class="wp-block-column">
 								<!-- wp:image {"align":"center"} -->


### PR DESCRIPTION
### Description

See [PLANET-6668](https://jira.greenpeace.org/browse/PLANET-6668)

- Houssam asked that we remove the lightbox from the Highlighted CTA icon by default, since it doesn't really make sense to have it for such small images with no caption.
- Also, he asked that we replace the previously used dark green color by our existing dark blue, since we'll only start using the dark green in our future new identity. Therefore I've removed it from our color palette for now.

**Related PR**: https://github.com/greenpeace/planet4-master-theme/pull/1655