### PR TITLE
PLANET-6720: Fix all-posts rest call with wpml

### DIFF
--- a/classes/rest/class-rest-api.php
+++ b/classes/rest/class-rest-api.php
@@ -52,19 +52,13 @@ class Rest_Api {
 						global $wpdb;
 
 						if ( is_plugin_active( 'sitepress-multilingual-cms/sitepress.php' ) ) {
-							// This is public data, no nonce needed.
-							// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-							if ( ! isset( $_GET['post_language'] ) ) {
-								return new \WP_REST_Response(
-									'WPML is active so you need to query posts with the `post_language` query parameter.',
-									400
-								);
-							}
-							// This is public data, no nonce needed.
-							// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-							$query = self::get_wpml_posts_query( $_GET['post_language'] );
+							$lang  = apply_filters( 'wpml_current_language', null );
+							$query = self::get_wpml_posts_query( $lang );
 						} else {
-							$query = "SELECT id, post_title FROM wp_posts WHERE post_status = 'publish' AND post_type = 'post' ORDER BY post_date DESC";
+							$query = "SELECT id, post_title
+								FROM wp_posts
+								WHERE post_status = 'publish' AND post_type = 'post'
+								ORDER BY post_date DESC";
 						}
 						// The query is prepared, just not in this line.
 						// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6720

> The "override" function on the articles block doesn't seem to load anything. It can't find any blogs.
> This seems not to affect other sites. The API request returns 400.

Our endpoint required a `post_language` parameter for queries on wpml enabled site.
Current post language can safely be determined by a backend side function call

## Test

Locally, install a Belgium instance:
- **Stop** your current instance with `make stop`
- Clone in a **new directory** and install
```shell
> git clone git@github.com:greenpeace/planet4-docker-compose.git pdc-6720 
> cd pdc-6720
> NRO_NAME=belgium NRO_DB_VERSION=latest make nro-from-release
```

To verify this fix:
- Check this branch
```shell
> (cd persistence/app/public/wp-content/plugins/planet4-plugin-gutenberg-blocks && git fetch origin && git reset --hard origin/$(git branch --show-current) && git pull && git checkout fix/allposts-rest-call-6720)
```
- Add an _Articles block_ in a new page
- Check the network calls to `/wp-json/planet4/v1/all-published-posts?`, it shouldn't respond an error 400
- Use the _Manual override_ field, it shows a list of titles