### PR TITLE
Hide image credits when caption is empty

### DIFF
--- a/assets/src/components/Image/ImageBlockEdit.js
+++ b/assets/src/components/Image/ImageBlockEdit.js
@@ -12,16 +12,20 @@ export const ImageBlockEdit = (BlockEdit) => {
     }
 
     const { attributes, clientId } = props;
-    const { id, caption } = attributes;
+    const { id, caption, className } = attributes;
 
     // Get image data
     const image = useSelect(select => id ? select('core').getMedia(id) : null);
     const credits = image?.meta?._credit_text;
     // Compile data for insertion
-    const image_credits = credits && credits.length > 0 && ! caption.includes(credits)
+    const image_credits = credits && credits.length > 0 && caption && ! caption.includes(credits)
       ? (credits.includes('©') ? credits : `© ${credits}`)
       : null;
     const block_id = clientId ? `block-${clientId}` : null;
+
+    if (!caption && credits && (!className || !className.includes('no-caption'))) {
+      attributes.className = className ? `${className} no-caption` : 'no-caption';
+    }
 
     return (
       <>

--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -71,4 +71,8 @@
   &.caption-alignment-right figcaption {
     text-align: right;
   }
+
+  &.no-caption figcaption {
+    display: none;
+  }
 }


### PR DESCRIPTION
### Description

This will be useful in block patterns in particular, where we don't want to show caption nor credits, and currently credits cannot be manually removed (unlike the caption).
There are issues with having it automatically implemented like it is in this PR: editors cannot manually remove the `no-caption` class, it will be applied automatically, which might be confusing as to why there are credits in the library but they don't show. Also, I am worried that there might be use cases where editors want the credits to show even if there's no caption, maybe it could be a legal issue?

I thought of creating a block style for this, but we cannot combine styles and we already need one for the image to be rounded... Or maybe we could hide the caption as part of the rounded styles, but I don't think that makes a lot of sense 🤔 

Maybe the best option would be to just add the `no-caption` class to pattern Image blocks and hide the caption only then, and editors could manually add/remove it. It would be similar to our `force-no-lightbox` [class](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/assets/src/styles/blocks/core-overrides/Image.scss#L20), that editors can use if they want to disable the lightbox.

### Testing

You can test this behaviour on [this page](https://www-dev.greenpeace.org/test-leda/images-without-credits/) for example. Also on local, you just need to have an image that has credits but no caption, and in that case the credits should not show in the editor or in the frontend.