### PR TITLE
Add Grey 5% to our color palette

### DIFF
--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -594,6 +594,11 @@ DEFERREDCSS;
 					'color' => '#e5e5e5',
 				],
 				[
+					'name'  => __( 'Grey 5%', 'planet4-blocks-backend' ),
+					'slug'  => 'grey-05',
+					'color' => '#f5f7f8',
+				],
+				[
 					'name'  => __( 'Grey', 'planet4-blocks-backend' ),
 					'slug'  => 'grey',
 					'color' => '#333333',


### PR DESCRIPTION
### Description

This is needed for some block patterns, for their background color, for example the [Deep Dive](https://jira.greenpeace.org/browse/PLANET-6534) or the [Quick Links](https://jira.greenpeace.org/browse/PLANET-6520).

**Related PR:** https://github.com/greenpeace/planet4-master-theme/pull/1718

### Testing

You can see the new color used in both text color and background color on [this page](https://www-dev.greenpeace.org/test-iocaste/new-grey-5-color/) for example!