### PR TITLE
PLANET-6748: Fix read more text from Covers block

### DIFF
--- a/assets/src/blocks/Covers/CoversEditor.js
+++ b/assets/src/blocks/Covers/CoversEditor.js
@@ -20,7 +20,7 @@ const { RichText } = wp.blockEditor;
 const { __ } = wp.i18n;
 
 const renderEdit = (attributes, toAttribute, setAttributes) => {
-  const { initialRowsLimit, posts, tags, cover_type, post_types, layout } = attributes;
+  const { initialRowsLimit, posts, tags, cover_type, post_types, layout, readMoreText } = attributes;
 
   const rowLimitOptions = [
     { label: __('1 Row', 'planet4-blocks-backend'), value: 1 },
@@ -105,9 +105,9 @@ const renderView = (attributes, toAttribute) => {
     className,
     layout,
     isExample,
-    exampleCovers
+    exampleCovers,
+    readMoreText,
   } = attributes;
-
   const { covers, loading, row, amountOfCoversPerRow } = useCovers(attributes);
 
   const isCarouselLayout = layout === COVERS_LAYOUTS.carousel;
@@ -122,6 +122,7 @@ const renderView = (attributes, toAttribute) => {
     isCarouselLayout,
     amountOfCoversPerRow,
     isExample,
+    readMoreText,
   };
 
   const showLoadMoreButton = !isCarouselLayout && !!initialRowsLimit && covers.length > (amountOfCoversPerRow * row);
@@ -166,7 +167,7 @@ const renderView = (attributes, toAttribute) => {
               totalAmountOfCovers={covers.length}
             />
           }
-          {showLoadMoreButton && <CoversGridLoadMoreButton showMoreCovers={() => {}} />}
+          {showLoadMoreButton && <CoversGridLoadMoreButton showMoreCovers={() => {}} readMoreText={readMoreText} />}
         </div>
       }
     </section>

--- a/assets/src/blocks/Covers/CoversEditorScript.js
+++ b/assets/src/blocks/Covers/CoversEditorScript.js
@@ -74,7 +74,11 @@ const registerCoversBlock = () => {
       },
       exampleCovers: { // Used for the block's preview, which can't extract items from anything.
         type: 'object',
-      }
+      },
+      readMoreText: {
+        type: 'string',
+        default: __('Load more', 'planet4-blocks')
+      },
     },
     edit: CoversEditor,
     save: frontendRendered(BLOCK_NAME),

--- a/assets/src/blocks/Covers/CoversFrontend.js
+++ b/assets/src/blocks/Covers/CoversFrontend.js
@@ -6,7 +6,7 @@ import { CoversCarouselControls } from './CoversCarouselControls';
 import { CoversGridLoadMoreButton } from './CoversGridLoadMoreButton';
 
 export const CoversFrontend = attributes => {
-  const { initialRowsLimit, cover_type, title, description, covers, className, layout } = attributes;
+  const { initialRowsLimit, cover_type, title, description, covers, className, layout, readMoreText } = attributes;
   const coversContainerRef = useRef(null);
 
   const {
@@ -87,7 +87,7 @@ export const CoversFrontend = attributes => {
             totalAmountOfCovers={covers.length}
           />
         }
-        {showLoadMoreButton && <CoversGridLoadMoreButton showMoreCovers={showMoreCovers} />}
+        {showLoadMoreButton && <CoversGridLoadMoreButton showMoreCovers={showMoreCovers} readMoreText={readMoreText} />}
       </div>
     </section>
   );

--- a/assets/src/blocks/Covers/CoversGridLoadMoreButton.js
+++ b/assets/src/blocks/Covers/CoversGridLoadMoreButton.js
@@ -1,7 +1,7 @@
 const { __ } = wp.i18n;
 
-export const CoversGridLoadMoreButton = ({ showMoreCovers }) => (
+export const CoversGridLoadMoreButton = ({ showMoreCovers, readMoreText }) => (
   <button onClick={showMoreCovers} className='btn btn-block btn-secondary load-more-btn'>
-    {__('Load more', 'planet4-blocks')}
+    {readMoreText}
   </button>
 );

--- a/classes/blocks/class-covers.php
+++ b/classes/blocks/class-covers.php
@@ -91,6 +91,10 @@ class Covers extends Base_Block {
 						$attributes['cover_type'] = self::OLD_COVER_TYPES[ $old_cover_type ];
 					}
 
+					if ( empty( $attributes['readMoreText'] ) ) {
+						$attributes['readMoreText'] = __( 'Load more', 'planet4-blocks' );
+					}
+
 					$attributes['covers'] = self::get_covers( $attributes );
 
 					$json = wp_json_encode( [ 'attributes' => $attributes ] );
@@ -143,6 +147,9 @@ class Covers extends Base_Block {
 					'layout'           => [
 						'type'    => 'string',
 						'default' => self::GRID_LAYOUT,
+					],
+					'readMoreText'     => [
+						'type' => 'string',
 					],
 				],
 			]


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6748

Demo page: [Mena's dev instance](https://www-dev.greenpeace.org/mena/ar/10072/)

GPBR reported that the `Load more` text is not being translated [see here](https://www-dev.greenpeace.org/brasil/noticias-e-historias/). Thus, I checked it from [LOCO](https://planet4.greenpeace.org/wp-admin/admin.php?bundle=planet4-plugin-gutenberg-blocks%2Fplanet4-gutenberg-blocks.php&domain=planet4-blocks&path=plugins%2Fplanet4-plugin-gutenberg-blocks%2Flanguages%2Fplanet4-blocks-pt_BR.po&page=loco-plugin&action=file-edit) and effectively it was correctly translated. 

In consequence of that, I assumed that it was a Covers's block issue then I decided to replicate the same functionality of the Articles block which I've already known that it has been working fine.

Other NROs with the same issue:
- Luxembourg (French) [Site page](https://www.greenpeace.org/luxembourg/fr/actualites/14176/petrole-gaz-et-charbon-les-carburants-de-la-guerre/) [LOCO](https://planet4.greenpeace.org/wp-admin/admin.php?path=plugins%2Fplanet4-plugin-gutenberg-blocks%2Flanguages%2Fplanet4-blocks-fr_FR.po&bundle=planet4-plugin-gutenberg-blocks%2Fplanet4-gutenberg-blocks.php&domain=planet4-blocks&page=loco-plugin&action=file-edit)
- Argentina (Spanish) [Site page](https://www.greenpeace.org/argentina/blog/blog/colaboramos-para-hacer-frente-al-coronavirus-en-mar-del-plata/) [Loco](https://planet4.greenpeace.org/wp-admin/admin.php?path=plugins%2Fplanet4-plugin-gutenberg-blocks%2Flanguages%2Fplanet4-blocks-es_AR.po&bundle=planet4-plugin-gutenberg-blocks%2Fplanet4-gutenberg-blocks.php&domain=planet4-blocks&page=loco-plugin&action=file-edit)


![Screenshot 2022-04-28 at 10 27 24](https://user-images.githubusercontent.com/77975803/165763049-b2a4a428-5bc3-4ca2-b746-dfe5606761ea.png)

