### PR TITLE
PLANET-6704: Insert placeholder images to patterns

### DIFF
--- a/classes/patterns/class-highlightedcta.php
+++ b/classes/patterns/class-highlightedcta.php
@@ -37,7 +37,7 @@ class HighlightedCta extends Block_Pattern {
 								<!-- wp:image {"align":"center","className":"force-no-lightbox"} -->
 									<div class="wp-block-image force-no-lightbox">
 										<figure class="aligncenter">
-											<img alt=""/>
+											<img src="' . esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-80x80.jpg" alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '"/>
 										</figure>
 									</div>
 								<!-- /wp:image -->

--- a/classes/patterns/class-issues.php
+++ b/classes/patterns/class-issues.php
@@ -27,11 +27,11 @@ class Issues extends Block_Pattern {
 	 * Returns the template for one media-text.
 	 */
 	public static function get_media_text_template(): string {
-
+		$media_link = esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-40x40.jpg';
 		return '
-			<!-- wp:media-text {"mediaWidth":15,"mediaSizeSlug":"thumbnail","isStackedOnMobile":false,"verticalAlignment":"center","imageFill":false,"backgroundColor":"white","className":"is-style-large-padding"} -->
+			<!-- wp:media-text {"mediaWidth":15,"mediaLink":"' . $media_link . '","mediaType":"image","mediaSizeSlug":"thumbnail","isStackedOnMobile":false,"verticalAlignment":"center","imageFill":false,"backgroundColor":"white","className":"is-style-large-padding"} -->
 			<div class="wp-block-media-text alignwide is-vertically-aligned-center has-white-background-color is-style-large-padding has-background" style="grid-template-columns:15% auto">
-			<figure class="wp-block-media-text__media"></figure>
+			<figure class="wp-block-media-text__media"><img src="' . $media_link . '" alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '"/></figure>
 			<div class="wp-block-media-text__content">
 			<!-- wp:paragraph {"align":"left","placeholder":"' . __( 'Enter text', 'planet4-blocks-backend' ) . '","style":{"typography":{"fontSize":"1rem","fontStyle":"normal","fontWeight":"700"}},"className":"is-style-roboto-font-family"} -->
 			<p class="has-text-align-left is-style-roboto-font-family" style="font-size:1rem;font-style:normal;font-weight:700"></p>

--- a/classes/patterns/class-realitycheck.php
+++ b/classes/patterns/class-realitycheck.php
@@ -32,7 +32,7 @@ class RealityCheck extends Block_Pattern {
 					<!-- wp:image {"align":"center","className":"mb-0 force-no-lightbox"} -->
 						<div class="wp-block-image mb-0 force-no-lightbox">
 							<figure class="aligncenter">
-								<img alt="" />
+								<img src="' . esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-75x75.jpg" alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '"/>
 							</figure>
 						</div>
 					<!-- /wp:image -->

--- a/classes/patterns/class-sideimagewithtextandcta.php
+++ b/classes/patterns/class-sideimagewithtextandcta.php
@@ -26,13 +26,16 @@ class SideImageWithTextAndCta extends Block_Pattern {
 	 * Returns the pattern config.
 	 */
 	public static function get_config(): array {
+		$media_link = esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-546x415.jpg';
 		return [
 			'title'      => __( 'Side image with text and CTA', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],
 			'content'    => '
-				<!-- wp:media-text {"className":"block"} -->
+				<!-- wp:media-text {"mediaLink":"' . $media_link . '","mediaType":"image","className":"block"} -->
 					<div class="wp-block-media-text alignwide is-stacked-on-mobile block">
-						<figure class="wp-block-media-text__media"></figure>
+						<figure class="wp-block-media-text__media">
+							<img src="' . $media_link . '" alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '"/>
+						</figure>
 						<div class="wp-block-media-text__content">
 							<!-- wp:heading {"placeholder":"' . __( 'Enter title', 'planet4-blocks-backend' ) . '"} -->
 								<h2></h2>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6704

Insert placeholder images to these block patterns:
- Issues
- Highlighted CTA
- Reality check
- Side image with text and CTA 

**Demo page** _keep in mind that placeholders are wouldn't available till we merge [#1708](https://github.com/greenpeace/planet4-master-theme/pull/1708)_
https://www-dev.greenpeace.org/test-leda/block-patterns-with-placeholder-images/


Blocked by these PRs:
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/846
- https://github.com/greenpeace/planet4-master-theme/pull/1708