### PR TITLE
Block report: Parse inner blocks data

### DIFF
--- a/classes/search/block/class-blockusage.php
+++ b/classes/search/block/class-blockusage.php
@@ -204,33 +204,49 @@ class BlockUsage {
 		);
 
 		$items = [];
-		foreach ( $block_list as $block ) {
-			$type  = $block['blockName'];
-			$attrs = $block['attrs'];
+		while ( ! empty( $block_list ) ) {
+			$block   = array_shift( $block_list );
+			$items[] = $this->format_block_data( $block, $post );
 
-			$namespace  = strpos( $type, '/' ) !== false
-				? explode( '/', $type )[0] : 'core';
-			$local_name = strpos( '/', $type ) !== false
-				? explode( '/', $type )[1] : $type;
-
-			$items[] = [
-				'post_id'       => $post->ID,
-				'post_title'    => $post->post_title
-					? $post->post_title : __( '(no title)', 'planet4-blocks-backend' ),
-				'post_status'   => $post->post_status,
-				'post_type'     => $post->post_type,
-				'post_date'     => $post->post_date,
-				'post_modified' => $post->post_modified,
-				'post_status'   => $post->post_status,
-				'guid'          => $post->guid,
-				'block_ns'      => $namespace,
-				'block_type'    => $type,
-				'local_name'    => $local_name,
-				'block_attrs'   => $attrs,
-			];
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$block_list = array_merge( $block_list, $block['innerBlocks'] );
+			}
 		}
 
 		return $items;
+	}
+
+	/**
+	 * Format block information.
+	 *
+	 * @param array  $block A block.
+	 * @param object $post  WP_Post.
+	 * @return array[]
+	 */
+	private function format_block_data( array $block, $post ): array {
+		$type  = $block['blockName'];
+		$attrs = $block['attrs'] ?? [];
+
+		$namespace  = strpos( $type, '/' ) !== false
+			? explode( '/', $type )[0] : 'core';
+		$local_name = strpos( '/', $type ) !== false
+			? explode( '/', $type )[1] : $type;
+
+		return [
+			'post_id'       => $post->ID,
+			'post_title'    => $post->post_title
+				? $post->post_title : __( '(no title)', 'planet4-blocks-backend' ),
+			'post_status'   => $post->post_status,
+			'post_type'     => $post->post_type,
+			'post_date'     => $post->post_date,
+			'post_modified' => $post->post_modified,
+			'post_status'   => $post->post_status,
+			'guid'          => $post->guid,
+			'block_ns'      => $namespace,
+			'block_type'    => $type,
+			'local_name'    => $local_name,
+			'block_attrs'   => $attrs,
+		];
 	}
 
 	/**


### PR DESCRIPTION
Inner blocks were previously skipped, WP parser returns inner blocks as properties of root blocks.

- Extract format_block_data method
- Add loop to go through any inner block depth

This allows to search for blocks used in query loop.

## Test

- Create a post with a query block
- Add some blocks in this query, save draft
- Search those blocks in the block report
