### PR TITLE
PLANET-6680: Page Header block pattern

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -88,6 +88,6 @@
     "no-invalid-double-slash-comments": true,
     "no-missing-end-of-source-newline": true,
     "max-empty-lines": 1,
-    "property-no-vendor-prefix": true
+    "property-no-vendor-prefix": [true, {"ignoreProperties": ["box-orient","line-clamp"]}]
   }
 }

--- a/assets/src/blocks/PageHeader/PageHeaderBlock.js
+++ b/assets/src/blocks/PageHeader/PageHeaderBlock.js
@@ -1,0 +1,67 @@
+const { registerBlockVariation } = wp.blocks;
+const { __ } = wp.i18n;
+
+export const registerPageHeaderBlock = () => {
+
+  const POS_LEFT = 'left';
+  const POS_RIGHT = 'right';
+  let opposite = (pos) => pos === POS_LEFT ? POS_RIGHT : POS_LEFT;
+  let classname = 'is-pattern-p4_page-header';
+
+  let scope = ['inserter'];
+
+  let attributes = {
+      className: classname,
+      mediaType: 'image',
+      mediaUrl: `${window.p4bk_vars.themeUrl}/images/placeholders/placeholder-546x415.jpg`,
+      imageFill: false,
+      align:'full'
+  };
+
+  let innerBlocks = (imgPosition) => [
+    ['core/group', {}, [
+      ['core/heading', {
+        level: 1,
+        backgroundColor: 'white',
+        //textAlign: opposite(imgPosition),
+        placeholder: __('Enter title', 'planet4-blocks-backend')
+      }]
+    ]],
+    ['core/paragraph', {
+      //align: opposite(imgPosition),
+      placeholder: __('Enter description', 'planet4-blocks-backend'),
+      style: { typography: { fontSize: '1.25rem'} }
+    }],
+    ['core/buttons', {
+      //layout: { type:"flex", justifyContent: opposite(imgPosition) }
+    }, [
+      ['core/button', {className: 'is-style-cta'}]
+    ]],
+  ];
+
+  registerBlockVariation('core/media-text', {
+    name: 'page-header-img-right',
+    title: __('Page header with image on the right', 'planet4-blocks-backend'),
+    description: __('Page header with image on the right', 'planet4-blocks-backend'),
+    scope: scope,
+    attributes: { mediaPosition: POS_RIGHT, ...attributes },
+    innerBlocks: innerBlocks(POS_RIGHT),
+    isActive: (blockAttributes) => {
+      return blockAttributes.className === classname
+        && blockAttributes.mediaPosition === POS_RIGHT;
+    }
+  });
+
+  registerBlockVariation('core/media-text', {
+    name: 'page-header-img-left',
+    title: __('Page header with image on the left', 'planet4-blocks-backend'),
+    description: __('Page header with image on the left', 'planet4-blocks-backend'),
+    scope: scope,
+    attributes: { mediaPosition: POS_LEFT, ...attributes },
+    innerBlocks: innerBlocks(POS_LEFT),
+    isActive: (blockAttributes) => {
+      return blockAttributes.className === classname
+        && blockAttributes.mediaPosition === POS_LEFT;
+    }
+  });
+}

--- a/assets/src/blocks/PageHeader/PageHeaderBlock.js
+++ b/assets/src/blocks/PageHeader/PageHeaderBlock.js
@@ -3,10 +3,7 @@ const { __ } = wp.i18n;
 
 export const registerPageHeaderBlock = () => {
 
-  const POS_LEFT = 'left';
-  const POS_RIGHT = 'right';
-  let opposite = (pos) => pos === POS_LEFT ? POS_RIGHT : POS_LEFT;
-  let classname = 'is-pattern-p4_page-header';
+  let classname = 'is-pattern-p4-page-header';
 
   let scope = ['inserter'];
 
@@ -23,45 +20,30 @@ export const registerPageHeaderBlock = () => {
       ['core/heading', {
         level: 1,
         backgroundColor: 'white',
-        //textAlign: opposite(imgPosition),
         placeholder: __('Enter title', 'planet4-blocks-backend')
       }]
     ]],
     ['core/paragraph', {
-      //align: opposite(imgPosition),
       placeholder: __('Enter description', 'planet4-blocks-backend'),
       style: { typography: { fontSize: '1.25rem'} }
     }],
-    ['core/buttons', {
-      //layout: { type:"flex", justifyContent: opposite(imgPosition) }
-    }, [
+    ['core/buttons', {}, [
       ['core/button', {className: 'is-style-cta'}]
     ]],
   ];
 
-  registerBlockVariation('core/media-text', {
-    name: 'page-header-img-right',
-    title: __('Page header with image on the right', 'planet4-blocks-backend'),
-    description: __('Page header with image on the right', 'planet4-blocks-backend'),
-    scope: scope,
-    attributes: { mediaPosition: POS_RIGHT, ...attributes },
-    innerBlocks: innerBlocks(POS_RIGHT),
-    isActive: (blockAttributes) => {
-      return blockAttributes.className === classname
-        && blockAttributes.mediaPosition === POS_RIGHT;
-    }
-  });
-
-  registerBlockVariation('core/media-text', {
-    name: 'page-header-img-left',
-    title: __('Page header with image on the left', 'planet4-blocks-backend'),
-    description: __('Page header with image on the left', 'planet4-blocks-backend'),
-    scope: scope,
-    attributes: { mediaPosition: POS_LEFT, ...attributes },
-    innerBlocks: innerBlocks(POS_LEFT),
-    isActive: (blockAttributes) => {
-      return blockAttributes.className === classname
-        && blockAttributes.mediaPosition === POS_LEFT;
-    }
+  [ 'left' , 'right' ].forEach((variation) => {
+    registerBlockVariation('core/media-text', {
+      name: `page-header-img-${variation}`,
+      title: __(`Page header with image on the ${variation}`, 'planet4-blocks-backend'),
+      description: __(`Page header with image on the ${variation}`, 'planet4-blocks-backend'),
+      scope,
+      attributes: { mediaPosition: variation, ...attributes },
+      innerBlocks: innerBlocks(variation),
+      isActive: (blockAttributes) => (
+        blockAttributes.className === classname
+        && blockAttributes.mediaPosition === variation
+      )
+    });
   });
 }

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -21,6 +21,7 @@ import { SubPagesBlock } from './blocks/SubPages/SubPagesBlock';
 import { blockEditorValidation } from './BlockEditorValidation';
 import { registerGuestBookBlock } from './blocks/GuestBook/GuestBookBlock';
 import { registerBlock as registerShareButtonsBlock } from './blocks/ShareButtons/ShareButtonsBlock';
+import { registerPageHeaderBlock } from './blocks/PageHeader/PageHeaderBlock';
 
 blockEditorValidation();
 new ArticlesBlock();
@@ -39,6 +40,7 @@ registerTakeActionBoxoutBlock();
 registerTimelineBlock();
 registerGuestBookBlock();
 registerShareButtonsBlock();
+registerPageHeaderBlock();
 
 addBlockFilters();
 setupImageBlockExtension();

--- a/assets/src/styles/blocks.scss
+++ b/assets/src/styles/blocks.scss
@@ -23,6 +23,8 @@
 
 // Other
 @import "blocks/WideBlocks";
+// Patterns
+@import "blocks/PageHeader";
 
 .is-style-small-padding {
   padding: 8px;

--- a/assets/src/styles/blocks/PageHeader.scss
+++ b/assets/src/styles/blocks/PageHeader.scss
@@ -1,0 +1,137 @@
+.wp-block-media-text.is-pattern-p4_page-header {
+  grid-template-columns: 100%;
+  min-width: 360px;
+  padding: 0;
+  width: 100vw;
+
+  .wp-block-media-text__media {
+    grid-column: 1;
+    grid-row: 1;
+
+    img {
+      max-height: 270px;
+      object-fit: cover;
+    }
+  }
+
+  .wp-block-media-text__content {
+    grid-column: 1;
+    grid-row: 2;
+
+    min-width: 312px;
+    margin: -44px 24px 24px 24px;
+  }
+
+  h1.has-background {
+    display: inline;
+    font-size: 2.5rem;
+    font-weight: 700;
+    line-height: initial;
+    padding: 0;
+    white-space: pre-wrap;
+  }
+
+  p {
+    padding-bottom: $sp-2;
+    padding-top: $sp-2;
+  }
+
+  @include medium-and-up {
+    .wp-block-media-text__media img {
+      max-height: 432px;
+    }
+
+    .wp-block-media-text__content {
+      margin: -44px 44px 0 44px;
+    }
+
+    .wp-block-group:first-child {
+      width: 520px;
+    }
+  }
+
+  @include large-and-up {
+    width: calc(100% + (100vw - 100%) / 2);
+
+    .wp-block-media-text__media img {
+      max-height: 576px;
+    }
+
+    .wp-block-media-text__content {
+      display: grid;
+      margin: 0;
+      padding: 0;
+
+      > *:nth-child(n+2) {
+        max-width: calc(350px - 24px);
+      }
+    }
+
+    .wp-block-group:first-child {
+      display: block;
+      max-width: 660px;
+      width: 660px;
+      position: relative;
+    }
+
+    h1.has-background {
+      display: inline;
+      font-size: 3.5rem;
+      font-weight: 800;
+    }
+  }
+}
+
+.wp-block-media-text.is-pattern-p4_page-header.has-media-on-the-right {
+  @include large-and-up {
+    grid-template-columns: 350px auto;
+    margin-left: 0;
+
+    .wp-block-media-text__media {
+      grid-column: 2;
+      grid-row: 1;
+    }
+
+    .wp-block-media-text__content {
+      grid-column: 1;
+      grid-row: 1;
+      padding-inline-end: 24px;
+
+      & > * {
+        justify-content: start;
+        text-align: left;
+      }
+    }
+  }
+}
+
+.wp-block-media-text.is-pattern-p4_page-header:not(.has-media-on-the-right) {
+  @include large-and-up {
+    grid-template-columns: auto 350px;
+
+    h1.has-background {
+      white-space: unset;
+    }
+
+    .wp-block-group:first-child {
+      left: -334px;
+      text-align: right;
+    }
+
+    .wp-block-media-text__media {
+      grid-column: 1;
+      grid-row: 1;
+    }
+
+    .wp-block-media-text__content {
+      grid-column: 2;
+      grid-row: 1;
+      padding-inline-start: 24px;
+
+      & > * {
+        justify-content: end;
+        text-align: right;
+      }
+    }
+  }
+}

--- a/assets/src/styles/blocks/PageHeader.scss
+++ b/assets/src/styles/blocks/PageHeader.scss
@@ -1,4 +1,10 @@
-.wp-block-media-text.is-pattern-p4_page-header {
+$title-width-l: 660px;
+$text-column-width-l: 320px;
+$text-column-width-xl: 380px;
+$text-column-width-xxl: 440px;
+$text-column-padding-in: 24px;
+
+.wp-block-media-text.alignfull.is-pattern-p4-page-header {
   grid-template-columns: 100%;
   min-width: 360px;
   padding: 0;
@@ -19,20 +25,38 @@
     grid-row: 2;
 
     min-width: 312px;
-    margin: -44px 24px 24px 24px;
+    margin: -$sp-5x $sp-3 $sp-3;
+    padding-inline-start: 0;
+    padding-inline-end: 0;
+  }
+
+  .wp-block-group:first-child {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
+    font-size: $font-size-xxl;
+    font-weight: 700;
+    line-height: initial;
   }
 
   h1.has-background {
     display: inline;
-    font-size: 2.5rem;
-    font-weight: 700;
-    line-height: initial;
     padding: 0;
-    white-space: pre-wrap;
+    font-size: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+
+    box-decoration-break: clone;
+    box-shadow: 8px 0 0 var(--transparent-button--active--color, #fff), calc(8px * -1) 0 0 var(--transparent-button--active--color, #fff);
   }
 
   p {
-    padding-bottom: $sp-2;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 5;
+    overflow: hidden;
+    margin-bottom: $sp-4;
     padding-top: $sp-2;
   }
 
@@ -42,7 +66,9 @@
     }
 
     .wp-block-media-text__content {
-      margin: -44px 44px 0 44px;
+      margin: -$sp-5x $sp-5x 0;
+      padding-inline-start: 0;
+      padding-inline-end: 0;
     }
 
     .wp-block-group:first-child {
@@ -63,28 +89,44 @@
       padding: 0;
 
       > *:nth-child(n+2) {
-        max-width: calc(350px - 24px);
+        max-width: calc(#{$text-column-width-l} - #{$text-column-padding-in});
       }
     }
 
     .wp-block-group:first-child {
-      display: block;
-      max-width: 660px;
-      width: 660px;
+      max-width: $title-width-l;
+      width: $title-width-l;
       position: relative;
-    }
-
-    h1.has-background {
-      display: inline;
       font-size: 3.5rem;
       font-weight: 800;
+      line-height: 4rem;
+    }
+  }
+
+  @include x-large-and-up {
+    .wp-block-media-text__content {
+      > *:nth-child(n+2) {
+        max-width: calc(#{$text-column-width-xl} - #{$text-column-padding-in});
+      }
+    }
+
+    p:first-of-type {
+      padding-top: $sp-3;
+    }
+  }
+
+  @include xx-large-and-up {
+    .wp-block-media-text__content {
+      > *:nth-child(n+2) {
+        max-width: calc(#{$text-column-width-xxl} - #{$text-column-padding-in});
+      }
     }
   }
 }
 
-.wp-block-media-text.is-pattern-p4_page-header.has-media-on-the-right {
+.wp-block-media-text.alignfull.is-pattern-p4-page-header.has-media-on-the-right {
   @include large-and-up {
-    grid-template-columns: 350px auto;
+    grid-template-columns: $text-column-width-l auto;
     margin-left: 0;
 
     .wp-block-media-text__media {
@@ -95,27 +137,57 @@
     .wp-block-media-text__content {
       grid-column: 1;
       grid-row: 1;
-      padding-inline-end: 24px;
+      padding-right: $sp-3;
 
       & > * {
-        justify-content: start;
+        justify-content: left;
         text-align: left;
+      }
+    }
+
+    .wp-block-group:first-child {
+      html[dir="rtl"] & {
+        left: calc(#{$title-width-l} - #{$text-column-width-l} + #{$text-column-padding-in});
+      }
+    }
+  }
+
+  @include x-large-and-up {
+    grid-template-columns: $text-column-width-xl auto;
+
+    .wp-block-group:first-child {
+      html[dir="rtl"] & {
+        left: calc(#{$title-width-l} - #{$text-column-width-xl} + #{$text-column-padding-in});
+      }
+    }
+  }
+
+  @include xx-large-and-up {
+    grid-template-columns: $text-column-width-xxl auto;
+
+    .wp-block-group:first-child {
+      html[dir="rtl"] & {
+        left: calc(#{$title-width-l} - #{$text-column-width-xxl} + #{$text-column-padding-in});
       }
     }
   }
 }
 
-.wp-block-media-text.is-pattern-p4_page-header:not(.has-media-on-the-right) {
+.wp-block-media-text.alignfull.is-pattern-p4-page-header:not(.has-media-on-the-right) {
   @include large-and-up {
-    grid-template-columns: auto 350px;
+    grid-template-columns: auto $text-column-width-l;
 
-    h1.has-background {
-      white-space: unset;
+    html[dir="rtl"] & {
+      margin-right: unset;
     }
 
     .wp-block-group:first-child {
-      left: -334px;
+      left: calc(-1 * (#{$title-width-l} - #{$text-column-width-l} + #{$text-column-padding-in}));
       text-align: right;
+
+      html[dir="rtl"] & {
+        left: 0;
+      }
     }
 
     .wp-block-media-text__media {
@@ -126,12 +198,28 @@
     .wp-block-media-text__content {
       grid-column: 2;
       grid-row: 1;
-      padding-inline-start: 24px;
+      padding-left: $sp-3;
 
       & > * {
-        justify-content: end;
+        justify-content: right;
         text-align: right;
       }
+    }
+  }
+
+  @include x-large-and-up {
+    grid-template-columns: auto $text-column-width-xl;
+
+    .wp-block-group:first-child {
+      left: calc(-1 * (#{$title-width-l} - #{$text-column-width-xl} + #{$text-column-padding-in}));
+    }
+  }
+
+  @include xx-large-and-up {
+    grid-template-columns: auto $text-column-width-xxl;
+
+    .wp-block-group:first-child {
+      left: calc(-1 * (#{$title-width-l} - #{$text-column-width-xxl} + #{$text-column-padding-in}));
     }
   }
 }

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -97,6 +97,10 @@ final class Loader {
 			'planet4',
 			[ 'label' => __( 'Planet 4', 'planet4-blocks-backend' ) ],
 		);
+		register_block_pattern_category(
+			'page-headers',
+			[ 'label' => __( 'Page Headers', 'planet4-blocks-backend' ) ],
+		);
 
 		register_block_pattern_category(
 			'layouts',

--- a/classes/patterns/class-block-pattern.php
+++ b/classes/patterns/class-block-pattern.php
@@ -45,6 +45,8 @@ abstract class Block_Pattern {
 			GetInformed::class,
 			HighlightedCta::class,
 			Issues::class,
+			PageHeader::class,
+			PageHeaderImgLeft::class,
 			QuickLinks::class,
 			RealityCheck::class,
 			SideImageWithTextAndCta::class,

--- a/classes/patterns/class-pageheader.php
+++ b/classes/patterns/class-pageheader.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Page Header pattern class.
+ *
+ * @package P4GBKS
+ * @since 0.1
+ */
+
+namespace P4GBKS\Patterns;
+
+/**
+ * Class Page Header.
+ *
+ * @package P4GBKS\Patterns
+ */
+class PageHeader extends Block_Pattern {
+
+	/**
+	 * Returns the pattern name.
+	 */
+	public static function get_name(): string {
+		return 'p4/page-header-img-right';
+	}
+
+	/**
+	 * Returns the pattern config.
+	 *
+	 * @param array $params Optional array of parameters for the config.
+	 */
+	public static function get_config( $params = [] ): array {
+		$classname  = 'is-pattern-p4_page-header';
+		$media_link = esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-546x415.jpg';
+		$media_pos  = empty( $params['media_position'] ) ? 'right' : $params['media_position'];
+		$pos_class  = 'left' === $media_pos ? '' : 'has-media-on-the-' . $media_pos;
+
+		return [
+			'title'      => __( 'Page Header with image on the right', 'planet4-blocks-backend' ),
+			'categories' => [ 'page-headers' ],
+			'content'    => '
+				<!-- wp:media-text {"align":"full","mediaPosition":"' . $media_pos . '","mediaType":"image","imageFill":false,"className":"' . $classname . '"} -->
+				<div class="wp-block-media-text alignfull ' . $pos_class . ' is-stacked-on-mobile ' . $classname . '">
+
+					<figure class="wp-block-media-text__media">
+						<img src="' . $media_link . '" alt=""/>
+					</figure>
+
+					<div class="wp-block-media-text__content">
+						<!-- wp:group -->
+						<div class="wp-block-group">
+							<!-- wp:heading {"level":1,"placeholder":"' . __( 'Enter title', 'planet4-blocks-backend' ) . '","backgroundColor":"white"} -->
+							<h1 class="has-white-background-color has-background"></h1>
+							<!-- /wp:heading -->
+						</div>
+						<!-- /wp:group -->
+
+						<!-- wp:paragraph {"placeholder":"' . __( 'Enter description', 'planet4-blocks-backend' ) . '","style":{"typography":{"fontSize":"1.25rem"}}} -->
+						<p style="font-size:1.25rem"></p>
+						<!-- /wp:paragraph -->
+
+						<!-- wp:buttons -->
+						<div class="wp-block-buttons">
+							<!-- wp:button {"className":"is-style-cta"} /-->
+						</div>
+						<!-- /wp:buttons -->
+					</div>
+				</div>
+				<!-- /wp:media-text -->
+			',
+		];
+	}
+}

--- a/classes/patterns/class-pageheader.php
+++ b/classes/patterns/class-pageheader.php
@@ -16,6 +16,16 @@ namespace P4GBKS\Patterns;
 class PageHeader extends Block_Pattern {
 
 	/**
+	 * @var string
+	 */
+	protected static $title = 'Page Header with image on the right';
+
+	/**
+	 * @var string
+	 */
+	protected static $media_position = 'right';
+
+	/**
 	 * Returns the pattern name.
 	 */
 	public static function get_name(): string {
@@ -28,16 +38,16 @@ class PageHeader extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
-		$classname  = 'is-pattern-p4_page-header';
+		$classname  = 'is-pattern-p4-page-header';
 		$media_link = esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-546x415.jpg';
-		$media_pos  = empty( $params['media_position'] ) ? 'right' : $params['media_position'];
-		$pos_class  = 'left' === $media_pos ? '' : 'has-media-on-the-' . $media_pos;
+		$pos_class  = 'left' === static::$media_position ? ''
+			: 'has-media-on-the-' . static::$media_position;
 
 		return [
-			'title'      => __( 'Page Header with image on the right', 'planet4-blocks-backend' ),
+			'title'      => __( static::$title, 'planet4-blocks-backend' ), // phpcs:ignore
 			'categories' => [ 'page-headers' ],
 			'content'    => '
-				<!-- wp:media-text {"align":"full","mediaPosition":"' . $media_pos . '","mediaType":"image","imageFill":false,"className":"' . $classname . '"} -->
+				<!-- wp:media-text {"align":"full","mediaPosition":"' . static::$media_position . '","mediaType":"image","imageFill":false,"className":"' . $classname . '"} -->
 				<div class="wp-block-media-text alignfull ' . $pos_class . ' is-stacked-on-mobile ' . $classname . '">
 
 					<figure class="wp-block-media-text__media">

--- a/classes/patterns/class-pageheaderimgleft.php
+++ b/classes/patterns/class-pageheaderimgleft.php
@@ -13,29 +13,22 @@ namespace P4GBKS\Patterns;
  *
  * @package P4GBKS\Patterns
  */
-class PageHeaderImgLeft extends Block_Pattern {
+class PageHeaderImgLeft extends PageHeader {
+
+	/**
+	 * @var string
+	 */
+	protected static $title = 'Page Header with image on the left';
+
+	/**
+	 * @var string
+	 */
+	protected static $media_position = 'left';
 
 	/**
 	 * Returns the pattern name.
 	 */
 	public static function get_name(): string {
 		return 'p4/page-header-img-left';
-	}
-
-	/**
-	 * Returns the pattern config.
-	 *
-	 * @param array $params Optional array of parameters for the config.
-	 */
-	public static function get_config( $params = [] ): array {
-		$params['media_position'] = 'left';
-
-		$config          = PageHeader::get_config( $params );
-		$config['title'] = __(
-			'Page Header with image on the left',
-			'planet4-blocks-backend'
-		);
-
-		return $config;
 	}
 }

--- a/classes/patterns/class-pageheaderimgleft.php
+++ b/classes/patterns/class-pageheaderimgleft.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Page Header pattern class.
+ *
+ * @package P4GBKS
+ * @since 0.1
+ */
+
+namespace P4GBKS\Patterns;
+
+/**
+ * Class Page Header.
+ *
+ * @package P4GBKS\Patterns
+ */
+class PageHeaderImgLeft extends Block_Pattern {
+
+	/**
+	 * Returns the pattern name.
+	 */
+	public static function get_name(): string {
+		return 'p4/page-header-img-left';
+	}
+
+	/**
+	 * Returns the pattern config.
+	 *
+	 * @param array $params Optional array of parameters for the config.
+	 */
+	public static function get_config( $params = [] ): array {
+		$params['media_position'] = 'left';
+
+		$config          = PageHeader::get_config( $params );
+		$config['title'] = __(
+			'Page Header with image on the left',
+			'planet4-blocks-backend'
+		);
+
+		return $config;
+	}
+}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6680

> Implement the [new page header design](https://zeroheight.com/05f6e9516/v/latest/p/1285c9-page-header/b/88c480).
> Requirments
> - Create new Block Patterns category: Page Headers
> - Create two block patterns:
>   "Page Header with image on the right"
>   "Page Header with image on the left"
>
> Tasks
>   Investigate if we can pull header and paragraph text from the pattern to populate metadata and opengraph.

<table>
<tr>
<td><img src="https://user-images.githubusercontent.com/617346/170026415-12462333-a590-48a4-8d14-e3a431626485.png" /></td>
<td><img src="https://user-images.githubusercontent.com/617346/170026447-cb192039-b5d7-4677-a5d4-3de36cd57734.png" /></td>
</tr></table>

## Test

- Activate _All blocks_ in _Planet 4 > Features_
- Add a new page
- Select pattern _Page header_ and edit