### PR TITLE
PLANET-6742 Add right sizes attributes for some core blocks

### DIFF
--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -454,7 +454,7 @@ add_filter(
 					$container    = $breakpoint['width'];
 					$column_count = isset( $breakpoint['collapse'] ) ? 1 : $column_count;
 
-					return "(min-width: ${screen}px) calc(($container / $column_count) - 1.25em * ($column_count - 1)";
+					return "(min-width: ${screen}px) calc(($container / $column_count) - 1.25em * ($column_count - 1))";
 				},
 				$breakpoints
 			);

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -432,11 +432,6 @@ $breakpoints = [
 		'screen' => 600,
 		'width'  => '540px',
 	],
-	[
-		'screen'   => 576,
-		'width'    => '540px',
-		'collapse' => true,
-	],
 ];
 
 add_filter(
@@ -450,16 +445,16 @@ add_filter(
 
 			$sizes = array_map(
 				function ( $breakpoint ) use ( $column_count ) {
-					$screen       = $breakpoint['screen'];
-					$container    = $breakpoint['width'];
-					$column_count = isset( $breakpoint['collapse'] ) ? 1 : $column_count;
+					$screen    = $breakpoint['screen'];
+					$container = $breakpoint['width'];
+					$cols_minus_one = $column_count - 1;
 
-					return "(min-width: ${screen}px) calc(($container / $column_count) - 1.25em * ($column_count - 1))";
+					return "(min-width: ${screen}px) calc($container / $column_count - 1.25em * $cols_minus_one)";
 				},
 				$breakpoints
 			);
 
-			$sizes_attr = 'sizes="' . implode( ', ', $sizes ) . ', calc(100vw - 24px)"';
+			$sizes_attr = 'sizes="' . implode( ', ', array_merge($sizes, ['calc(100vw - 24px)']) ) . '"';
 
 			// Assume all images are full width in a container.
 			$block_content = preg_replace( '/sizes=".*"/', $sizes_attr, $block_content );

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -465,6 +465,25 @@ add_filter(
 			$block_content = preg_replace( '/sizes=".*"/', $sizes_attr, $block_content );
 		}
 
+		if ( 'core/media-text' === $block['blockName'] && $instance->attributes['mediaId'] ) {
+			$media_id = $instance->attributes['mediaId'];
+			$width    = $instance->attributes['mediaWidth'] ?? 50;
+
+			$srcset = wp_get_attachment_image_srcset( $media_id, 'full' );
+
+			$stack_mobile = ! $instance->attributes['isStackedOnMobile'] ? '' : '(max-width: 600px) 100vw, ';
+
+			$sizes_attr = "sizes=\"{$stack_mobile}{$width}vw\"";
+
+			$image_class_start = "class=\"wp-image-$media_id ";
+
+			$block_content = str_replace(
+				$image_class_start,
+				"$sizes_attr srcset=\"$srcset\" $image_class_start",
+				$block_content
+			);
+		}
+
 		return $block_content;
 	},
 	10,

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -459,7 +459,7 @@ add_filter(
 				$breakpoints
 			);
 
-			$sizes_attr = 'sizes="' . implode( ', ', $sizes ) . ', 100vw"';
+			$sizes_attr = 'sizes="' . implode( ', ', $sizes ) . ', calc(100vw - 24px)"';
 
 			// Assume all images are full width in a container.
 			$block_content = preg_replace( '/sizes=".*"/', $sizes_attr, $block_content );

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -454,7 +454,7 @@ add_filter(
 					$container    = $breakpoint['width'];
 					$column_count = isset( $breakpoint['collapse'] ) ? 1 : $column_count;
 
-					return "(min-width: ${screen}px) calc(($container / $column_count) - 1.25em + (1.25em / $column_count))";
+					return "(min-width: ${screen}px) calc(($container / $column_count) - 1.25em * ($column_count - 1)";
 				},
 				$breakpoints
 			);


### PR DESCRIPTION
Ref: [PLANET-6742](https://jira.greenpeace.org/browse/PLANET-6742)

We found while checking the Brasil site that image handling in core is pretty terrible, not just on the Query Loop block. With some small fixes we can [reduce the amount of unnecessary data being sent](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/837#issuecomment-1108816046) by a lot.

These 2 blocks are relatively easy to provide the right `sizes` attribute, which helps browsers avoid downloading oversized images. Image handling is [still an open issue in core](https://github.com/WordPress/gutenberg/issues/6177) and doesn't seem to have much progress lately.

Investigating:
* Is the replacement safe to do? Should fail "gracefully" the fix would just not be applied, visual result is identical.
* It gets hard when multiple blocks that force a width are nested in each other. In that case it might be possible to access block context, at least for a few cases. For now this is not handled, only top level Media and Text / Query Loop grid will have proper `sizes`.

### How I tested these changes
https://github.com/ausi/respimagelint can scan a page's images and report on missing/incorrect data in srcset and sizes attributes.

On the master branch, running this bookmarklet clearly shows errors of images being multiple times smaller than their sizes attributes indicates.
![Screenshot from 2022-04-25 14-15-41](https://user-images.githubusercontent.com/7604138/165087331-ba60a120-8e55-4e9e-b4da-90985d6e6004.png)


On this branch, it should not give any more errors for images inside Query Loop (grid) and Media and Text. (page is identical)

![Screenshot from 2022-04-25 14-17-01](https://user-images.githubusercontent.com/7604138/165087355-3406c921-fa54-4844-981d-c218e09102f6.png)

### Media and Text
This one is easier and likely has more benefits. However if the block is inside a container that forces a width, it's still way off. At least page header images.

### Query Loop

* Makes the assumption that the only images inside the block are post featured images spanning the full width of the container.
* It gets hard when multiple blocks that force a width are nested in each other. In that case it might be possible to access block context, at least for a few cases.
