### PR TITLE
PLANET-6712 Add transparent style to core Button block

### DIFF
--- a/admin/js/editor.js
+++ b/admin/js/editor.js
@@ -25,6 +25,10 @@ wp.domReady(() => {
       name: 'cta',
       label: __('Primary', 'planet4-blocks-backend')
     },
+    {
+      name: 'transparent',
+      label: __('Transparent', 'planet4-blocks-backend')
+    }
   ];
 
   registerBlockStyle('core/button', buttonStyles);

--- a/classes/patterns/class-highlightedcta.php
+++ b/classes/patterns/class-highlightedcta.php
@@ -49,7 +49,7 @@ class HighlightedCta extends Block_Pattern {
 								<!-- /wp:spacer -->
 								<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 									<div class="wp-block-buttons">
-										<!-- wp:button {"className":"transparent-button"} /-->
+										<!-- wp:button {"className":"is-style-transparent"} /-->
 									</div>
 								<!-- /wp:buttons -->
 								<!-- wp:spacer {"height":"16px"} -->


### PR DESCRIPTION
### Description

See [PLANET-6712](https://jira.greenpeace.org/browse/PLANET-6712)
This is needed for some block patterns, for now only the Highlighted CTA

**Related PR**: https://github.com/greenpeace/planet4-master-theme/pull/1714

### Testing

You can test both the Highlighted CTA pattern and regular buttons on this [page](https://www-dev.greenpeace.org/test-titan/transparent-buttons/) I made for UAT, with several background colors from our palette.