### PR TITLE
Add group variation for full block link

### DIFF
--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -47,3 +47,18 @@ replaceTaxonomyTermSelectors();
 setupCustomSidebar();
 setUpCssVariables();
 blockEditorValidation();
+
+const { registerBlockVariation } = wp.blocks;
+const { __ } = wp.i18n;
+
+registerBlockVariation('core/group', {
+  name: 'group-stretched-link',
+  title: __('Stretched Link', 'planet4-blocks-backend'),
+  description: __('Make the entire block contents clickable, using the first link inside.', 'planet4-blocks-backend'),
+  attributes: { className: 'group-stretched-link' },
+  scope: ['inserter', 'transform'],
+  isActive: (blockAttributes) => {
+    return blockAttributes.className === 'group-stretched-link';
+  },
+  icon: 'admin-links',
+});

--- a/assets/src/styles/blocks.scss
+++ b/assets/src/styles/blocks.scss
@@ -23,7 +23,6 @@
 
 // Other
 @import "blocks/WideBlocks";
-@import "blocks/Editor";
 
 .is-style-small-padding {
   padding: 8px;
@@ -58,3 +57,6 @@
 .is-style-roboto-font-family {
   font-family: $roboto;
 }
+
+// Variations
+@import "../variations/stretched-link";

--- a/assets/src/styles/blocks/Editor.scss
+++ b/assets/src/styles/blocks/Editor.scss
@@ -1,4 +1,0 @@
-.block-edit-mode-warning {
-  padding: $sp-2;
-  margin: 0;
-}

--- a/assets/src/styles/editorStyle.scss
+++ b/assets/src/styles/editorStyle.scss
@@ -15,6 +15,7 @@
 @import "blocks/TakeActionBoxout/edit";
 @import "blocks/CookiesEditor";
 @import "blocks/core-overrides/HeadingEditor";
+@import "../variations/stretched-link/edit";
 
 @import "components/LayoutSelector";
 @import "components/EmptyMessage";
@@ -27,3 +28,8 @@
 @import "components/FormField";
 @import "components/HTMLSidebarHelp";
 @import "editorFonts";
+
+.block-edit-mode-warning {
+  padding: $sp-2;
+  margin: 0;
+}

--- a/assets/src/variations/stretched-link/edit.scss
+++ b/assets/src/variations/stretched-link/edit.scss
@@ -1,0 +1,4 @@
+.group-stretched-link {
+  outline: 1px dashed grey;
+  outline-offset: 2px;
+}

--- a/assets/src/variations/stretched-link/index.scss
+++ b/assets/src/variations/stretched-link/index.scss
@@ -1,0 +1,19 @@
+.group-stretched-link {
+  position: relative;
+
+  // Ensure it's only applying to the first link.
+  a:first-of-type {
+    &:before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      right: 0;
+    }
+
+    &:after {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
### Description

This should work well on any block that can use `position: relative`, and as long as the link is not within a block with `position: relative` inside the container.

~~A drawback about this method is a block can only have 1 block style at a time. I have another PR that uses [block styles to add padding on the same blocks](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/832). The only way to use styles for more things is to add 1 style for every possible combination. For more than 2 things that would probably get out of hand.~~

A possible alternative is to create a [variation of the core group block](https://github.com/WordPress/gutenberg/blob/29c0c4239c5e16fd3a32bc4ea82aa0135450b344/packages/block-library/src/group/variations.js#L7-L43), similar to the new "row" block, which has this CSS. That would make it much more obvious what's happening than a style. That also frees up the block styles for actual styles.

I ended up using a variation because styles are already used for padding and equally spacing inside groups. A nice plus of the variation is that it shows up with the variation name, also in the block list.

![Screenshot from 2022-05-03 11-08-24](https://user-images.githubusercontent.com/7604138/166429032-7a455ef4-812b-45e1-8e16-6755332bf5bf.png)

### Testing

Example: https://www-dev.greenpeace.org/test-phoebe/expanded-link-block/