### PR TITLE
Create CSS class to force hiding Image block caption/credits

### DIFF
--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -21,6 +21,10 @@
     cursor: pointer;
   }
 
+  &.force-no-caption figcaption {
+    display: none;
+  }
+
   @include large-and-up {
     margin-top: $sp-2;
     margin-bottom: $sp-4;


### PR DESCRIPTION
### Description

This will be useful for block patterns, where we never want to show caption nor credits. It works similarly to our [force-no-lightbox](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/assets/src/styles/blocks/core-overrides/Image.scss#L20-L22) class, that editors can manually add to the block in case they want to disable the Lightbox for this particular image.

### Testing

On local, first add an Image block and select any image that has credits and/or caption set up in the library. Then in the sidebar, in the "Advanced" tab, in the "Additional CSS class(es)" you can add the `force-no-caption` class. You should then see the caption disappear in the editor, and it should also be hidden in the frontend.
Alternatively you can check out this [page](https://www-dev.greenpeace.org/test-pluto/images-with-or-without-caption-credits/) on the pluto test instance!