### PR TITLE
PLANET-6740 Limit Lightbox pointer cursor to img

### DIFF
--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -5,7 +5,7 @@
   margin-top: $sp-1;
   margin-bottom: $sp-2;
 
-  &:not(.force-no-lightbox) {
+  &:not(.force-no-lightbox) img {
     cursor: pointer;
   }
 


### PR DESCRIPTION
### Description

See [PLANET-6740](https://jira.greenpeace.org/browse/PLANET-6740)
If we add the cursor to the whole `wp-block-image` div, if the image is smaller then it looks like you can click in paddings

### Testing

You can see see the difference by comparing these two pages I created:
- [broken](https://www-dev.greenpeace.org/test-mars/lightbox-tests/)
- [fixed](https://www-dev.greenpeace.org/test-iocaste/lightbox-tests/)