### PR TITLE
PLANET-6699: Remove purple visited state from Split Two Columns links

### DIFF
--- a/assets/src/styles/blocks/SplitTwoColumns.scss
+++ b/assets/src/styles/blocks/SplitTwoColumns.scss
@@ -100,6 +100,10 @@
     text-shadow: 1px 1px 3px $grey-80;
   }
 
+  &:visited {
+    color: $yellow;
+  }
+
   @include medium-and-up {
     font-size: 1.5rem;
     margin-bottom: 15px;
@@ -152,6 +156,10 @@
 
   &:hover {
     text-decoration: underline;
+  }
+
+  &:visited {
+    color: var(--link--color, $link-color);
   }
 
   &:after {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6699

> Remove purple visited state from Split Two Columns links

Set visited colors as non-visited colors for issue link and tag link

## Test

Check a _Split two columns_ block on the frontend
- Toggle the `:visited` state for the blue issue link and yellow tag link
- Color should not change
