### PR TITLE
PLANET-6735 Add Lightbox to Media and Text block images

### DIFF
--- a/assets/src/components/Lightbox/setupLightboxForImages.js
+++ b/assets/src/components/Lightbox/setupLightboxForImages.js
@@ -50,4 +50,7 @@ export const setupLightboxForImages = function() {
 
   const imagesInParagraphs = document.querySelectorAll('.post-content p:not(.wp-caption), .page-content p:not(.wp-caption)');
   imagesInParagraphs.forEach(setupImageAndCaption(lightBoxNode, 'img'));
+
+  const mediaAndTextImages = document.querySelectorAll('.wp-block-media-text:not(.force-no-lightbox)');
+  mediaAndTextImages.forEach(setupImageAndCaption(lightBoxNode));
 }

--- a/assets/src/styles/blocks/core-overrides/_media-text.scss
+++ b/assets/src/styles/blocks/core-overrides/_media-text.scss
@@ -1,4 +1,8 @@
 .wp-block-media-text {
+  &:not(.force-no-lightbox) img {
+    cursor: pointer;
+  }
+
   @media (max-width: 600px) {
     .wp-block-media-text__content {
       padding: 0;


### PR DESCRIPTION
### Description

See [PLANET-6735](https://jira.greenpeace.org/browse/PLANET-6735)
This is to allow users to enlarge/zoom images, especially on mobile. Editors can still disable this functionality by adding the `force-no-lightbox` class to the block.

### Testing

You can test the changes on your local or on [this page that I created](https://www-dev.greenpeace.org/test-iocaste/media-text-tests/).