### PR TITLE
PLANET-6723: Enable articles in posts

### DIFF
--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -108,6 +108,7 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 const POST_BLOCK_TYPES = [
 	'planet4-blocks/accordion',
+	'planet4-blocks/articles',
 	'planet4-blocks/counter',
 	'planet4-blocks/gallery',
 	'planet4-blocks/social-media',


### PR DESCRIPTION
Ticket: https://jira.greenpeace.org/browse/PLANET-6723

The new post page has changed to a new layout ([design](https://www.figma.com/file/tdt8olZ6RS4bTMqbo2cvCU/Post-page-V1?node-id=79%3A7)).

_The oberon's instance is using the `allow_articles_block_in_posts` master's theme branch_ ([see here](https://github.com/greenpeace/planet4-test-oberon/blob/main/composer-local.json#L6)). 

[Related master theme PR](https://github.com/greenpeace/planet4-master-theme/pull/1741). 

[Demo page](https://www-dev.greenpeace.org/test-oberon/story/51096/post-title-goes-here-it-can-be-this-long/)

**Testing**
- Login to the assigned instance and create a new post
- You should be able to add the Articles block into the post
- After it's published, the Articles block should be inside the post content, currently it's outside of it
- The same happens with the comment's block.