### PR TITLE
PLANET-6520: Implement Quick Links block pattern

### DIFF
--- a/assets/src/styles/blocks/core-overrides/_columns.scss
+++ b/assets/src/styles/blocks/core-overrides/_columns.scss
@@ -1,5 +1,5 @@
 .wp-block-columns.is-not-stacked-on-mobile.is-style-mobile-carousel {
-  @include mobile-only {
+  @include small-and-less {
     flex-wrap: nowrap;
     overflow-x: auto;
     scrollbar-width: none;

--- a/assets/src/styles/blocks/core-overrides/_columns.scss
+++ b/assets/src/styles/blocks/core-overrides/_columns.scss
@@ -1,4 +1,4 @@
-.is-style-mobile-carousel {
+.wp-block-columns.is-not-stacked-on-mobile.is-style-mobile-carousel {
   @include mobile-only {
     flex-wrap: nowrap;
     overflow-x: auto;
@@ -9,11 +9,8 @@
     }
 
     .wp-block-column {
-      min-width: 30vw;
-    }
-
-    &:not(.is-not-stacked-on-mobile) .wp-block-column:not(:last-child) {
-      margin-inline-end: $sp-2;
+      flex-basis: auto;
+      flex-shrink: 0;
     }
   }
 }

--- a/classes/patterns/class-block-pattern.php
+++ b/classes/patterns/class-block-pattern.php
@@ -38,6 +38,7 @@ abstract class Block_Pattern {
 			RealityCheck::class,
 			Issues::class,
 			DeepDive::class,
+			QuickLinks::class,
 		];
 
 		/**

--- a/classes/patterns/class-quicklinks.php
+++ b/classes/patterns/class-quicklinks.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Quick Links pattern class.
+ *
+ * @package P4GBKS
+ * @since 0.1
+ */
+
+namespace P4GBKS\Patterns;
+
+/**
+ * Class Quick Links.
+ *
+ * @package P4GBKS\Patterns
+ */
+class QuickLinks extends Block_Pattern {
+
+	/**
+	 * Returns the pattern name.
+	 */
+	public static function get_name(): string {
+		return 'p4/quick-links';
+	}
+
+	/**
+	 * Returns the template for one column.
+	 */
+	public static function get_column_template(): string {
+		return '
+			<!-- wp:column -->
+				<div class="wp-block-column">
+					<!-- wp:group {"className":"group-stretched-link"} -->
+						<div class="wp-block-group group-stretched-link">
+							<!-- wp:image {"align":"center","className":"is-style-rounded-90 force-no-lightbox force-no-caption mb-0"} -->
+								<div class="wp-block-image is-style-rounded-90 force-no-lightbox force-no-caption mb-0">
+									<figure class="aligncenter">
+										<img src="' . esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-90x90.jpg" alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '" />
+									</figure>
+								</div>
+							<!-- /wp:image -->
+							<!-- wp:spacer {"height":"16px"} -->
+								<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
+							<!-- /wp:spacer -->
+							<!-- wp:heading {"level":5,"style":{"typography":{"fontSize":"1rem"}},"align":"center","className":"has-text-align-center","placeholder":"' . __( 'Category', 'planet4-blocks-backend' ) . '"} -->
+								<h5 style="font-size:1rem;" class="has-text-align-center"></h5>
+							<!-- /wp:heading -->
+						</div>
+					<!-- /wp:group -->
+				</div>
+			<!-- /wp:column -->
+		';
+	}
+
+	/**
+	 * Returns the pattern config.
+	 * We start with 6 columns, but editors can easily remove and/or duplicate them.
+	 */
+	public static function get_config(): array {
+		return [
+			'title'      => __( 'Quick Links', 'planet4-blocks-backend' ),
+			'categories' => [ 'planet4' ],
+			'content'    => '
+				<!-- wp:group {"className":"block","align":"full","backgroundColor":"grey-05"} -->
+					<div class="wp-block-group alignfull block has-grey-05-background-color has-background">
+						<!-- wp:group {"className":"container"} -->
+							<div class="wp-block-group container">
+								<!-- wp:spacer {"height":"24px"} -->
+									<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+								<!-- /wp:spacer -->
+								<!-- wp:heading {"level":4,"placeholder":"' . __( 'Enter title', 'planet4-blocks-backend' ) . '"} -->
+									<h4></h4>
+								<!-- /wp:heading -->
+								<!-- wp:columns {"isStackedOnMobile":false,"className":"is-style-mobile-carousel"} -->
+									<div class="wp-block-columns is-not-stacked-on-mobile is-style-mobile-carousel">
+											' . self::get_column_template() . '
+											' . self::get_column_template() . '
+											' . self::get_column_template() . '
+											' . self::get_column_template() . '
+											' . self::get_column_template() . '
+											' . self::get_column_template() . '
+									</div>
+								<!-- /wp:columns -->
+							</div>
+						<!-- /wp:group -->
+					</div>
+				<!-- /wp:group -->
+			',
+		];
+	}
+}

--- a/classes/patterns/class-quicklinks.php
+++ b/classes/patterns/class-quicklinks.php
@@ -34,14 +34,23 @@ class QuickLinks extends Block_Pattern {
 							<!-- wp:image {"align":"center","className":"is-style-rounded-90 force-no-lightbox force-no-caption mb-0"} -->
 								<div class="wp-block-image is-style-rounded-90 force-no-lightbox force-no-caption mb-0">
 									<figure class="aligncenter">
-										<img src="' . esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-90x90.jpg" alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '" />
+										<img
+											src="' . esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-90x90.jpg"
+											alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '"
+										/>
 									</figure>
 								</div>
 							<!-- /wp:image -->
 							<!-- wp:spacer {"height":"16px"} -->
 								<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 							<!-- /wp:spacer -->
-							<!-- wp:heading {"level":5,"style":{"typography":{"fontSize":"1rem"}},"align":"center","className":"has-text-align-center","placeholder":"' . __( 'Category', 'planet4-blocks-backend' ) . '"} -->
+							<!-- wp:heading {
+								"level":5,
+								"style":{"typography":{"fontSize":"1rem"}},
+								"align":"center",
+								"className":"has-text-align-center",
+								"placeholder":"' . __( 'Category', 'planet4-blocks-backend' ) . '"
+							} -->
 								<h5 style="font-size:1rem;" class="has-text-align-center"></h5>
 							<!-- /wp:heading -->
 						</div>


### PR DESCRIPTION
### Description

See [PLANET-6520](https://jira.greenpeace.org/browse/PLANET-6520)
I've yet to figure out how to implement [this transition](https://www-dev.greenpeace.org/gutenberg/deep-dive-topics-links/) requested by the design team, maybe it will be for a second iteration?

### Testing

On local, you'll need to set master-theme to the `new-pattern-placeholders` branch to see the correct image placeholders both in the editor and in the frontend ([corresponding PR](https://github.com/greenpeace/planet4-master-theme/pull/1717)).
Otherwise you can test the new pattern on [this page](https://www-dev.greenpeace.org/test-neptune/quick-links-patterns-block/) for example 🙂 