### PR TITLE
PLANET-6731: Add filter hook for enform data

### DIFF
--- a/classes/rest/class-rest-api.php
+++ b/classes/rest/class-rest-api.php
@@ -410,6 +410,7 @@ class Rest_Api {
 			);
 		}
 
+		$form     = apply_filters( 'planet4_enform_data', $form, $en_page_id );
 		$request  = [
 			'url'  => 'https://e-activist.com/ens/service/page/' . $en_page_id . '/process',
 			'args' => [


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6731

GPLux needs to control the transmission of a `email_ok` field so it doesn't interfere with other petitions.

Adding a hook to allow to modify data before it is sent to EN.
We can then do this kind of operation at a child-theme level to not transmit some fields with specific value.

```php
add_filter(
	'planet4_enform_data',
	function ( $data ) {
		if ( isset( $data['supporter']['questions']['question.3805'] )
			&& $data['supporter']['questions']['question.3805'] === 'N'
		) {
			unset( $data['supporter']['questions']['question.3805'] );
		}

		return $data;
	}
);
```