### PR TITLE
Add Image block rounded styles with specific sizes

### DIFF
--- a/admin/js/editor.js
+++ b/admin/js/editor.js
@@ -76,4 +76,21 @@ wp.domReady(() => {
   ];
 
   registerBlockStyle('core/heading', headingStyles);
+
+  // Unregister default Rounded Image block style
+  unregisterBlockStyle('core/image', 'rounded');
+
+  // Register our custom Image block styles
+  const imageStyles = [
+    {
+      name: 'rounded-180',
+      label: __('Rounded 180x180', 'planet4-blocks-backend')
+    },
+    {
+      name: 'rounded-90',
+      label: __('Rounded 90x90', 'planet4-blocks-backend')
+    },
+  ];
+
+  registerBlockStyle('core/image', imageStyles);
 });

--- a/assets/src/components/Image/ImageBlockEdit.js
+++ b/assets/src/components/Image/ImageBlockEdit.js
@@ -12,7 +12,7 @@ export const ImageBlockEdit = (BlockEdit) => {
     }
 
     const { attributes, clientId } = props;
-    const { id, caption } = attributes;
+    const { id, caption, className } = attributes;
 
     // Get image data
     const image = useSelect(select => id ? select('core').getMedia(id) : null);
@@ -22,6 +22,14 @@ export const ImageBlockEdit = (BlockEdit) => {
       ? (credits.includes('©') ? credits : `© ${credits}`)
       : null;
     const block_id = clientId ? `block-${clientId}` : null;
+
+    // Update width and height when sized rounded styles are selected
+    if (className && className.includes('is-style-rounded-')) {
+      const classes = className.split(' ');
+      const size = classes.find(c => c.includes('is-style-rounded-')).replace('is-style-rounded-', '');
+      attributes.width = parseInt(size) || 180;
+      attributes.height = parseInt(size) || 180;
+    }
 
     return (
       <>

--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -1,3 +1,16 @@
+@mixin rounded-image-size($size) {
+  figure,
+  img {
+    border-radius: 50%;
+    height: $size;
+    width: $size;
+  }
+
+  img {
+    object-fit: cover;
+  }
+}
+
 .wp-block-image {
   position: relative;
   width: auto;
@@ -5,16 +18,12 @@
   margin-top: $sp-1;
   margin-bottom: $sp-2;
 
-  &.is-style-rounded {
-    figure,
-    img {
-      border-radius: 50%;
-    }
+  &.is-style-rounded-180 {
+    @include rounded-image-size(180px);
+  }
 
-    img {
-      object-fit: cover;
-      aspect-ratio: 1;
-    }
+  &.is-style-rounded-90 {
+    @include rounded-image-size(90px);
   }
 
   &:not(.force-no-lightbox) img {


### PR DESCRIPTION
### Description

These have specific width and height, to facilitate creating block patterns such as [Deep Dive](https://jira.greenpeace.org/browse/PLANET-6534) and [Quick Links](https://jira.greenpeace.org/browse/PLANET-6520). I can't think of another way to force images to have a specific size and aspect ratio.

### Testing

You can test the new styles on your local environment or on the oberon test instance ([example page](https://www-dev.greenpeace.org/test-oberon/rounded-images-with-custom-sizes/)). When selecting either the `Rounded 90x90` or `Rounded 180x180` style, you should see the width and height adapt accordingly in the sidebar. Editors can still change these values manually, which might result in some confusion, but as far as I know it's not possible to disable them 😕 