### PR TITLE
Add chevron style to heading core block

### DIFF
--- a/admin/js/editor.js
+++ b/admin/js/editor.js
@@ -15,7 +15,7 @@ wp.domReady(() => {
   unregisterBlockStyle('core/button', 'outline');
 
   // Add our custom Button block styles
-  const styles = [
+  const buttonStyles = [
     {
       name: 'secondary',
       label: __('Secondary', 'planet4-blocks-backend'),
@@ -27,7 +27,7 @@ wp.domReady(() => {
     },
   ];
 
-  registerBlockStyle('core/button', styles);
+  registerBlockStyle('core/button', buttonStyles);
 
   ['core/media-text', 'core/group', 'core/column'].forEach(
     block => registerBlockStyle(block, [
@@ -62,4 +62,14 @@ wp.domReady(() => {
     name: 'mobile-carousel',
     label: __('Mobile carousel', 'planet4-blocks-backend'),
   });
+
+  // Add our custom Heading styles
+  const headingStyles = [
+    {
+      name: 'chevron',
+      label: __('Chevron', 'planet4-blocks-backend')
+    }
+  ];
+
+  registerBlockStyle('core/heading', headingStyles);
 });

--- a/assets/src/styles/blocks.scss
+++ b/assets/src/styles/blocks.scss
@@ -19,6 +19,7 @@
 @import "blocks/core-overrides/Table";
 @import "blocks/core-overrides/media-text";
 @import "blocks/core-overrides/columns";
+@import "blocks/core-overrides/Heading";
 
 // Other
 @import "blocks/WideBlocks";

--- a/assets/src/styles/blocks/core-overrides/Heading.scss
+++ b/assets/src/styles/blocks/core-overrides/Heading.scss
@@ -1,0 +1,18 @@
+.is-style-chevron::after {
+  content: "";
+  pointer-events: none;
+  margin-inline-start: $sp-1;
+  height: 12px;
+  width: 12px;
+  display: inline-block;
+  mask-image: url("../../public/images/icons/chevron.svg");
+  mask-repeat: no-repeat;
+  mask-size: contain;
+  background-repeat: no-repeat;
+  background-color: currentColor;
+  vertical-align: middle;
+
+  html[dir="rtl"] & {
+    transform: rotate(180deg);
+  }
+}

--- a/assets/src/styles/blocks/core-overrides/HeadingEditor.scss
+++ b/assets/src/styles/blocks/core-overrides/HeadingEditor.scss
@@ -1,0 +1,3 @@
+.is-style-chevron::after {
+  position: relative !important;
+}

--- a/assets/src/styles/editorStyle.scss
+++ b/assets/src/styles/editorStyle.scss
@@ -14,6 +14,7 @@
 @import "blocks/ENForm/ENFormEditorStyle";
 @import "blocks/TakeActionBoxout/edit";
 @import "blocks/CookiesEditor";
+@import "blocks/core-overrides/HeadingEditor";
 
 @import "components/LayoutSelector";
 @import "components/EmptyMessage";


### PR DESCRIPTION
### Description

This is needed for the [deep dive block pattern](https://www.figma.com/file/2VVSBXQZrPoV3hNiMNGXB6/P4-Blocks_Master?node-id=1721%3A7823)

### Testing

You can test the new style on this [page](https://www-dev.greenpeace.org/test-deimos/headings-with-chevrons/) with all possible heading sizes. The "extreme" ones (h1, h6) look a bit strange with this size of chevron, but I'm not sure it's worth defining a chevron size per heading level: h2/h3 are probably the most used, and anyway for any heading level editors can manually change the font size... I'm still discussing this with Mag!