### PR TITLE
PLANET-6340 Add lazy loading to Take Action covers

### DIFF
--- a/assets/src/blocks/Covers/TakeActionCovers.js
+++ b/assets/src/blocks/Covers/TakeActionCovers.js
@@ -53,6 +53,7 @@ export const TakeActionCovers = ({
             {isExample ?
               <CoversImagePlaceholder height={220} /> :
               <img
+                loading='lazy'
                 alt={alt_text}
                 src={image}
                 srcSet={srcset}


### PR DESCRIPTION
### Description

See [PLANET-6340](https://jira.greenpeace.org/browse/PLANET-6340)
Other Covers block styles already have it ([Campaign](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/assets/src/blocks/Covers/CampaignCovers.js#L42), [Content](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/assets/src/blocks/Covers/ContentCovers.js#L50)) but for some reason this one didn't. This should improve performance.