### PR TITLE
Enforce hiding Image block caption with CSS

### DIFF
--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -31,7 +31,7 @@
   }
 
   &.force-no-caption figcaption {
-    display: none;
+    display: none !important;
   }
 
   @include large-and-up {


### PR DESCRIPTION
### Description

We need to use `!important`, otherwise in the editor the caption will sometimes still show (in cases where the image has an alignement class for example, because the CSS selectors then change).

### Testing

On local, add an Image block and select an image that has a caption and/or some credits assigned in the library. Then add alignment to the block (such as `Center`) and the `force-no-caption` class in the advanced settings. On this branch the caption should be hidden in both frontend and backend, whereas on master branch the caption will still show in the editor.