### PR TITLE
PLANET-6816: Pull pages for covers manual override

### DIFF
--- a/assets/src/blocks/Covers/CoversEditor.js
+++ b/assets/src/blocks/Covers/CoversEditor.js
@@ -85,7 +85,7 @@ const renderEdit = (attributes, toAttribute, setAttributes) => {
               label={__('Select pages', 'planet4-blocks-backend')}
               selected={posts || []}
               onChange={toAttribute('posts')}
-              postType={cover_type === COVERS_TYPES.content ? 'post' : 'act_page'}
+              postType={cover_type === COVERS_TYPES.content ? 'post,page' : 'act_page'}
               placeholder={__('Select pages', 'planet4-blocks-backend')}
               maxLength={layout === COVERS_LAYOUTS.carousel ? CAROUSEL_LAYOUT_COVERS_LIMIT : null}
             />

--- a/assets/src/components/PostSelector/PostSelector.js
+++ b/assets/src/components/PostSelector/PostSelector.js
@@ -38,6 +38,7 @@ export const PostSelector = (attributes) => {
     if ('post' === postType) {
       return [].concat(
         select('core').getEntityRecords('postType', 'post', {'include': selected}) || [],
+        select('core').getEntityRecords('postType', 'page', {'include': selected}) || [],
         select('core').getEntityRecords('planet4/v1', 'all-published-posts', args) || [],
       );
     }

--- a/assets/src/components/PostSelector/PostSelector.js
+++ b/assets/src/components/PostSelector/PostSelector.js
@@ -4,10 +4,10 @@ const { __ } = wp.i18n;
 
 // Allows to query a custom endpoint with select('core') tools
 dispatch('core').addEntities( [{
-    baseURL: '/planet4/v1/all-published-posts',
+    baseURL: '/planet4/v1/published',
     kind: 'planet4/v1',
-    name: 'all-published-posts',
-    label: 'All published posts',
+    name: 'published',
+    label: 'All published of post_type',
 }] );
 
 /**
@@ -30,27 +30,30 @@ export const PostSelector = (attributes) => {
    */
   const act_parent = window.p4ge_vars.planet4_options.act_page || null;
   const args = { per_page: -1, orderby: 'title', post_status: 'publish' };
-  const act_args = {
-    post_parent: act_parent,
-    ...args,
-  };
   const posts = useSelect((select) => {
     if ('post' === postType) {
-      return [].concat(
-        select('core').getEntityRecords('postType', 'post', {'include': selected}) || [],
-        select('core').getEntityRecords('postType', 'page', {'include': selected}) || [],
-        select('core').getEntityRecords('planet4/v1', 'all-published-posts', args) || [],
-      );
+      return [
+        ...select('core').getEntityRecords('postType', 'post', {'include': selected}) || [],
+        ...select('core').getEntityRecords('planet4/v1', 'published', {post_type: postType, ...args}) || [],
+      ];
+    }
+
+    if ('post,page' === postType) {
+      return [
+        ...select('core').getEntityRecords('postType', 'post', {'include': selected}) || [],
+        ...select('core').getEntityRecords('postType', 'page', {'include': selected}) || [],
+        ...select('core').getEntityRecords('planet4/v1', 'published', {post_type: postType, ...args}) || [],
+      ];
     }
 
     if ('act_page' === postType) {
-      const selectedPosts = [].concat(
-        select('core').getEntityRecords('postType', 'page', {'include': selected}) || [],
-        select('core').getEntityRecords('postType', 'p4_action', {'include': selected}) || [],
-      );
+      const selectedPosts = [
+        ...select('core').getEntityRecords('postType', 'page', {'include': selected}) || [],
+        ...select('core').getEntityRecords('postType', 'p4_action', {'include': selected}) || [],
+      ];
       const actions = select('core').getEntityRecords('postType', 'p4_action', args) || [];
       const pages = act_parent
-        ? (select('core').getEntityRecords('postType', 'page', act_args) || [])
+        ? (select('core').getEntityRecords('postType', 'page', {post_parent: act_parent, ...args}) || [])
         : [];
       return [].concat(selectedPosts, actions, pages);
     }
@@ -62,7 +65,7 @@ export const PostSelector = (attributes) => {
    * Convert posts to {id, title}
    */
   const options = posts.map(post => ({
-    id: post.id,
+    id: parseInt(post.id),
     title: post.title?.raw || post.post_title,
   }));
 
@@ -81,7 +84,7 @@ export const PostSelector = (attributes) => {
    */
   const getPostsTitlesFromIds = (ids) => {
     return options?.length && ids?.length
-    ? ids.map(postId => options.find(option => option.id === postId)?.title).filter(t => t)
+    ? ids.map(postId => options.find(option => option.id === parseInt(postId))?.title).filter(t => t)
     : []
   };
 

--- a/classes/blocks/class-covers.php
+++ b/classes/blocks/class-covers.php
@@ -285,6 +285,8 @@ class Covers extends Base_Block {
 			// If cover type is take action pages set post_type to page.
 			if ( isset( $fields['cover_type'] ) && self::TAKE_ACTION_COVER_TYPE === $fields['cover_type'] ) {
 				$args['post_type'] = [ 'page', ActionPage::POST_TYPE ];
+			} else {
+				$args['post_type'] = [ 'post', 'page' ];
 			}
 
 			// Ignore sniffer rule, arguments contain suppress_filters.

--- a/classes/rest/class-published.php
+++ b/classes/rest/class-published.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * @package P4GBKS\Rest
+ */
+
+namespace P4GBKS\Rest;
+
+use P4\MasterTheme\SqlParameters;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Published items.
+ *
+ * Faster alternative to get_posts(), to return only IDs and titles of published items.
+ */
+class Published {
+	/**
+	 * Allowed post types
+	 *
+	 * @var string[]
+	 */
+	public const ALLOWED_TYPES = [ 'post', 'page' ];
+
+	/**
+	 * @var wpdb
+	 */
+	private $db;
+
+	/**
+	 * @var WP_REST_Request
+	 */
+	private $request;
+
+	/**
+	 * Constructor
+	 *
+	 * @param WP_REST_Request $request Request.
+	 */
+	public function __construct( WP_REST_Request $request ) {
+		global $wpdb;
+		$this->db      = $wpdb;
+		$this->request = $request;
+	}
+
+	/**
+	 * Permission callback
+	 */
+	public static function permission(): bool {
+		return current_user_can( 'edit_pages' ) || current_user_can( 'edit_campaigns' );
+	}
+
+	/**
+	 * HTTP Method
+	 */
+	public static function methods(): string {
+		return WP_REST_Server::READABLE;
+	}
+
+	/**
+	 * Get API response data.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function response() {
+		$types = explode( ',', $this->request->get_param( 'post_type' ) ?? '' );
+		$types = array_intersect( self::ALLOWED_TYPES, $types );
+		if ( empty( $types ) ) {
+			return rest_ensure_response( [] );
+		}
+
+		if ( is_plugin_active( 'sitepress-multilingual-cms/sitepress.php' ) ) {
+			$lang  = apply_filters( 'wpml_current_language', null );
+			$query = $this->get_wpml_posts_query( $lang, $types );
+		} else {
+			$query = $this->get_posts_query( $types );
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$results = $this->db->get_results( $query ) ?? [];
+
+		array_walk(
+			$results,
+			function ( &$p ) {
+				$p->id = (int) $p->id;
+			}
+		);
+
+		return rest_ensure_response( $results );
+	}
+
+	/**
+	 * Create query for all published items of type asked.
+	 *
+	 * @param string[] $types Post types.
+	 */
+	private function get_posts_query( array $types ): string {
+		$params = new SqlParameters();
+		$sql    = 'SELECT id, post_title
+			FROM ' . $params->identifier( $this->db->posts ) . '
+			WHERE post_status = \'publish\'
+				AND post_type IN ' . $params->string_list( $types ) . '
+			ORDER BY post_date DESC';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		return $this->db->prepare( $sql, $params->get_values() );
+	}
+
+	/**
+	 * Create a query for all published items with a certain language code.
+	 *
+	 * @param string   $lang  Return posts with this language code.
+	 * @param string[] $types Post types.
+	 *
+	 * @return string The prepared query.
+	 */
+	private function get_wpml_posts_query( string $lang, array $types ): string {
+		$icl_types = array_map(
+			fn ( $t ) => 'post_' . $t,
+			$types
+		);
+
+		$params = new SqlParameters();
+		$sql    = 'SELECT p.id, p.post_title
+			FROM ' . $params->identifier( $this->db->posts ) . ' p
+			JOIN ' . $params->identifier( $this->db->prefix . 'icl_translations' ) . ' t
+					ON p.ID = t.element_id
+					AND t.element_type IN ' . $params->string_list( $icl_types ) . '
+			WHERE p.post_status = \'publish\'
+				AND p.post_type IN ' . $params->string_list( $types ) . '
+				AND t.language_code = ' . $params->string( $lang ) . '
+			ORDER BY p.post_date DESC';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		return $this->db->prepare( $sql, $params->get_values() );
+	}
+}

--- a/classes/rest/class-rest-api.php
+++ b/classes/rest/class-rest-api.php
@@ -57,7 +57,8 @@ class Rest_Api {
 						} else {
 							$query = "SELECT id, post_title
 								FROM wp_posts
-								WHERE post_status = 'publish' AND post_type = 'post'
+								WHERE post_status = 'publish'
+									AND post_type IN ('post', 'page')
 								ORDER BY post_date DESC";
 						}
 						// The query is prepared, just not in this line.
@@ -487,7 +488,7 @@ class Rest_Api {
 				FROM wp_posts p
          		JOIN wp_icl_translations t
               		ON p.ID = t.element_id AND t.element_type = 'post_post'
-				WHERE p.post_type = 'post'
+				WHERE p.post_type IN ('post', 'page')
   					AND p.post_status = 'publish'
   					AND t.language_code = %s
 				ORDER BY p.post_date DESC; ",

--- a/classes/rest/class-rest-api.php
+++ b/classes/rest/class-rest-api.php
@@ -41,35 +41,19 @@ class Rest_Api {
 		 */
 		register_rest_route(
 			self::REST_NAMESPACE,
-			'/all-published-posts',
+			'/published',
 			[
 				[
-					'permission_callback' => static function () {
-						return current_user_can( 'edit_pages' ) || current_user_can( 'edit_campaigns' );
-					},
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => static function () {
-						global $wpdb;
-
-						if ( is_plugin_active( 'sitepress-multilingual-cms/sitepress.php' ) ) {
-							$lang  = apply_filters( 'wpml_current_language', null );
-							$query = self::get_wpml_posts_query( $lang );
-						} else {
-							$query = "SELECT id, post_title
-								FROM wp_posts
-								WHERE post_status = 'publish'
-									AND post_type IN ('post', 'page')
-								ORDER BY post_date DESC";
-						}
-						// The query is prepared, just not in this line.
-						// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-						$result = $wpdb->get_results( $query );
-
-						return rest_ensure_response( $result );
+					'permission_callback' => [ Published::class, 'permission' ],
+					'methods'             => Published::methods(),
+					'callback'            => static function ( $request ) {
+						$api = new Published( $request );
+						return $api->response();
 					},
 				],
 			]
 		);
+
 		/**
 		 * Save meta to the preview of the current user.
 		 */
@@ -471,28 +455,6 @@ class Rest_Api {
 				}
 				\Sentry\captureMessage( $message );
 			}
-		);
-	}
-
-	/**
-	 * Create a query for all posts with a certain language code.
-	 *
-	 * @param string $language_code Return posts with this language code.
-	 * @return string The prepared query.
-	 */
-	private static function get_wpml_posts_query( string $language_code ): string {
-		global $wpdb;
-
-		return $wpdb->prepare(
-			"SELECT p.id,p.post_title
-				FROM wp_posts p
-         		JOIN wp_icl_translations t
-              		ON p.ID = t.element_id AND t.element_type = 'post_post'
-				WHERE p.post_type IN ('post', 'page')
-  					AND p.post_status = 'publish'
-  					AND t.language_code = %s
-				ORDER BY p.post_date DESC; ",
-			$language_code
 		);
 	}
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6816

This modification allows to manually add pages and posts (instead of only posts) to Content Covers block.

## Code

I've extracted the endpoint code to a single class and renamed it to a more generic `/published`.

## Test

Example page https://www-dev.greenpeace.org/test-tavros/content-covers/

- Create a new page
- Add a Covers block with Content Covers style
- Use the _Manual override_ field by typing the title of some other pages
- The autocomplete should list posts but also pages
  - After reloading, posts and pages manually added still appear in the Manual override box
  - Manually added content appears on frontend too
- Check that the Articles block only allows for manual addition of posts, not pages