### PR TITLE
PLANET-6700: Fix broken arrows for Gallery and Cover blocks

### DIFF
--- a/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
+++ b/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
@@ -545,7 +545,7 @@ $medium-image-height: 600px;
   }
 }
 
-.carousel-control-prev-icon {
+.carousel-header .carousel-control-prev-icon {
   text-align: center;
   width: 28px;
   height: 46px;
@@ -590,7 +590,7 @@ $medium-image-height: 600px;
   }
 }
 
-.carousel-control-next-icon {
+.carousel-header .carousel-control-next-icon {
   text-align: center;
   width: 28px;
   height: 46px;

--- a/assets/src/styles/blocks/Covers/layouts/CoversCarouselLayout.scss
+++ b/assets/src/styles/blocks/Covers/layouts/CoversCarouselLayout.scss
@@ -47,6 +47,7 @@
 
     &:not(:disabled):hover {
       background: $grey-10;
+      padding-inline-start: 0;
     }
 
     @include large-and-up {

--- a/assets/src/styles/blocks/Gallery/styles/GalleryCarousel.scss
+++ b/assets/src/styles/blocks/Gallery/styles/GalleryCarousel.scss
@@ -170,6 +170,7 @@
 
     &:hover {
       background: $grey-10;
+      padding-inline-start: 0;
     }
 
     @include medium-and-up {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6700
Ref: https://jira.greenpeace.org/browse/PLANET-6719

Gallery carousel and Take action cover carousel are inheriting their style from the Carousel header.
Its icons declaration are interfering between blocks.
The conflict only shows when related css files are all included, which happens in the editor, on preview, and when these blocks are all on the same page

- Add more specific selectors to fix the multiple arrows issue
- Add specific padding to avoid a movement of the _next_ icon on `:hover`

## Test

Test page on Sinope https://www-dev.greenpeace.org/test-sinope/planet-6700/

Locally
- Create a new page
- Add a Carousel header, a Gallery, a Cover with take action covers and carousel layout
- Check that each arrow works properly
  - no multiple icons displayed at the same place
  - no unexpected icon movement on hover