### PR TITLE
Fix slider not full width in editor

### DIFF
--- a/assets/src/styles/blocks/CarouselHeader/CarouselHeaderEditorStyle.scss
+++ b/assets/src/styles/blocks/CarouselHeader/CarouselHeaderEditorStyle.scss
@@ -3,6 +3,12 @@
 @import "../../master-theme/assets/src/scss/base/variables";
 @import "./SidebarSlidesEditor.scss";
 
+// Fix for the block being inside of a wrapper element.
+// We can remove this fix once this block starts using the v2 block registration API.
+div[data-type="planet4-blocks/carousel-header"] {
+  max-width: 100vw !important;
+}
+
 .visually-hidden {
   display: none;
 }


### PR DESCRIPTION
* Our full width block class doesn't work in this case because it has
wrapper markup.

Test page https://www-dev.greenpeace.org/test-venus/wp-admin/post.php?post=13&action=edit

Related ticket: https://jira.greenpeace.org/browse/PLANET-6670