### PR TITLE
Fix aspect ratio for rounded images in Firefox

### DIFF
--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -12,6 +12,7 @@
     }
 
     img {
+      height: 100%;
       object-fit: cover;
       aspect-ratio: 1;
     }


### PR DESCRIPTION
Browser support is still a bit limited for this CSS property, but updating the image width seems to solve it for Firefox