### PR TITLE
Add Rounded style to Image block

### DIFF
--- a/admin/js/editor.js
+++ b/admin/js/editor.js
@@ -3,10 +3,6 @@ const { unregisterBlockStyle, registerBlockStyle } = wp.blocks;
 const { __ } = wp.i18n;
 
 wp.domReady(() => {
-  // Remove Image block styles
-  unregisterBlockStyle('core/image', 'rounded');
-  unregisterBlockStyle('core/image', 'default');
-
   // Remove Take Action and Campaign covers styles for Covers block in campaigns
   const postType = wp.data.select('core/editor').getCurrentPostType();
   if (postType === 'campaign') {

--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -5,6 +5,13 @@
   margin-top: $sp-1;
   margin-bottom: $sp-2;
 
+  &.is-style-rounded {
+    figure,
+    img {
+      border-radius: 50%;
+    }
+  }
+
   &:not(.force-no-lightbox) img {
     cursor: pointer;
   }


### PR DESCRIPTION
### Description

This is needed for both the [Deep Dive ](https://jira.greenpeace.org/browse/PLANET-6534)and [Quick Links](https://jira.greenpeace.org/browse/PLANET-6520) block patterns.
This is actually a default WP styles that we had manually removed, but it also needs some small CSS tweaks to fit our designs.

### Testing

You can test the new rounded style on your local or on [this page](https://www-dev.greenpeace.org/test-tavros/image-blocks/) I created on the tavros instance.