### PR TITLE
Register new rounded style to core/image

### DIFF
--- a/admin/js/editor.js
+++ b/admin/js/editor.js
@@ -32,4 +32,11 @@ wp.domReady(() => {
   ];
 
   registerBlockStyle('core/button', styles);
+
+  ['core/image'].forEach(block => {
+    registerBlockStyle(block, {
+      name: 'rounded',
+      label: __('Rounded', 'planet4-blocks-backend'),
+    });
+  });
 });

--- a/assets/src/styles/blocks.scss
+++ b/assets/src/styles/blocks.scss
@@ -32,3 +32,7 @@
 // Other
 @import "blocks/WideBlocks";
 @import "blocks/Editor";
+
+.is-style-rounded {
+  border-radius: 50%;
+}


### PR DESCRIPTION
Register a new rounded style applied to the `core/image` block.

This feature will be required by the [Quick links pattern block](https://jira.greenpeace.org/browse/PLANET-6520), but it will also very useful to another patterns.

Demo page: https://www-dev.greenpeace.org/test-deimos/new-rounded-image-style/

