### PR TITLE
PLANET-6782: Pattern usage report

### DIFF
--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -171,7 +171,7 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 		public function plugin_blocks_report_beta() {
 			// Nonce verify.
 			if ( isset( $_REQUEST['filter_action'] ) ) {
-				check_admin_referer( 'bulk-blocks' );
+				check_admin_referer( 'bulk-' . BlockUsageTable::PLURAL );
 			}
 
 			// Create table.

--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -18,6 +18,7 @@ use P4GBKS\Search\Block\Query\Parameters as BlockParameters;
 use P4GBKS\Search\Pattern\Query\Parameters as PatternParameters;
 use P4GBKS\Search\Pattern\PatternUsage;
 use P4GBKS\Search\Pattern\PatternUsageTable;
+use P4GBKS\Search\Pattern\PatternUsageApi;
 use WP_Block_Type_Registry;
 use WP_Block_Patterns_Registry;
 
@@ -130,10 +131,12 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 			);
 
 			// Group results.
-			$api    = new BlockUsageApi();
-			$report = [
-				'block_types' => $api->get_count(),
-				'post_types'  => $post_types,
+			$block_api   = new BlockUsageApi();
+			$pattern_api = new PatternUsageApi();
+			$report      = [
+				'block_types'    => $block_api->get_count(),
+				'block_patterns' => $pattern_api->get_count(),
+				'post_types'     => $post_types,
 			];
 
 			return $report;

--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -10,11 +10,16 @@ namespace P4GBKS\Controllers\Menu;
 
 use P4\MasterTheme\SqlParameters;
 use P4\MasterTheme\Exception\SqlInIsEmpty;
+use P4GBKS\Patterns\Block_Pattern;
 use P4GBKS\Search\Block\BlockUsage;
 use P4GBKS\Search\Block\BlockUsageTable;
 use P4GBKS\Search\Block\BlockUsageApi;
-use P4GBKS\Search\Block\Query\Parameters;
+use P4GBKS\Search\Block\Query\Parameters as BlockParameters;
+use P4GBKS\Search\Pattern\Query\Parameters as PatternParameters;
+use P4GBKS\Search\Pattern\PatternUsage;
+use P4GBKS\Search\Pattern\PatternUsageTable;
 use WP_Block_Type_Registry;
+use WP_Block_Patterns_Registry;
 
 if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 
@@ -52,6 +57,7 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 		private function hooks() {
 			add_action( 'rest_api_init', [ $this, 'plugin_blocks_report_register_rest_route' ] );
 			BlockUsageTable::set_hooks();
+			PatternUsageTable::set_hooks();
 		}
 
 		/**
@@ -159,6 +165,15 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 					'plugin_blocks_report_beta',
 					[ $this, 'plugin_blocks_report_beta' ]
 				);
+
+				add_submenu_page(
+					P4GBKS_PLUGIN_SLUG_NAME,
+					__( 'Pattern Report (Beta)', 'planet4-blocks-backend' ),
+					__( 'Pattern Report (Beta)', 'planet4-blocks-backend' ),
+					'manage_options',
+					'plugin_patterns_report',
+					[ $this, 'plugin_patterns_report' ]
+				);
 			}
 		}
 
@@ -185,7 +200,7 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 			$special_filter = isset( $_REQUEST['unregistered'] ) ? 'unregistered'
 				: ( isset( $_REQUEST['unallowed'] ) ? 'unallowed' : null );
 			$table->prepare_items(
-				Parameters::from_request( $_REQUEST ),
+				BlockParameters::from_request( $_REQUEST ),
 				$_REQUEST['group'] ?? null,
 				$special_filter
 			);
@@ -202,6 +217,46 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 			echo '<input type="hidden" name="action"
 				value="' . esc_attr( BlockUsageTable::ACTION_NAME ) . '"/>';
 			echo '</form>';
+			echo '</div>';
+		}
+
+		/**
+		 * Beta block usage report page.
+		 *
+		 * @todo before replacing current one:
+		 * - review json report / keep or replace with new search
+		 */
+		public function plugin_patterns_report() {
+			// Nonce verify.
+			if ( isset( $_REQUEST['filter_action'] ) ) {
+				check_admin_referer( 'bulk-' . PatternUsageTable::PLURAL );
+			}
+
+			// Create table.
+			$args  = [
+				'pattern_usage'    => new PatternUsage(),
+				'pattern_registry' => WP_Block_Patterns_Registry::get_instance(),
+			];
+			$table = new PatternUsageTable( $args );
+
+			// Prepare data.
+			$table->prepare_items(
+				PatternParameters::from_request( $_REQUEST ),
+				$_REQUEST['group'] ?? null
+			);
+
+			// Display data.
+			echo '<div class="wrap">
+				<h1 class="wp-heading-inline">Pattern usage</h1>
+				<hr class="wp-header-end">';
+
+			echo '<form id="patterns-report" method="get">';
+			$table->views();
+			$table->display();
+			echo '<input type="hidden" name="action"
+				value="' . esc_attr( PatternUsageTable::ACTION_NAME ) . '"/>';
+			echo '</form>';
+			echo '</div>';
 		}
 
 		/**

--- a/classes/patterns/class-block-pattern.php
+++ b/classes/patterns/class-block-pattern.php
@@ -27,6 +27,29 @@ abstract class Block_Pattern {
 	abstract public static function get_config( $params = [] ): array;
 
 	/**
+	 * Returns the pattern classname used for tracking patterns.
+	 */
+	public static function get_classname(): string {
+		return 'is_pattern-' . preg_replace( '#[^_a-zA-Z0-9-]#', '_', static::get_name() );
+	}
+
+	/**
+	 * Patterns list.
+	 */
+	public static function get_list(): array {
+		return [
+			BlankPage::class,
+			DeepDive::class,
+			GetInformed::class,
+			HighlightedCta::class,
+			Issues::class,
+			QuickLinks::class,
+			RealityCheck::class,
+			SideImageWithTextAndCta::class,
+		];
+	}
+
+	/**
 	 * Pattern constructor.
 	 */
 	public static function register_all() {
@@ -34,16 +57,7 @@ abstract class Block_Pattern {
 			return;
 		}
 
-		$patterns = [
-			BlankPage::class,
-			SideImageWithTextAndCta::class,
-			HighlightedCta::class,
-			RealityCheck::class,
-			Issues::class,
-			DeepDive::class,
-			QuickLinks::class,
-			GetInformed::class,
-		];
+		$patterns = self::get_list();
 
 		/**
 		 * @var $pattern self

--- a/classes/patterns/class-block-pattern.php
+++ b/classes/patterns/class-block-pattern.php
@@ -7,6 +7,8 @@
 
 namespace P4GBKS\Patterns;
 
+use P4GBKS\Search\Pattern\PatternData;
+
 /**
  * Class Base_Pattern
  *
@@ -30,7 +32,7 @@ abstract class Block_Pattern {
 	 * Returns the pattern classname used for tracking patterns.
 	 */
 	public static function get_classname(): string {
-		return 'is_pattern-' . preg_replace( '#[^_a-zA-Z0-9-]#', '_', static::get_name() );
+		return PatternData::make_classname( static::get_name() );
 	}
 
 	/**

--- a/classes/patterns/class-deepdive.php
+++ b/classes/patterns/class-deepdive.php
@@ -58,12 +58,13 @@ class DeepDive extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
+		$classname = self::get_classname();
 		return [
 			'title'      => __( 'Deep Dive', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],
 			'content'    => '
-				<!-- wp:group {"className":"block","align":"full","backgroundColor":"grey-05"} -->
-					<div class="wp-block-group alignfull block has-grey-05-background-color has-background">
+				<!-- wp:group {"className":"block ' . $classname . '","align":"full","backgroundColor":"grey-05"} -->
+					<div class="wp-block-group alignfull block ' . $classname . ' has-grey-05-background-color has-background">
 						<!-- wp:group {"className":"container"} -->
 							<div class="wp-block-group container">
 								<!-- wp:spacer {"height":"24px"} -->

--- a/classes/patterns/class-getinformed.php
+++ b/classes/patterns/class-getinformed.php
@@ -28,13 +28,14 @@ class GetInformed extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
+		$classname = self::get_classname();
 		return [
 			'title'      => __( 'Get Informed', 'planet4-blocks-backend' ),
 			'blockTypes' => [ 'core/post-content' ],
 			'categories' => [ 'pages' ],
 			'content'    => '
-				<!-- wp:group {"className":"block"} -->
-					<div class="wp-block-group">
+				<!-- wp:group {"className":"block ' . $classname . '"} -->
+					<div class="wp-block-group block ' . $classname . '">
 						' . QuickLinks::get_config( [ 'title_placeholder' => __( 'Explore by topic', 'planet4-blocks' ) ] )['content'] . '
 						' . SideImageWithTextAndCta::get_config( [ 'title_placeholder' => __( 'Topic 1', 'planet4-blocks' ) ] )['content'] . '
 						' . SideImageWithTextAndCta::get_config(

--- a/classes/patterns/class-highlightedcta.php
+++ b/classes/patterns/class-highlightedcta.php
@@ -28,12 +28,13 @@ class HighlightedCta extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
+		$classname = self::get_classname();
 		return [
 			'title'      => __( 'Highlighted CTA', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],
 			'content'    => '
-				<!-- wp:columns {"className":"block","textColor":"white","backgroundColor":"dark-blue"} -->
-					<div class="wp-block-columns block has-dark-blue-background-color has-text-color has-background has-white-color">
+				<!-- wp:columns {"className":"block ' . $classname . '","textColor":"white","backgroundColor":"dark-blue"} -->
+					<div class="wp-block-columns block ' . $classname . ' has-dark-blue-background-color has-text-color has-background has-white-color">
 						<!-- wp:column -->
 							<div class="wp-block-column">
 								<!-- wp:image {"align":"center","className":"force-no-lightbox force-no-caption"} -->

--- a/classes/patterns/class-issues.php
+++ b/classes/patterns/class-issues.php
@@ -46,14 +46,15 @@ class Issues extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
+		$classname         = self::get_classname();
 		$title_placeholder = $params['title_placeholder'] ?? '';
 
 		return [
 			'title'      => __( 'Issues', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],
 			'content'    => '
-				<!-- wp:group {"align":"full","backgroundColor":"grey-05"} -->
-				<div class="wp-block-group alignfull has-grey-05-background-color has-background">
+				<!-- wp:group {"className":"' . $classname . '","align":"full","backgroundColor":"grey-05"} -->
+				<div class="wp-block-group ' . $classname . ' alignfull has-grey-05-background-color has-background">
 
 					<!-- wp:group {"className":"container"} -->
 					<div class="wp-block-group container">

--- a/classes/patterns/class-quicklinks.php
+++ b/classes/patterns/class-quicklinks.php
@@ -67,14 +67,15 @@ class QuickLinks extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
+		$classname         = self::get_classname();
 		$title_placeholder = $params['title_placeholder'] ?? '';
 
 		return [
 			'title'      => __( 'Quick Links', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],
 			'content'    => '
-				<!-- wp:group {"className":"block","align":"full","backgroundColor":"grey-05"} -->
-					<div class="wp-block-group alignfull block has-grey-05-background-color has-background">
+				<!-- wp:group {"className":"block ' . $classname . '","align":"full","backgroundColor":"grey-05"} -->
+					<div class="wp-block-group alignfull block ' . $classname . ' has-grey-05-background-color has-background">
 						<!-- wp:group {"className":"container"} -->
 							<div class="wp-block-group container">
 								<!-- wp:spacer {"height":"24px"} -->

--- a/classes/patterns/class-realitycheck.php
+++ b/classes/patterns/class-realitycheck.php
@@ -57,12 +57,14 @@ class RealityCheck extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
+		$classname = self::get_classname();
+
 		return [
 			'title'      => __( 'Reality Check', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],
 			'content'    => '
-				<!-- wp:columns {"className":"block"} -->
-					<div class="wp-block-columns block">
+				<!-- wp:columns {"className":"block ' . $classname . '"} -->
+					<div class="wp-block-columns block ' . $classname . '">
 						' . self::get_column_template() . '
 						' . self::get_column_template() . '
 						' . self::get_column_template() . '

--- a/classes/search/block/class-blockusagetable.php
+++ b/classes/search/block/class-blockusagetable.php
@@ -137,6 +137,12 @@ class BlockUsageTable extends WP_List_Table {
 
 		$this->search_params = $search_params
 			->with_post_status( self::DEFAULT_POST_STATUS )
+			->with_post_type(
+				array_filter(
+					\get_post_types( [ 'show_in_rest' => true ] ),
+					fn ( $t ) => \post_type_supports( $t, 'editor' )
+				)
+			)
 			->with_order( array_merge( [ $this->group_by ], $this->sort_by ) );
 
 		$items = $this->block_usage->get_blocks( $this->search_params );

--- a/classes/search/block/class-blockusagetable.php
+++ b/classes/search/block/class-blockusagetable.php
@@ -222,7 +222,6 @@ class BlockUsageTable extends WP_List_Table {
 				)
 			)
 		);
-		// @todo WP 5.? : parse blocks variations when available
 		sort( $namespaces );
 		$this->blocks_ns = $namespaces;
 	}
@@ -591,31 +590,6 @@ class BlockUsageTable extends WP_List_Table {
 			return;
 		}
 		parent::display_tablenav( $which );
-	}
-
-	/**
-	 * Block count in search result.
-	 *
-	 * @return int
-	 */
-	public function block_count(): int {
-		return count( $this->items );
-	}
-
-	/**
-	 * Post count in search result.
-	 *
-	 * @return int
-	 */
-	public function post_count(): int {
-		return count(
-			array_unique(
-				array_column(
-					$this->items,
-					'post_id'
-				)
-			)
-		);
 	}
 
 	/**

--- a/classes/search/block/class-blockusagetable.php
+++ b/classes/search/block/class-blockusagetable.php
@@ -10,6 +10,7 @@ namespace P4GBKS\Search\Block;
 use InvalidArgumentException;
 use WP_List_Table;
 use WP_Block_Type_Registry;
+use P4GBKS\Search\RowActions;
 use P4GBKS\Search\Block\Query\Parameters;
 use P4GBKS\Controllers\Menu\Blocks_Usage_Controller;
 
@@ -572,57 +573,9 @@ class BlockUsageTable extends WP_List_Table {
 	 * phpcs:disable WordPress.WP.I18n.TextDomainMismatch
 	 */
 	protected function handle_row_actions( $item, $column_name, $primary ) {
-		if ( $column_name !== $primary ) {
-			return '';
-		}
-
-		$actions = [];
-		$id      = (int) $item['post_id'];
-		$title   = $item['post_title'];
-
-		$actions['edit'] = sprintf(
-			'<a href="%s" aria-label="%s">%s</a>',
-			get_edit_post_link( $item['post_id'] ),
-			/* translators: %s: Post title. */
-			esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;', 'default' ), $title ) ),
-			__( 'Edit', 'default' )
+		return $this->row_actions(
+			( new RowActions() )->get_post_actions( $item, $column_name, $primary )
 		);
-
-		if ( in_array( $item['post_status'], [ 'pending', 'draft', 'future' ], true ) ) {
-			$preview_link    = get_preview_post_link( $id );
-			$actions['view'] = sprintf(
-				'<a href="%s" rel="bookmark" aria-label="%s">%s</a>',
-				esc_url( $preview_link ),
-				/* translators: %s: Post title. */
-				esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;', 'default' ), $title ) ),
-				__( 'Preview', 'default' )
-			);
-		} elseif ( 'trash' !== $item['post_status'] ) {
-			$actions['view'] = sprintf(
-				'<a href="%s" rel="bookmark" aria-label="%s">%s</a>',
-				get_permalink( $item['post_id'] ),
-				/* translators: %s: Post title. */
-				esc_attr( sprintf( __( 'View &#8220;%s&#8221;', 'default' ), $title ) ),
-				__( 'View', 'default' )
-			);
-		}
-
-		$actions['clone'] = '<a href="' . duplicate_post_get_clone_post_link( $id, 'display', false ) .
-			'" aria-label="' . esc_attr(
-			/* translators: %s: Post title. */
-				sprintf( __( 'Clone &#8220;%s&#8221;', 'duplicate-post' ), $title )
-			) . '">' .
-			esc_html_x( 'Clone', 'verb', 'duplicate-post' ) . '</a>';
-
-		$actions['edit_as_new_draft'] = '<a href="' . duplicate_post_get_clone_post_link( $id ) .
-			'" aria-label="' . esc_attr(
-			/* translators: %s: Post title. */
-				sprintf( __( 'New draft of &#8220;%s&#8221;', 'duplicate-post' ), $title )
-			) . '">' .
-			esc_html__( 'New Draft', 'duplicate-post' ) .
-			'</a>';
-
-		return $this->row_actions( $actions );
 	}
 
 	/**

--- a/classes/search/block/query/class-parameters.php
+++ b/classes/search/block/query/class-parameters.php
@@ -39,6 +39,11 @@ class Parameters {
 	/**
 	 * @var string[]
 	 */
+	private $post_type;
+
+	/**
+	 * @var string[]
+	 */
 	private $order;
 
 	/**
@@ -88,6 +93,7 @@ class Parameters {
 				'content'     => $text_search,
 				'attributes'  => $request['attributes'] ?? [ $text_search ],
 				'post_status' => $request['post_status'] ?? self::DEFAULT_POST_STATUS,
+				'post_type'   => $request['post_type'] ?? null,
 				'order'       => $request['order'] ?? null,
 			]
 		);
@@ -120,10 +126,10 @@ class Parameters {
 	 *
 	 * @throws \BadMethodCallException Property not allowed.
 	 *
-	 * @return self Unmutable parameter object.
+	 * @return self Immutable parameter object.
 	 */
 	public function with( string $name, $value = null ): self {
-		$allowed = [ 'namespace', 'name', 'attributes', 'content', 'post_status', 'order' ];
+		$allowed = [ 'namespace', 'name', 'attributes', 'content', 'post_status', 'post_type', 'order' ];
 		if ( ! in_array( $name, $allowed, true ) ) {
 			throw new \BadMethodCallException( 'Property ' . $name . ' does not exist.' );
 		}
@@ -165,6 +171,13 @@ class Parameters {
 	 */
 	public function post_status(): ?array {
 		return $this->post_status ? $this->post_status : self::DEFAULT_POST_STATUS;
+	}
+
+	/**
+	 * List of required post types.
+	 */
+	public function post_type(): ?array {
+		return $this->post_type ? $this->post_type : null;
 	}
 
 	/**

--- a/classes/search/block/query/class-parameters.php
+++ b/classes/search/block/query/class-parameters.php
@@ -170,14 +170,14 @@ class Parameters {
 	 * List of required post status.
 	 */
 	public function post_status(): ?array {
-		return $this->post_status ? $this->post_status : self::DEFAULT_POST_STATUS;
+		return $this->post_status ?? self::DEFAULT_POST_STATUS;
 	}
 
 	/**
 	 * List of required post types.
 	 */
 	public function post_type(): ?array {
-		return $this->post_type ? $this->post_type : null;
+		return $this->post_type ?? null;
 	}
 
 	/**

--- a/classes/search/block/sql/class-sqlquery.php
+++ b/classes/search/block/sql/class-sqlquery.php
@@ -54,13 +54,16 @@ class SqlQuery implements Block\Query {
 		// Prepare query parameters.
 		$regex  = [];
 		$status = [];
+		$type   = [];
 		$order  = [];
 		foreach ( $params_list as $params ) {
 			$regex[] = ( new Regex( $params ) )->__toString();
 			$status  = array_merge( $status, $params->post_status() ?? [] );
+			$type    = array_merge( $type, $params->post_type() ?? [] );
 			$order   = array_merge( $order, $params->order() ?? [] );
 		}
 		$status = array_unique( array_filter( $status ) );
+		$type   = array_unique( array_filter( $type ) );
 		$order  = $this->parse_order( array_unique( array_filter( $order ) ) );
 
 		// Prepare query.
@@ -68,6 +71,9 @@ class SqlQuery implements Block\Query {
 		$sql        = 'SELECT ID
 			FROM ' . $sql_params->identifier( $this->db->posts ) . '
 			WHERE post_status IN ' . $sql_params->string_list( $status );
+		if ( ! empty( $type ) ) {
+			$sql .= ' AND post_type IN ' . $sql_params->string_list( $type );
+		}
 		foreach ( $regex as $r ) {
 			$sql .= ' AND post_content REGEXP ' . $sql_params->string( $r ) . ' ';
 		}

--- a/classes/search/class-blocksearch.php
+++ b/classes/search/class-blocksearch.php
@@ -2,7 +2,7 @@
 /**
  * Block search
  *
- * @package P4BKS\Controllers
+ * @package P4BKS\Search
  */
 
 namespace P4GBKS\Search;

--- a/classes/search/class-patternsearch.php
+++ b/classes/search/class-patternsearch.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Pattern search
+ *
+ * @package P4BKS\Search
+ */
+
+namespace P4GBKS\Search;
+
+use P4GBKS\Search\Block\Sql\SqlQuery as BlockSqlQuery;
+use P4GBKS\Search\Pattern\Query\Parameters;
+use P4GBKS\Search\Block\Query\Parameters as BlockSearchParameters;
+use P4GBKS\Search\Pattern\PatternData;
+use P4\MasterTheme\SqlParameters;
+
+/**
+ * Search for posts containing specific patterns
+ */
+class PatternSearch {
+	public const DEFAULT_POST_TYPE = [ 'post', 'page' ];
+
+	public const DEFAULT_POST_STATUS = [ 'publish', 'private', 'draft', 'pending', 'future' ];
+
+	/**
+	 * @param Parameters $params Query parameters.
+	 * @return int[] list of posts IDs.
+	 */
+	public function get_posts( Parameters $params ): array {
+		$patterns = array_map(
+			fn ( $pattern ) => PatternData::from_name( $pattern ),
+			$params->name()
+		);
+
+		return array_unique(
+			array_filter(
+				array_merge(
+					$this->query_by_pattern_classname( $params, ...$patterns ),
+					$this->query_by_pattern_blocks( $params, ...$patterns )
+				)
+			)
+		);
+	}
+
+	/**
+	 * @param Parameters  $params          Search parameters.
+	 * @param PatternData ...$pattern_data Pattern data.
+	 * @return int[] List of posts IDs.
+	 */
+	private function query_by_pattern_blocks(
+		Parameters $params,
+		PatternData ...$pattern_data
+	): array {
+		// Query posts with all blocks of tree.
+		$block_query = new BlockSqlQuery();
+
+		$post_ids = [];
+		foreach ( $pattern_data as $pattern ) {
+			$block_params = array_map(
+				fn ( $block_name ) => BlockSearchParameters::from_array(
+					[
+						'name'        => $block_name,
+						'post_status' => $params->post_status() ?? self::DEFAULT_POST_STATUS,
+						'post_type'   => $params->post_type() ?? self::DEFAULT_POST_TYPE,
+					]
+				),
+				$pattern->block_list
+			);
+
+			$post_ids = array_merge( $post_ids, $block_query->get_posts( ...$block_params ) );
+		}
+
+		return array_unique( $post_ids );
+	}
+
+	/**
+	 * Query posts by pattern classname.
+	 *
+	 * @param Parameters  $params          Search parameters.
+	 * @param PatternData ...$pattern_data Pattern data.
+	 * @return int[] List of posts IDs.
+	 */
+	private function query_by_pattern_classname(
+		Parameters $params,
+		PatternData ...$pattern_data
+	): array {
+		$classes = array_map(
+			fn ( $p ) => $p->classname,
+			$pattern_data
+		);
+		if ( empty( $classes ) ) {
+			return [];
+		}
+
+		global $wpdb;
+
+		$like = array_map( fn ( $c ) => "post_content LIKE '%$c%'", $classes );
+		$like = implode( ' OR ', $like );
+
+		$sql_params = new SqlParameters();
+		$query      = 'SELECT ID
+			FROM ' . $sql_params->identifier( $wpdb->posts ) . '
+			WHERE post_status IN ' . $sql_params->string_list(
+				$params->post_status() ?? self::DEFAULT_POST_STATUS
+			) . '
+			AND post_type IN ' . $sql_params->string_list(
+				$params->post_type() ?? self::DEFAULT_POST_TYPE
+			) . '
+			AND ( ' . $like . ' )';
+
+		$results = $wpdb->get_results(
+			$wpdb->prepare( $query, $sql_params->get_values() ) // phpcs:ignore
+		);
+
+		return array_map(
+			fn ( $r ) => (int) $r->ID,
+			$results
+		);
+	}
+}

--- a/classes/search/class-rowactions.php
+++ b/classes/search/class-rowactions.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Display post actions in table
+ *
+ * @package P4BKS\Search
+ */
+
+namespace P4GBKS\Search;
+
+/**
+ * Row actions
+ */
+class RowActions {
+	/**
+	 * Add action links to a row
+	 *
+	 * @param array  $item        Item.
+	 * @param string $column_name Current column name.
+	 * @param string $primary     Primary column name.
+	 *
+	 * phpcs:disable WordPress.WP.I18n.TextDomainMismatch
+	 */
+	public function get_post_actions( array $item, string $column_name, string $primary ): array {
+		if ( $column_name !== $primary ) {
+			return [];
+		}
+
+		$id      = (int) $item['post_id'];
+		$title   = $item['post_title'];
+		$actions = [];
+
+		$actions['edit'] = sprintf(
+			'<a href="%s" aria-label="%s">%s</a>',
+			get_edit_post_link( $item['post_id'] ),
+			/* translators: %s: Post title. */
+			esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;', 'default' ), $title ) ),
+			__( 'Edit', 'default' )
+		);
+
+		if ( in_array( $item['post_status'], [ 'pending', 'draft', 'future' ], true ) ) {
+			$preview_link    = get_preview_post_link( $id );
+			$actions['view'] = sprintf(
+				'<a href="%s" rel="bookmark" aria-label="%s">%s</a>',
+				esc_url( $preview_link ),
+				/* translators: %s: Post title. */
+				esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;', 'default' ), $title ) ),
+				__( 'Preview', 'default' )
+			);
+		} elseif ( 'trash' !== $item['post_status'] ) {
+			$actions['view'] = sprintf(
+				'<a href="%s" rel="bookmark" aria-label="%s">%s</a>',
+				get_permalink( $item['post_id'] ),
+				/* translators: %s: Post title. */
+				esc_attr( sprintf( __( 'View &#8220;%s&#8221;', 'default' ), $title ) ),
+				__( 'View', 'default' )
+			);
+		}
+
+		$actions['clone'] = '<a href="' . duplicate_post_get_clone_post_link( $id, 'display', false ) .
+			'" aria-label="' . esc_attr(
+			/* translators: %s: Post title. */
+				sprintf( __( 'Clone &#8220;%s&#8221;', 'duplicate-post' ), $title )
+			) . '">' .
+			esc_html_x( 'Clone', 'verb', 'duplicate-post' ) . '</a>';
+
+		$actions['edit_as_new_draft'] = '<a href="' . duplicate_post_get_clone_post_link( $id ) .
+			'" aria-label="' . esc_attr(
+			/* translators: %s: Post title. */
+				sprintf( __( 'New draft of &#8220;%s&#8221;', 'duplicate-post' ), $title )
+			) . '">' .
+			esc_html__( 'New Draft', 'duplicate-post' ) .
+			'</a>';
+
+		return $actions;
+	}
+}

--- a/classes/search/pattern/class-contentstructure.php
+++ b/classes/search/pattern/class-contentstructure.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Table displaying patterns usage
+ *
+ * @package P4BKS\Search
+ */
+
+namespace P4GBKS\Search\Pattern;
+
+use WP_Block_Parser;
+
+/**
+ * Prepare pattern usage, using native WordPress table
+ */
+class ContentStructure {
+	/**
+	 * @var WP_Block_Parser
+	 */
+	private $parser;
+
+	/**
+	 * @var string
+	 */
+	private $content;
+
+	/**
+	 * @var array
+	 */
+	private $tree;
+
+	/**
+	 * @var string
+	 */
+	private $signature;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->parser = new WP_Block_Parser();
+	}
+
+	/**
+	 * Parse content as structure.
+	 *
+	 * @param string $content Post content.
+	 */
+	public function parse_content( string $content ): void {
+		$this->content = $content;
+		$this->make_content_tree( $this->content );
+		$this->make_structure_signature( $this->tree );
+	}
+
+	/**
+	 * @return string|null Content
+	 */
+	public function get_content(): ?string {
+		return $this->content;
+	}
+
+	/**
+	 * @return array Content tree
+	 */
+	public function get_content_tree(): array {
+		return $this->tree;
+	}
+
+	/**
+	 * @return string Content signature
+	 */
+	public function get_content_signature(): string {
+		return $this->signature;
+	}
+
+	/**
+	 * Make tree structure from content.
+	 *
+	 * @param string $content Post content.
+	 */
+	public function make_content_tree( string $content ): void {
+		$parsed = $this->parser->parse( $content );
+		$tree   = [];
+		while ( ! empty( $parsed ) ) {
+			/** @var array $block */
+			$block  = array_shift( $parsed );
+			$tree[] = $this->make_tree( $block );
+		}
+
+		$this->tree = array_values( array_filter( $tree ) );
+	}
+
+	/**
+	 * Make signature from tree structure.
+	 *
+	 * @param array $tree Tree.
+	 */
+	public function make_structure_signature( array $tree ): void {
+		$this->normalize_tree_for_signature( $tree );
+		$signature = json_encode( $tree ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+
+		$this->signature = trim( $signature, '[]' );
+	}
+
+	/**
+	 * Normalize tree to remove duplications.
+	 *
+	 * @param array $tree Tree.
+	 */
+	public function normalize_tree_for_signature( array &$tree ) {
+		// No classes in content signature.
+		if ( isset( $tree['classes'] ) ) {
+			unset( $tree['classes'] );
+		}
+
+		foreach ( $tree as $key => &$node ) {
+			// No classes in content signature.
+			if ( isset( $node['classes'] ) ) {
+				unset( $node['classes'] );
+			}
+
+			if ( empty( $node['children'] ) || ! is_array( $node['children'] ) ) {
+				continue;
+			}
+
+			if ( 'core/columns' === $node['name'] ) {
+				$columns_count  = count( $node['children'] );
+				$unique_columns = array_unique( $node['children'], \SORT_REGULAR );
+				$unique_count   = count( $unique_columns );
+
+				if ( 1 === $unique_count && $columns_count > $unique_count ) {
+					$node['children'] = $unique_columns;
+				}
+			}
+
+			if ( 'core/group' === $node['name'] ) {
+				$subgroups_count  = count( $node['children'] );
+				$unique_subgroups = array_unique( $node['children'], \SORT_REGULAR );
+				$unique_count     = count( $unique_subgroups );
+
+				if ( 1 === $unique_count && $subgroups_count > $unique_count ) {
+					$node['children'] = $unique_subgroups;
+				}
+			}
+
+			if ( ! empty( $node['children'] ) ) {
+				$this->normalize_tree_for_signature( $node['children'] );
+			}
+		}
+	}
+
+	/**
+	 * Make blocks tree
+	 *
+	 * @param array $block Block.
+	 *
+	 * @return null|array Tree representation of block content.
+	 */
+	public function make_tree( array $block ): ?array {
+		if ( empty( $block['blockName'] ) ) {
+			return null;
+		}
+
+		return [
+			'name'     => $block['blockName'],
+			'classes'  => array_filter(
+				explode( ' ', $block['attrs']['className'] ?? '' )
+			),
+			'children' => empty( $block['innerBlocks'] )
+				? null
+				: array_values(
+					array_filter(
+						array_map(
+							fn ( $b ) => $this->make_tree( $b ),
+							$block['innerBlocks']
+						)
+					)
+				),
+		];
+	}
+}

--- a/classes/search/pattern/class-patterndata.php
+++ b/classes/search/pattern/class-patterndata.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Pattern search
+ *
+ * @package P4BKS\Search
+ */
+
+namespace P4GBKS\Search\Pattern;
+
+use P4GBKS\Blocks\BlockList;
+use WP_Block_Patterns_Registry;
+
+/**
+ * Container class for pattern data
+ */
+class PatternData {
+
+	// Native properties.
+	// Cf. WP_Block_Patterns_Registry::register().
+
+	/**
+	 * @var string
+	 */
+	public $name;
+
+	/**
+	 * @var string
+	 */
+	public $title;
+
+	/**
+	 * @var string
+	 */
+	public $content;
+
+	/**
+	 * @var ?string
+	 */
+	public $description;
+
+	/**
+	 * @var ?int
+	 */
+	public $viewport_width;
+
+	/**
+	 * @var ?string[]
+	 */
+	public $block_types;
+
+	/**
+	 * @var ?string[]
+	 */
+	public $post_types;
+
+	/**
+	 * @var string[]
+	 */
+	public $keywords;
+
+	// Extended properties.
+
+	/**
+	 * @var string Specific class name for the pattern
+	 */
+	public $classname;
+
+	/**
+	 * @var array Pattern structure
+	 */
+	public $structure;
+
+	/**
+	 * @var string Pattern signature
+	 */
+	public $signature;
+
+	/**
+	 * @var string[] Unique blocks in pattern
+	 */
+	public $block_list;
+
+	/**
+	 * @param string $name Pattern name.
+	 */
+	public static function from_name( string $name ): self {
+		return self::from_pattern(
+			( WP_Block_Patterns_Registry::get_instance() )->get_registered( $name )
+		);
+	}
+
+	/**
+	 * @param array $pattern Pattern data from registry.
+	 */
+	public static function from_pattern( array $pattern ): self {
+		$data = new self();
+
+		$data->name    = $pattern['name'];
+		$data->title   = $pattern['title'];
+		$data->content = $pattern['content'] ?? '';
+
+		$data->description    = $pattern['description'] ?? null;
+		$data->viewport_width = $pattern['viewportWidth'] ?? null;
+		$data->block_types    = $pattern['blockTypes'] ?? null;
+		$data->post_types     = $pattern['postTypes'] ?? null;
+		$data->keywords       = $pattern['keywords'] ?? null;
+
+		$struct = new ContentStructure();
+		$struct->parse_content( $data->content );
+
+		$data->structure  = $struct->get_content_tree();
+		$data->signature  = $struct->get_content_signature();
+		$data->block_list = BlockList::parse_block_list( $data->content );
+		$data->classname  = self::make_classname( $data->name );
+
+		return $data;
+	}
+
+	/**
+	 * @param string $name Pattern name.
+	 */
+	public static function make_classname( string $name ): string {
+		return 'is_pattern-' . preg_replace( '#[^_a-zA-Z0-9-]#', '_', $name );
+	}
+}

--- a/classes/search/pattern/class-patterndata.php
+++ b/classes/search/pattern/class-patterndata.php
@@ -120,6 +120,6 @@ class PatternData {
 	 * @param string $name Pattern name.
 	 */
 	public static function make_classname( string $name ): string {
-		return 'is_pattern-' . preg_replace( '#[^_a-zA-Z0-9-]#', '_', $name );
+		return 'is-pattern-' . preg_replace( '#[^_a-zA-Z0-9-]#', '-', $name );
 	}
 }

--- a/classes/search/pattern/class-patternusage.php
+++ b/classes/search/pattern/class-patternusage.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Table displaying patterns usage
+ *
+ * @package P4BKS\Search
+ */
+
+namespace P4GBKS\Search\Pattern;
+
+use WP_Block_Parser;
+use WP_Block_Patterns_Registry;
+use WP_Post;
+use P4GBKS\Search\PatternSearch;
+use P4GBKS\Search\Pattern\Query\Parameters;
+
+/**
+ * Prepare pattern usage, using native WordPress table
+ */
+class PatternUsage {
+	/**
+	 * @var PatternSearch
+	 */
+	private $search;
+
+	/**
+	 * @var WP_Block_Parser
+	 */
+	private $parser;
+
+	/**
+	 * @var WP_Block_Patterns_Registry
+	 */
+	private $registry;
+
+	/**
+	 * @param PatternSearch|null   $search Search class.
+	 * @param WP_Block_Parser|null $parser Block parser.
+	 */
+	public function __construct(
+		?PatternSearch $search = null,
+		?WP_Block_Parser $parser = null
+	) {
+		$this->search   = $search ?? new PatternSearch();
+		$this->parser   = $parser ?? new WP_Block_Parser();
+		$this->registry = WP_Block_Patterns_Registry::get_instance();
+	}
+
+	/**
+	 * @param Parameters $params Search parameters.
+	 * @return array
+	 */
+	public function get_patterns( Parameters $params ): array {
+		$posts_ids = $this->search->get_posts( $params );
+
+		return $this->get_filtered_patterns( $posts_ids, $params );
+	}
+
+	/**
+	 * @param int[]      $posts_ids Posts ids.
+	 * @param Parameters $params    Search parameters.
+	 * @return array
+	 */
+	private function get_filtered_patterns( array $posts_ids, Parameters $params ): array {
+		$chunks = array_chunk( $posts_ids, 50 );
+
+		$post_args = [
+			'orderby'     => empty( $params->order() ) ? null : array_fill_keys( $params->order(), 'ASC' ),
+			'post_status' => $params->post_status(),
+			'post_type'   => $params->post_type(),
+		];
+
+		$patterns = [];
+		foreach ( $chunks as $chunk ) {
+			/** @var WP_Post[] $posts */
+			$posts = get_posts( array_merge( [ 'include' => $chunk ], $post_args ) );
+
+			foreach ( $posts as $post ) {
+				$post_struct = new ContentStructure();
+				$post_struct->parse_content( $post->post_content ?? '' );
+
+				foreach ( $params->name() as $pattern_name ) {
+					$pattern = PatternData::from_name( $pattern_name );
+
+					// struct matches.
+					$struct_occ = substr_count(
+						$post_struct->get_content_signature(),
+						$pattern->signature
+					);
+					if ( $struct_occ > 0 ) {
+						$patterns[] = $this->format_pattern_data(
+							$pattern,
+							$post,
+							$struct_occ,
+							'structure'
+						);
+					}
+
+					// class matches.
+					$class_occ = round(
+						substr_count( $post->post_content, $pattern->classname ) / 2
+					);
+					if ( $class_occ > 0 ) {
+						$patterns[] = $this->format_pattern_data(
+							$pattern,
+							$post,
+							$class_occ,
+							'classname'
+						);
+					}
+				}
+			}
+		}
+
+		return $patterns;
+	}
+
+	/**
+	 * @param PatternData $pattern     PatternData   Pattern.
+	 * @param WP_Post     $post        WP_Post Post.
+	 * @param int         $occurrences Pattern occurrences.
+	 * @param string      $match_type  Match type.
+	 */
+	private function format_pattern_data(
+		PatternData $pattern,
+		WP_Post $post,
+		int $occurrences,
+		string $match_type
+	): array {
+		return [
+			'post_title'    => $post->post_title,
+			'pattern_name'  => $pattern->name,
+			'pattern_title' => $pattern->title,
+			'pattern_occ'   => $occurrences ?? 1,
+			'post_date'     => $post->post_date,
+			'post_modified' => $post->post_modified,
+			'post_id'       => $post->ID,
+			'post_status'   => $post->post_status,
+			'match_type'    => $match_type,
+		];
+	}
+}

--- a/classes/search/pattern/class-patternusageapi.php
+++ b/classes/search/pattern/class-patternusageapi.php
@@ -73,9 +73,12 @@ class PatternUsageApi {
 	 * Get all patterns names
 	 */
 	private function pattern_names(): array {
-		return array_column(
-			( WP_Block_Patterns_Registry::get_instance() )->get_all_registered(),
-			'name'
+		return array_filter(
+			array_column(
+				( WP_Block_Patterns_Registry::get_instance() )->get_all_registered(),
+				'name'
+			),
+			fn ( $name ) => 'p4/blank-page' !== $name
 		);
 	}
 

--- a/classes/search/pattern/class-patternusageapi.php
+++ b/classes/search/pattern/class-patternusageapi.php
@@ -8,6 +8,7 @@
 namespace P4GBKS\Search\Pattern;
 
 use WP_Block_Patterns_Registry;
+use P4GBKS\Patterns\BlankPage;
 use P4GBKS\Search\Pattern\Query\Parameters;
 
 /**
@@ -78,7 +79,7 @@ class PatternUsageApi {
 				( WP_Block_Patterns_Registry::get_instance() )->get_all_registered(),
 				'name'
 			),
-			fn ( $name ) => 'p4/blank-page' !== $name
+			fn ( $name ) => BlankPage::get_name() !== $name
 		);
 	}
 

--- a/classes/search/pattern/class-patternusageapi.php
+++ b/classes/search/pattern/class-patternusageapi.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Table displaying blocks usage
+ *
+ * @package P4BKS\Search
+ */
+
+namespace P4GBKS\Search\Pattern;
+
+use WP_Block_Patterns_Registry;
+use P4GBKS\Search\Pattern\Query\Parameters;
+
+/**
+ * Pattern usage API
+ */
+class PatternUsageApi {
+
+	public const DEFAULT_POST_STATUS = [ 'publish' ];
+
+	/**
+	 * @var PatternUsage
+	 */
+	private $usage;
+
+	/**
+	 * @var Parameters
+	 */
+	private $params;
+
+	/**
+	 * @var array[] Blocks.
+	 */
+	private $items;
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		$this->usage  = new PatternUsage();
+		$this->params = ( new Parameters() )
+			->with_name( $this->pattern_names() )
+			->with_post_type( $this->allowed_post_types() )
+			->with_post_status( self::DEFAULT_POST_STATUS );
+	}
+
+	/**
+	 * Count patterns
+	 */
+	public function get_count(): array {
+		if ( null === $this->items ) {
+			$this->fetch_items();
+		}
+
+		$names    = $this->pattern_names();
+		$patterns = array_fill_keys( $names, [ 'total' => 0 ] );
+		ksort( $patterns );
+
+		foreach ( $this->items as $item ) {
+			$patterns[ $item['pattern_name'] ]['total']++;
+		}
+
+		return $patterns;
+	}
+
+	/**
+	 * Fetch parsed blocks
+	 */
+	private function fetch_items(): void {
+		$this->items = $this->usage->get_patterns( $this->params );
+	}
+
+	/**
+	 * Get all patterns names
+	 */
+	private function pattern_names(): array {
+		return array_column(
+			( WP_Block_Patterns_Registry::get_instance() )->get_all_registered(),
+			'name'
+		);
+	}
+
+	/**
+	 * Get post types that can contain patterns
+	 *
+	 * @return string[]
+	 */
+	private function allowed_post_types(): array {
+		return array_filter(
+			get_post_types( [ 'show_in_rest' => true ] ),
+			fn ( $t ) => post_type_supports( $t, 'editor' )
+		);
+	}
+}

--- a/classes/search/pattern/class-patternusagetable.php
+++ b/classes/search/pattern/class-patternusagetable.php
@@ -10,6 +10,7 @@ namespace P4GBKS\Search\Pattern;
 use InvalidArgumentException;
 use WP_List_Table;
 use WP_Block_Patterns_Registry;
+use P4GBKS\Patterns\BlankPage;
 use P4GBKS\Search\RowActions;
 use P4GBKS\Search\Pattern\Query\Parameters;
 
@@ -99,7 +100,7 @@ class PatternUsageTable extends WP_List_Table {
 				$this->pattern_registry->get_all_registered(),
 				'name'
 			),
-			fn ( $name ) => 'p4/blank-page' !== $name
+			fn ( $name ) => BlankPage::get_name() !== $name
 		);
 	}
 
@@ -170,7 +171,9 @@ class PatternUsageTable extends WP_List_Table {
 		$filter = $this->search_params->name() ?? [];
 
 		echo '<select name="name" id="filter-by-name">';
-		echo '<option value="">- All patterns -</option>';
+		echo '<option value="">'
+			. esc_html( __( '- All patterns -', 'planet4-blocks-backend' ) )
+			. '</option>';
 		foreach ( $this->pattern_names as $name ) {
 			echo sprintf(
 				'<option value="%s" %s>%s</option>',
@@ -276,17 +279,17 @@ class PatternUsageTable extends WP_List_Table {
 			'pattern_name' => sprintf(
 				'pattern_name' === $this->group_by ? $active_link_tpl : $link_tpl,
 				add_query_arg( 'group', 'pattern_name' ),
-				'Group by pattern name'
+				__( 'Group by pattern name', 'planet4-blocks-backend' )
 			),
 			'post_title'   => sprintf(
 				'post_title' === $this->group_by ? $active_link_tpl : $link_tpl,
 				add_query_arg( 'group', 'post_title' ),
-				'Group by post title'
+				__( 'Group by post title', 'planet4-blocks-backend' )
 			),
 			'post_id'      => sprintf(
 				'post_id' === $this->group_by ? $active_link_tpl : $link_tpl,
 				add_query_arg( 'group', 'post_id' ),
-				'Group by post ID'
+				__( 'Group by post ID', 'planet4-blocks-backend' )
 			),
 		];
 	}

--- a/classes/search/pattern/class-patternusagetable.php
+++ b/classes/search/pattern/class-patternusagetable.php
@@ -1,0 +1,402 @@
+<?php
+/**
+ * Table displaying patterns usage
+ *
+ * @package P4BKS\Search
+ */
+
+namespace P4GBKS\Search\Pattern;
+
+use InvalidArgumentException;
+use WP_List_Table;
+use WP_Block_Patterns_Registry;
+use P4GBKS\Search\RowActions;
+use P4GBKS\Search\Pattern\Query\Parameters;
+
+if ( ! class_exists( 'WP_List_Table' ) ) {
+	require_once ABSPATH . '/wp-admin/includes/class-wp-list-table.php';
+}
+
+/**
+ * Show pattern usage, using native WordPress table
+ */
+class PatternUsageTable extends WP_List_Table {
+
+	public const ACTION_NAME = 'pattern_usage';
+
+	public const DEFAULT_GROUP_BY = 'pattern_name';
+
+	public const DEFAULT_POST_STATUS = [ 'publish', 'private', 'draft', 'pending', 'future' ];
+
+	public const PLURAL = 'patterns';
+
+	/**
+	 * @var PatternUsage
+	 */
+	private $pattern_usage;
+
+	/**
+	 * @var array
+	 */
+	private $pattern_registry;
+
+	/**
+	 * @var Parameters Search filters requested.
+	 */
+	private $search_params;
+
+	/**
+	 * @var string Group column.
+	 */
+	private $group_by = self::DEFAULT_GROUP_BY;
+
+	/**
+	 * @var string[]
+	 */
+	private $allowed_groups = [ 'pattern_name', 'post_id', 'post_title' ];
+
+	/**
+	 * @var string[]|null Columns name => title.
+	 */
+	private $columns = null;
+
+	/**
+	 * @var string|null Latest row content displayed.
+	 */
+	private $latest_row = null;
+
+	/**
+	 * @var string[]|null Pattern names.
+	 */
+	private $pattern_names = null;
+
+
+	/**
+	 * @param array $args Args.
+	 * @throws InvalidArgumentException Throws on missing parameter.
+	 * @see WP_List_Table::__construct()
+	 */
+	public function __construct( $args = [] ) {
+		$args['plural'] = self::PLURAL;
+		parent::__construct( $args );
+
+		$this->pattern_usage    = $args['pattern_usage'] ?? null;
+		$this->pattern_registry = $args['pattern_registry'] ?? null;
+
+		if ( ! ( $this->pattern_usage instanceof PatternUsage ) ) {
+			throw new InvalidArgumentException(
+				'Table requires a PatternUsage instance.'
+			);
+		}
+		if ( ! ( $this->pattern_registry instanceof WP_Block_Patterns_Registry ) ) {
+			throw new InvalidArgumentException(
+				'Table requires a WP_Block_Patterns_Registry instance.'
+			);
+		}
+
+		$this->pattern_names = array_column(
+			$this->pattern_registry->get_all_registered(),
+			'name'
+		);
+	}
+
+	/**
+	 * @param null|Parameters $search_params Search parameters.
+	 * @param null|string     $group_by      Group.
+	 */
+	public function prepare_items(
+		?Parameters $search_params = null,
+		?string $group_by = null
+	): void {
+		if ( in_array( $group_by, $this->allowed_groups, true ) ) {
+			$this->group_by = $group_by;
+		}
+
+		$this->search_params = $search_params
+			->with_post_type( $this->allowed_post_types() )
+			->with_post_status( self::DEFAULT_POST_STATUS );
+
+		$items = $this->get_items();
+		usort( $items, fn ( $a, $b ) => $a[ $this->group_by ] <=> $b[ $this->group_by ] );
+
+		// Pagination handling.
+		$total_items  = count( $items );
+		$per_page     = 50;
+		$current_page = $this->get_pagenum();
+		$this->items  = array_slice( $items, ( ( $current_page - 1 ) * $per_page ), $per_page );
+		$this->set_pagination_args(
+			[
+				'total_items' => $total_items,
+				'per_page'    => $per_page,
+				'total_pages' => ceil( $total_items / $per_page ),
+			]
+		);
+
+		$this->_column_headers = $this->get_column_headers();
+	}
+
+	/**
+	 * Get patterns to display
+	 */
+	private function get_items(): array {
+		$search_params = clone $this->search_params;
+		if ( empty( $search_params->name() ) ) {
+			$search_params = $search_params->with_name(
+				array_column(
+					( WP_Block_Patterns_Registry::get_instance() )->get_all_registered(),
+					'name'
+				)
+			);
+		}
+
+		return $this->pattern_usage->get_patterns( $search_params );
+	}
+
+	/**
+	 * Allowed post types to search for
+	 */
+	private function allowed_post_types(): array {
+		return array_filter(
+			get_post_types( [ 'show_in_rest' => true ] ),
+			fn ( $t ) => post_type_supports( $t, 'editor' )
+		);
+	}
+
+	/**
+	 * Pattern select
+	 */
+	private function patternname_dropdown() {
+		sort( $this->pattern_names );
+		$filter = $this->search_params->name() ?? [];
+
+		echo '<select name="name" id="filter-by-name">';
+		echo '<option value="">- All patterns -</option>';
+		foreach ( $this->pattern_names as $name ) {
+			echo sprintf(
+				'<option value="%s" %s>%s</option>',
+				esc_attr( $name ),
+				esc_attr( in_array( $name, $filter, true ) ? 'selected' : '' ),
+				esc_html( $name )
+			);
+		}
+		echo '</select>';
+	}
+
+	/**
+	 * Add filters to table.
+	 *
+	 * @param string $which Tablenav identifier.
+	 */
+	protected function extra_tablenav( $which ) {
+		echo '<div class="actions">';
+		$this->patternname_dropdown();
+		submit_button(
+			__( 'Filter', 'planet4-blocks-backend' ),
+			'',
+			'filter_action',
+			false,
+			[ 'id' => 'pattern-query-submit' ]
+		);
+		echo '</div>';
+	}
+
+	/**
+	 * Add pagination information to table.
+	 *
+	 * @param string $which Tablenav identifier.
+	 */
+	protected function pagination( $which ) {
+		parent::pagination( 'top' );
+	}
+
+	/**
+	 * Show only top tablenav (duplicate form post bug)
+	 *
+	 * @param string $which Tablenav identifier.
+	 */
+	protected function display_tablenav( $which ) {
+		if ( 'bottom' === $which ) {
+			echo '<div class="tablenav bottom">';
+			parent::pagination( $which );
+			echo '</div>';
+			return;
+		}
+		parent::display_tablenav( $which );
+	}
+
+	/**
+	 * Add action links to a row
+	 *
+	 * @param array  $item        Item.
+	 * @param string $column_name Current column name.
+	 * @param string $primary     Primary column name.
+	 *
+	 * phpcs:disable WordPress.WP.I18n.TextDomainMismatch
+	 */
+	protected function handle_row_actions( $item, $column_name, $primary ) {
+		return $this->row_actions(
+			( new RowActions() )->get_post_actions( $item, $column_name, $primary )
+		);
+	}
+
+	/**
+	 * Columns list for table.
+	 */
+	public function get_columns() {
+		if ( null !== $this->columns ) {
+			return $this->columns;
+		}
+
+		$default_columns = [
+			'pattern_name'  => 'Pattern',
+			'post_title'    => 'Title',
+			'match_type'    => 'Match',
+			'pattern_occ'   => 'Count',
+			'post_date'     => 'Created',
+			'post_modified' => 'Modified',
+			'post_id'       => 'ID',
+			'post_status'   => 'Status',
+		];
+
+		$this->columns = array_merge(
+			[ $this->group_by => $default_columns[ $this->group_by ] ],
+			$default_columns
+		);
+
+		return $this->columns;
+	}
+
+	/**
+	 * Available grouping as views.
+	 */
+	protected function get_views() {
+		$link_tpl        = '<a href="%s">%s</a>';
+		$active_link_tpl = '<a class="current" href="%s">%s</a>';
+		return [
+			'pattern_name' => sprintf(
+				'pattern_name' === $this->group_by ? $active_link_tpl : $link_tpl,
+				add_query_arg( 'group', 'pattern_name' ),
+				'Group by pattern name'
+			),
+			'post_title'   => sprintf(
+				'post_title' === $this->group_by ? $active_link_tpl : $link_tpl,
+				add_query_arg( 'group', 'post_title' ),
+				'Group by post title'
+			),
+			'post_id'      => sprintf(
+				'post_id' === $this->group_by ? $active_link_tpl : $link_tpl,
+				add_query_arg( 'group', 'post_id' ),
+				'Group by post ID'
+			),
+		];
+	}
+
+	/**
+	 * All, hidden and sortable columns.
+	 */
+	private function get_column_headers() {
+		return [
+			$this->get_columns(),
+			[],
+			[ 'post_title', 'post_date', 'post_modified' ],
+		];
+	}
+
+	/**
+	 * Post title display.
+	 *
+	 * @param array $item Item.
+	 * @return string
+	 */
+	public function column_post_title( $item ): string {
+		$content = $item['post_title'] ?? null;
+		if ( empty( $content ) ) {
+			return '';
+		}
+
+		$title_tpl = '%2$s';
+		$link_tpl  = '<a href="%s" title="%s">%s</a>';
+		$page_uri  = get_page_uri( $item['post_id'] );
+
+		return sprintf(
+			empty( $page_uri ) ? $title_tpl : $link_tpl,
+			$page_uri,
+			esc_attr( $content ),
+			( strlen( $content ) > 45 ? substr( $content, 0, 45 ) . '...' : $content )
+		);
+	}
+
+	/**
+	 * Full row display, edited for grouping functionality.
+	 *
+	 * @param array $item Item.
+	 */
+	public function single_row( $item ) {
+		$cols      = $this->get_columns();
+		$colspan   = count( $cols );
+		$first_col = array_key_first( $cols );
+
+		if ( $this->latest_row !== $item[ $first_col ] ) {
+			echo '<tr>';
+			echo sprintf(
+				'<th colspan="%s"><strong>%s</strong></th>',
+				esc_attr( $colspan ),
+				esc_html( $item[ $first_col ] )
+			);
+			echo '</tr>';
+		}
+
+		$this->latest_row   = $item[ $first_col ];
+		$item[ $first_col ] = '';
+		parent::single_row( $item );
+	}
+
+	/**
+	 * Default column value representation.
+	 *
+	 * @param array  $item Item.
+	 * @param string $column_name Column name.
+	 *
+	 * @return mixed
+	 */
+	public function column_default( $item, $column_name ) {
+		return $item[ $column_name ] ?? '';
+	}
+
+	/**
+	 * Table URL
+	 */
+	public static function url(): string {
+		return admin_url( 'admin.php?page=plugin_patterns_report' );
+	}
+
+	/**
+	 * Add redirection for filter action
+	 */
+	public static function set_hooks(): void {
+		add_action(
+			'admin_action_' . self::ACTION_NAME,
+			function () {
+				$nonce = $_GET['_wpnonce'] ?? null;
+				if ( ! \wp_verify_nonce( $nonce, 'bulk-' . self::PLURAL ) ) {
+					\wp_safe_redirect( self::url() );
+					exit;
+				}
+
+				$redirect_query = remove_query_arg(
+					[ '_wp_http_referer', '_wpnonce', 'action', 'filter_action' ],
+					\wp_parse_url( $_SERVER['REQUEST_URI'], \PHP_URL_QUERY )
+				);
+				\parse_str( $redirect_query, $args );
+				$args = array_filter(
+					$args,
+					fn( $e ) => ! empty( $e ) && '0' !== $e
+				);
+
+				\wp_safe_redirect( add_query_arg( $args, self::url() ) );
+				exit;
+			},
+			10
+		);
+	}
+}

--- a/classes/search/pattern/class-patternusagetable.php
+++ b/classes/search/pattern/class-patternusagetable.php
@@ -94,9 +94,12 @@ class PatternUsageTable extends WP_List_Table {
 			);
 		}
 
-		$this->pattern_names = array_column(
-			$this->pattern_registry->get_all_registered(),
-			'name'
+		$this->pattern_names = array_filter(
+			array_column(
+				$this->pattern_registry->get_all_registered(),
+				'name'
+			),
+			fn ( $name ) => 'p4/blank-page' !== $name
 		);
 	}
 
@@ -142,10 +145,7 @@ class PatternUsageTable extends WP_List_Table {
 		$search_params = clone $this->search_params;
 		if ( empty( $search_params->name() ) ) {
 			$search_params = $search_params->with_name(
-				array_column(
-					( WP_Block_Patterns_Registry::get_instance() )->get_all_registered(),
-					'name'
-				)
+				$this->pattern_names
 			);
 		}
 

--- a/classes/search/pattern/query/class-parameters.php
+++ b/classes/search/pattern/query/class-parameters.php
@@ -134,14 +134,14 @@ class Parameters {
 	 * List of required post status.
 	 */
 	public function post_status(): ?array {
-		return $this->post_status ? $this->post_status : self::DEFAULT_POST_STATUS;
+		return $this->post_status ?? self::DEFAULT_POST_STATUS;
 	}
 
 	/**
 	 * List of required post types.
 	 */
 	public function post_type(): ?array {
-		return $this->post_type ? $this->post_type : null;
+		return $this->post_type ?? null;
 	}
 
 	/**

--- a/classes/search/pattern/query/class-parameters.php
+++ b/classes/search/pattern/query/class-parameters.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Pattern search query parameters
+ *
+ * @package P4BKS\Search
+ */
+
+namespace P4GBKS\Search\Pattern\Query;
+
+/**
+ * Parameter bag for Query interface
+ *
+ * @method self with_name(string[] $name)
+ * @method self with_post_status(string[] $status)
+ * @method self with_post_type(string[] $type)
+ * @method self with_order(string[] $order)
+ */
+class Parameters {
+	/**
+	 * @var string[]
+	 */
+	private $name;
+
+	/**
+	 * @var string[]
+	 */
+	private $post_status;
+
+	/**
+	 * @var string[]
+	 */
+	private $post_type;
+
+	/**
+	 * @var string[]
+	 */
+	private $order;
+
+	/**
+	 * @var string[]
+	 */
+	private const DEFAULT_POST_STATUS = [ 'publish', 'private' ];
+
+	/**
+	 * Generate a query param object from an array.
+	 *
+	 * @param array $params The parameters.
+	 *
+	 * @return self Parameters
+	 */
+	public static function from_array( array $params ): self {
+		$query = new self();
+
+		foreach ( $params as $field => $value ) {
+			if ( null === $value ) {
+				continue;
+			}
+
+			$query = $query->with( $field, $value );
+		}
+
+		return $query;
+	}
+
+	/**
+	 * Generate query param object from HTTP request.
+	 *
+	 * @param array $request The request parameters.
+	 *
+	 * @return self Parameters
+	 */
+	public static function from_request( array $request ): self {
+		$name = $request['name'] ?? null;
+		if ( $name ) {
+			$name = is_array( $name ) ? $name : [ $name ];
+		}
+
+		return self::from_array(
+			[
+				'name'        => $name,
+				'post_status' => $request['post_status'] ?? self::DEFAULT_POST_STATUS,
+				'post_type'   => $request['post_type'] ?? null,
+				'order'       => $request['order'] ?? null,
+			]
+		);
+	}
+
+	/**
+	 *
+	 *
+	 * @param string $name The name.
+	 * @param array  $args The arguments.
+	 *
+	 * @return Parameters
+	 * @throws \BadMethodCallException Method does not exist.
+	 */
+	public function __call( string $name, array $args ) {
+		if ( strpos( $name, 'with_' ) === 0 ) {
+			$property = substr( $name, 5 );
+			return $this->with( $property, $args[0] );
+		}
+
+		throw new \BadMethodCallException( 'Method ' . $name . ' does not exist.' );
+	}
+
+	/**
+	 * Sets parameter
+	 *
+	 * @param string $name  The name.
+	 * @param mixed  $value The value.
+	 *
+	 * @throws \BadMethodCallException Property not allowed.
+	 *
+	 * @return self Immutable parameter object.
+	 */
+	public function with( string $name, $value = null ): self {
+		$allowed = [ 'name', 'post_status', 'post_type', 'order' ];
+		if ( ! in_array( $name, $allowed, true ) ) {
+			throw new \BadMethodCallException( 'Property ' . $name . ' does not exist.' );
+		}
+
+		$this->$name = $value ?? null;
+		return $this;
+	}
+
+	/**
+	 * Pattern name.
+	 */
+	public function name(): ?array {
+		return $this->name;
+	}
+
+	/**
+	 * List of required post status.
+	 */
+	public function post_status(): ?array {
+		return $this->post_status ? $this->post_status : self::DEFAULT_POST_STATUS;
+	}
+
+	/**
+	 * List of required post types.
+	 */
+	public function post_type(): ?array {
+		return $this->post_type ? $this->post_type : null;
+	}
+
+	/**
+	 * Columns names to sort on.
+	 */
+	public function order(): ?array {
+		return $this->order;
+	}
+}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6782

> Since we keep adding block patterns, it would be a good data point for assessing them at a later point to know how often each pattern is being used.

## Pattern report

![Screenshot from 2022-07-05 11-40-33](https://user-images.githubusercontent.com/617346/177299577-c611cdc3-fa38-4ad6-aaf6-146b298791b7.png)
Pattern report accessible in _Blocks > Pattern report (Beta)_

- List of patterns, with post informations
- Filter by pattern
- Group by pattern, post title, post id

### Pattern detection

This version uses 2 types of detection:
- by class name
  Each pattern has a `is-pattern-{pattern name}` class assigned to it, so that it is easily found in the database.
  This allows to see usage _and_ find modifications applied to patterns.
- by structure
  We match the blocks and inner blocks of the pattern to a post content, to see if the pattern is in the post.
  We generate a "signature" from the structure of blocks (basically a json_encode of a tree of blocks), and try to find that signature in a post.
  It is a lot more CPU intensive, but seems to be the only way to detect patterns inserted before the use of a specific class names.

The short term goal is to append the proper class to the existing patterns in production, so we can drop the "structure matching" detection. This will remove the current double detection issue (a pattern will appear twice if it's detected by both methods).


## Test

Test [on Nix](https://www-dev.greenpeace.org/test-nix/wp-admin/admin.php?page=plugin_patterns_report)
Also test the block rest API, it should include a `block_patterns` section
```console
> curl -k https://www-dev.greenpeace.org/test-nix/wp-json/plugin_blocks/v3/plugin_blocks_report/ | jq
```