### PR TITLE
PLANET-6778 Add spacing to core Group block

### DIFF
--- a/assets/src/styles/blocks/core-overrides/BlockSpacing.scss
+++ b/assets/src/styles/blocks/core-overrides/BlockSpacing.scss
@@ -1,6 +1,8 @@
 .wp-block-quote,
 .wp-block-file,
 .wp-block-button,
+.page-content > .wp-block-group,
+.post-details > .wp-block-group,
 .page-content > h2,
 .page-content > ul > li:last-of-type,
 .page-content > p,

--- a/assets/src/styles/blocks/core-overrides/BlockSpacing.scss
+++ b/assets/src/styles/blocks/core-overrides/BlockSpacing.scss
@@ -5,9 +5,11 @@
 .post-details > .wp-block-group,
 .page-content > h2,
 .page-content > ul > li:last-of-type,
+.page-content > ol > li:last-of-type,
 .page-content > p,
 .post-details > h2,
 .post-details > ul > li:last-of-type,
+.post-details > ol > li:last-of-type,
 .post-details > p,
 .post-details > p:first-of-type {
   margin-top: $sp-1;
@@ -20,7 +22,9 @@
 }
 
 .page-content > ul > li,
-.post-details > ul > li {
+.post-details > ul > li,
+.page-content > ol > li,
+.post-details > ol > li {
   margin-top: $sp-1;
   margin-bottom: $sp-1;
 

--- a/assets/src/styles/editorStyle.scss
+++ b/assets/src/styles/editorStyle.scss
@@ -33,3 +33,13 @@
   padding: $sp-2;
   margin: 0;
 }
+
+.block-editor-block-list__layout > * {
+  margin-top: $sp-1;
+  margin-bottom: $sp-2;
+
+  @include large-and-up {
+    margin-top: $sp-2;
+    margin-bottom: $sp-4;
+  }
+}


### PR DESCRIPTION
### Description

See [PLANET-6778](https://jira.greenpeace.org/browse/PLANET-6778)
Since we can use Group blocks within other blocks, this custom spacing should only apply to parent Group blocks.
While checking this I found out that blocks don't all have margins in the editor, so I've pushed a fix for that. Also, I've added a fix for numbered lists to follow the same rules as bullet lists.

### Testing

You can test the Group block spacing on this [page](https://www-dev.greenpeace.org/test-deimos/group-block-spacing/) for example, or on local. In the editor you can also play around with different blocks to see what the new spacing looks like!