### PR TITLE
PLANET-6638 Update Issues block pattern background color

### DIFF
--- a/classes/patterns/class-issues.php
+++ b/classes/patterns/class-issues.php
@@ -48,8 +48,8 @@ class Issues extends Block_Pattern {
 			'title'      => __( 'Issues', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],
 			'content'    => '
-				<!-- wp:group {"align":"full","backgroundColor":"grey-10"} -->
-				<div class="wp-block-group alignfull has-grey-10-background-color has-background">
+				<!-- wp:group {"align":"full","backgroundColor":"grey-05"} -->
+				<div class="wp-block-group alignfull has-grey-05-background-color has-background">
 
 					<!-- wp:group {"className":"container"} -->
 					<div class="wp-block-group container">


### PR DESCRIPTION
### Description

See [PLANET-6638](https://jira.greenpeace.org/browse/PLANET-6638)
It should be `grey-05` instead of `grey-10`, it was just added to our palette!
