### PR TITLE
Force rounded images to have an aspect ratio of 1

### DIFF
--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -10,6 +10,11 @@
     img {
       border-radius: 50%;
     }
+
+    img {
+      object-fit: cover;
+      aspect-ratio: 1;
+    }
   }
 
   &:not(.force-no-lightbox) img {


### PR DESCRIPTION
### Description

This is needed for the [Quick Links](https://jira.greenpeace.org/browse/PLANET-6520) and [Deep Dive](https://jira.greenpeace.org/browse/PLANET-6534) block patterns.
Otherwise images look oval instead of rounded like we want, even when fixing the width/height in the backend, because we set the img elements' height to `auto` in several places.
Another option would be to remove the `auto` height for all images, but I think this was added for large images that might be cropped in width in smaller screens and would then look really bad with their original height 😬 

**Note:** this CSS property is still experimental, however [it seems to be supported](https://caniuse.com/?search=aspect-ratio) by most browsers' latest versions!

### Testing

You can compare the broken version [here](https://www-dev.greenpeace.org/test-titan/rounded-images/) with the fixed one [here](https://www-dev.greenpeace.org/test-pluto/rounded-images/)!