### PR TITLE
Fix block report when all blocks are allowed

### DIFF
--- a/classes/search/block/class-blockusagetable.php
+++ b/classes/search/block/class-blockusagetable.php
@@ -224,10 +224,11 @@ class BlockUsageTable extends WP_List_Table {
 			$context = new \WP_Block_Editor_Context(
 				[ 'post' => (object) [ 'post_type' => $type ] ]
 			);
-			$allowed = array_merge(
-				$allowed,
-				array_values( get_allowed_block_types( $context ) )
-			);
+			$on_type = get_allowed_block_types( $context );
+			if ( ! is_array( $on_type ) ) {
+				$on_type = $on_type ? $this->blocks_registered : [];
+			}
+			$allowed = array_merge( $allowed, array_values( $on_type ) );
 		}
 
 		$allowed = array_unique( $allowed );


### PR DESCRIPTION
Function get_allowed_block_types can return a bool sometimes, which breaks filters.
Returning all blocks registered instead if that's the case.
