### PR TITLE
PLANET-6734 Remove blocks heading links style overrides

### DIFF
--- a/assets/src/styles/blocks/Articles.scss
+++ b/assets/src/styles/blocks/Articles.scss
@@ -77,10 +77,6 @@
     color: $grey-80;
   }
 
-  a {
-    color: inherit;
-  }
-
   @include mobile-only {
     display: -webkit-box;
     -webkit-line-clamp: 2;

--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -9,7 +9,7 @@
     }
   }
 
-  h3, h3 > a {
+  h3 {
     line-height: 1.6rem;
 
     --block-columns--column-heading-- {
@@ -28,10 +28,6 @@
         font-size: 1.5rem;
       }
     }
-  }
-
-  h3 > a:hover {
-    text-decoration: underline;
   }
 
   // Columns block, layout no-image.


### PR DESCRIPTION
### Description

See [PLANET-6734](https://jira.greenpeace.org/browse/PLANET-6734)
These styles are now defined in master theme for all heading links.

**Related PR:** https://github.com/greenpeace/planet4-master-theme/pull/1679

### Testing

You can test the new heading links on [this page](https://www-dev.greenpeace.org/test-venus/heading-links/) for example, and compare it to [the old version](https://www-dev.greenpeace.org/test-titan/51775-2/). Also make sure that our P4 Columns and Articles blocks still behave as expected too (for instance on the [homepage](https://www-dev.greenpeace.org/test-venus/)).