### PR TITLE
PLANET-6670 Use core class for full alignment

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
@@ -84,7 +84,7 @@ export const CarouselHeaderEditor = ({ setAttributes, attributes }) => {
   }), [needsMigration]);
 
   return (
-    <section className={`block block-header block-wide carousel-header ${className ?? ''}`}>
+    <section className={`block block-header alignfull carousel-header ${className ?? ''}`}>
       <Sidebar
         carouselAutoplay={carousel_autoplay}
         slides={slides}

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
@@ -89,7 +89,7 @@ export const CarouselHeaderFrontend = ({ slides, carousel_autoplay, className })
 
   return (
     <section
-      className={`block block-header block-wide carousel-header ${className ?? ''}`}
+      className={`block block-header alignfull carousel-header ${className ?? ''}`}
       ref={containerRef}
       onMouseEnter={() => setAutoplayPaused(true)}
       onMouseLeave={() => setAutoplayPaused(false)}

--- a/assets/src/blocks/ENForm/ENFormFrontend.js
+++ b/assets/src/blocks/ENForm/ENFormFrontend.js
@@ -32,9 +32,9 @@ export const ENFormFrontend = (attributes) => {
   const section_style = ((style) => {
     switch (style) {
       case 'side-style':
-        return 'block-header block-wide';
+        return 'block-header alignfull';
       case 'full-width-bg':
-        return 'block-footer block-wide';
+        return 'block-footer alignfull';
       default:
         return '';
     }

--- a/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
+++ b/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
@@ -36,9 +36,9 @@ export const ENFormInPlaceEdit = ({attributes, setAttributes}) => {
   const section_style = ((style) => {
     switch (style) {
       case 'side-style':
-        return 'block-header block-wide';
+        return 'block-header alignfull';
       case 'full-width-bg':
-        return 'block-footer block-wide';
+        return 'block-footer alignfull';
       default:
         return '';
     }

--- a/assets/src/blocks/Happypoint/HappypointFrontend.js
+++ b/assets/src/blocks/Happypoint/HappypointFrontend.js
@@ -51,7 +51,7 @@ export const HappypointFrontend = ({
   const instanceId = 'happy-point';
 
   return (
-    <section className={`block block-footer block-wide happy-point-block-wrap ${className ?? ''}`}>
+    <section className={`block block-footer alignfull happy-point-block-wrap ${className ?? ''}`}>
       <picture>
         <img {...imgProps} loading="lazy" />
       </picture>

--- a/assets/src/blocks/HubspotForm/HubspotFormEditor.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormEditor.js
@@ -61,7 +61,7 @@ export const HubspotFormEditor = ({
         hubspotThankyouMessage,
         setAttributes
       }} />
-      <section className={`hubspot-form hubspot-form-editor block-wide ${blockStyle}`} style={{...backgroundImage}}>
+      <section className={`hubspot-form hubspot-form-editor alignfull ${blockStyle}`} style={{...backgroundImage}}>
         <div className='container'>
           <div className='block-wrapper'>
             <div className='block-wrapper-inner block-wrapper-text' style={{...backgroundImage}}>

--- a/assets/src/blocks/HubspotForm/HubspotFormFrontend.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormFrontend.js
@@ -30,7 +30,7 @@ export const HubspotFormFrontend = ({
   }, [ blockStyle ]);
 
   return (
-    <section className={`hubspot-form block-wide ${styleClass}`} style={{...backgroundImage}}>
+    <section className={`hubspot-form alignfull ${styleClass}`} style={{...backgroundImage}}>
       <div className='container'>
         <div className='block-wrapper'>
           <div className='block-wrapper-inner block-wrapper-text' style={{...backgroundImage}}>

--- a/assets/src/blocks/Splittwocolumns/SplittwocolumnsFrontend.js
+++ b/assets/src/blocks/Splittwocolumns/SplittwocolumnsFrontend.js
@@ -30,7 +30,7 @@ export const SplittwocolumnsFrontend = ({
   }
 
   return (
-    <section className={`block-wide split-two-column ${className ?? ''}`}>
+    <section className={`alignfull split-two-column ${className ?? ''}`}>
       <div className="split-two-column-item item--left">
         {issue_image_src &&
           <div className="split-two-column-item-image">

--- a/assets/src/blocks/Splittwocolumns/SplittwocolumnsInPlaceEdit.js
+++ b/assets/src/blocks/Splittwocolumns/SplittwocolumnsInPlaceEdit.js
@@ -37,7 +37,7 @@ export const SplittwocolumnsInPlaceEdit = ({attributes, charLimit, setAttributes
   }, 400);
 
   return (
-    <section className={`block-wide split-two-column ${className ?? ''}`}>
+    <section className={`alignfull split-two-column ${className ?? ''}`}>
       <div className="split-two-column-item item--left">
         {issue_image_src &&
           <div className="split-two-column-item-image">

--- a/assets/src/styles/blocks/HubspotForm/HubspotFormStyles.scss
+++ b/assets/src/styles/blocks/HubspotForm/HubspotFormStyles.scss
@@ -15,7 +15,7 @@
   background-position: center center;
   box-shadow: inset 0 0 0 100vw transparentize($grey-80, .45);
 
-  &.block-wide {
+  &.alignfull {
     width: 100vw;
     /* A better way is to add these changes into the WideBlocks stylesheet */
     margin-inline-start: calc(((100vw - 100%) / 2) * -1);

--- a/assets/src/styles/blocks/WideBlocks.scss
+++ b/assets/src/styles/blocks/WideBlocks.scss
@@ -1,4 +1,6 @@
-.block-wide {
+// .block-wide kept for BC of existing content.
+// Can be removed once no content uses it anymore.
+.alignfull, .block-wide {
   width: 100vw;
   //     Screen width - block width
   //  -  --------------------------

--- a/templates/blocks/carousel_header_full-width-classic.twig
+++ b/templates/blocks/carousel_header_full-width-classic.twig
@@ -3,7 +3,7 @@
     {{ text|length > maxLength ? text|slice(0, maxLength) ~ '…' : text }}
 {% endmacro %}
 
-<section class="block block-header block-wide carousel-header_full-width-classic">
+<section class="block block-header alignfull carousel-header_full-width-classic">
 	<div id="carousel-wrapper-header"
 		data-block-style="full-width-classic"
 		data-carousel-autoplay="{{ fields.carousel_autoplay == 1 ? 'true' : '' }}">

--- a/templates/blocks/enform.twig
+++ b/templates/blocks/enform.twig
@@ -1,5 +1,5 @@
 {% block enblock %}
-	<section class="block enform-wrap enform-{{ fields.en_form_style }} {% if fields.en_form_style == 'side-style' %}block-header block-wide{% endif %} {%if fields.en_form_style == 'full-width-bg' %}block-footer block-wide{% endif %} {% if campaign_data.template %}campaign-{{ campaign_data.template }}{% endif %}">
+	<section class="block enform-wrap enform-{{ fields.en_form_style }} {% if fields.en_form_style == 'side-style' %}block-header alignfull{% endif %} {%if fields.en_form_style == 'full-width-bg' %}block-footer alignfull{% endif %} {% if campaign_data.template %}campaign-{{ campaign_data.template }}{% endif %}">
 		{% if fields.en_form_style == 'full-width-bg' or fields.en_form_style == 'side-style' %}
 			<picture>
 				<img src="{{ fields.background_src.0|default(fields.default_image) }}"

--- a/templates/blocks/enform/enblock.twig
+++ b/templates/blocks/enform/enblock.twig
@@ -1,5 +1,5 @@
 {% block enblock %}
-	<section class="block enform-wrap enform-{{ fields.en_form_style }} {% if fields.en_form_style == 'side-style' %}block-header block-wide{% endif %} {%if fields.en_form_style == 'full-width-bg' %}block-footer block-wide{% endif %} {% if campaign_data.template %}campaign-{{ campaign_data.template }}{% endif %}">
+	<section class="block enform-wrap enform-{{ fields.en_form_style }} {% if fields.en_form_style == 'side-style' %}block-header alignfull{% endif %} {%if fields.en_form_style == 'full-width-bg' %}block-footer alignfull{% endif %} {% if campaign_data.template %}campaign-{{ campaign_data.template }}{% endif %}">
 		{% if fields.en_form_style == 'full-width-bg' or fields.en_form_style == 'side-style' %}
 			<picture>
 				<img src="{{ fields.background_src.0|default(fields.default_image) }}"


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6670

Change the `.block-wide` class to `.alignfull` in markup. Perserve the old class because some blocks save markup in the DB.

Needs to be merged after https://github.com/greenpeace/planet4-master-theme/pull/1654, as tests are not in the repo of the code they're testing.