### PR TITLE
Fix undefined mediaId value in core/media-text block when the media is not set

### DIFF
--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -464,7 +464,7 @@ add_filter(
 			$block_content = preg_replace( '/sizes=".*"/', $sizes_attr, $block_content );
 		}
 
-		if ( 'core/media-text' === $block['blockName'] && $instance->attributes['mediaId'] ) {
+		if ( 'core/media-text' === $block['blockName'] && array_key_exists( 'mediaId', $instance->attributes ) ) {
 			$media_id    = $instance->attributes['mediaId'];
 			$media_width = $instance->attributes['mediaWidth'] ?? 50;
 


### PR DESCRIPTION
I got an error when I want to save a media text without setting a media.

> Notice: Undefined index: mediaId in /app/source/public/wp-content/plugins/planet4-plugin-gutenberg-blocks/planet4-gutenberg-blocks.php on line 467

This fix check if the field has been defined previously and prevent to don't execute [this logic](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/planet4-gutenberg-blocks.php#L467-L507) if `mediaId` is `undefined`.
