### PR TITLE
Add Pages block pattern category

### DIFF
--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -87,7 +87,7 @@ final class Loader {
 		new Blocks\HubspotForm();
 
 		/**
-		 * Create block patterns category 'Planet 4'.
+		 * Create Planet 4 block patterns categories.
 		*/
 		if ( ! function_exists( 'register_block_pattern_category' ) ) {
 			return;
@@ -96,6 +96,11 @@ final class Loader {
 		register_block_pattern_category(
 			'planet4',
 			[ 'label' => __( 'Planet 4', 'planet4-blocks-backend' ) ],
+		);
+
+		register_block_pattern_category(
+			'pages',
+			[ 'label' => __( 'Pages', 'planet4-blocks-backend' ) ],
 		);
 
 		// Load block patterns.


### PR DESCRIPTION
### Description

This is needed for the new pages templates, such as [PLANET-6529](https://jira.greenpeace.org/browse/PLANET-6529) and [PLANET-6523](https://jira.greenpeace.org/browse/PLANET-6523)

**Note:** it won't appear in the editor yet because it's empty for now, I'm adding it in a separate PR because we might need to make similar changes for the Page Header patterns.
