### PR TITLE
PLANET-6686: Fix Split two columns issue/tag types

### DIFF
--- a/assets/src/blocks/Splittwocolumns/SplittwocolumnsSettings.js
+++ b/assets/src/blocks/Splittwocolumns/SplittwocolumnsSettings.js
@@ -47,10 +47,10 @@ export const SplittwocolumnsSettings = ({attributes, charLimit, setAttributes}) 
   }, []);
 
   const onIssueChange = (issue_id) => {
-    const issue = issuesList.find(issue => issue.id === issue_id) || null;
+    const issue = issuesList.find(issue => issue.id === parseInt(issue_id)) || null;
 
     setAttributes({
-      select_issue: issue_id,
+      select_issue: parseInt(issue_id),
       title: edited.title ? title : cleanString(
           issue?.cmb2?.p4_metabox.p4_title || issue?.title.raw || title,
           charLimit.title
@@ -67,10 +67,10 @@ export const SplittwocolumnsSettings = ({attributes, charLimit, setAttributes}) 
   }
 
   const onTagChange = (tag_id) => {
-    const tag = tagsList.find(tag => tag.id === tag_id);
+    const tag = tagsList.find(tag => tag.id === parseInt(tag_id));
 
     setAttributes({
-      select_tag: tag_id,
+      select_tag: parseInt(tag_id),
       tag_name: cleanString(tag?.name || '', charLimit.title),
       tag_description: edited.tag_description ? tag_description : cleanString(
           tag?.description || tag_description,
@@ -220,7 +220,7 @@ const convertFocalStringToObj = (focal_str) => {
   }
   const [x, y] = focal_str.replace(/%/g, '').split(' ');
 
-  return {x: (parseInt(x)/100), y: (parseInt(y)/100)};
+  return {x: ((parseInt(x) || 0)/100), y: ((parseInt(y) || 0)/100)};
 }
 
 /**

--- a/assets/src/styles/blocks/SplitTwoColumns.scss
+++ b/assets/src/styles/blocks/SplitTwoColumns.scss
@@ -166,6 +166,10 @@
     mask-size: contain;
     background-repeat: no-repeat;
     background-color: currentColor;
+
+    html[dir="rtl"] & {
+      rotate: 180deg;
+    }
   }
 }
 

--- a/assets/src/styles/blocks/SplitTwoColumnsEditor.scss
+++ b/assets/src/styles/blocks/SplitTwoColumnsEditor.scss
@@ -3,7 +3,7 @@
   padding: 10px 10px;
 }
 
-.block-editor a:not([href]).split-two-column-item-link {
+.block-editor a:not([href]).split-two-column-item-tag {
   text-decoration: none;
   color: $yellow;
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6686

> Reproduce steps:
> - Edit the page. Block requires recovery.
> - Attempt recovering and update the page. It works fine, but issue and tag are missing.
> - Select issue for the left column and tag for the right one. And update the page.
> - Refresh the editor.
> - Block requires recovery again.


Tag and issue ids are declared as numbers, but the select component returns a string
Casting those as int fixes recovery and selectors issues

## Test

- Add a SplitTwoColumns block in a new page
- Select an issue and a tag
  - Image and text should appear in the block
- Save and reload the editor
  - the block should appear without recovery needed
  - issue and tag are selected in the block settings