### PR TITLE
Add parameters to block patterns get_config function

### DIFF
--- a/classes/patterns/class-block-pattern.php
+++ b/classes/patterns/class-block-pattern.php
@@ -21,8 +21,10 @@ abstract class Block_Pattern {
 
 	/**
 	 * Returns the pattern config.
+	 *
+	 * @param array $params Optional array of parameters for the config.
 	 */
-	abstract public static function get_config(): array;
+	abstract public static function get_config( $params = [] ): array;
 
 	/**
 	 * Pattern constructor.

--- a/classes/patterns/class-deepdive.php
+++ b/classes/patterns/class-deepdive.php
@@ -54,8 +54,10 @@ class DeepDive extends Block_Pattern {
 	/**
 	 * Returns the pattern config.
 	 * We start with 4 columns, but editors can easily remove and/or duplicate them.
+	 *
+	 * @param array $params Optional array of parameters for the config.
 	 */
-	public static function get_config(): array {
+	public static function get_config( $params = [] ): array {
 		return [
 			'title'      => __( 'Deep Dive', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],

--- a/classes/patterns/class-highlightedcta.php
+++ b/classes/patterns/class-highlightedcta.php
@@ -24,8 +24,10 @@ class HighlightedCta extends Block_Pattern {
 
 	/**
 	 * Returns the pattern config.
+	 *
+	 * @param array $params Optional array of parameters for the config.
 	 */
-	public static function get_config(): array {
+	public static function get_config( $params = [] ): array {
 		return [
 			'title'      => __( 'Highlighted CTA', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],

--- a/classes/patterns/class-issues.php
+++ b/classes/patterns/class-issues.php
@@ -42,8 +42,10 @@ class Issues extends Block_Pattern {
 
 	/**
 	 * Returns the pattern config.
+	 *
+	 * @param array $params Optional array of parameters for the config.
 	 */
-	public static function get_config(): array {
+	public static function get_config( $params = [] ): array {
 		return [
 			'title'      => __( 'Issues', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],

--- a/classes/patterns/class-quicklinks.php
+++ b/classes/patterns/class-quicklinks.php
@@ -63,8 +63,10 @@ class QuickLinks extends Block_Pattern {
 	/**
 	 * Returns the pattern config.
 	 * We start with 6 columns, but editors can easily remove and/or duplicate them.
+	 *
+	 * @param array $params Optional array of parameters for the config.
 	 */
-	public static function get_config(): array {
+	public static function get_config( $params = [] ): array {
 		return [
 			'title'      => __( 'Quick Links', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],

--- a/classes/patterns/class-realitycheck.php
+++ b/classes/patterns/class-realitycheck.php
@@ -53,8 +53,10 @@ class RealityCheck extends Block_Pattern {
 	/**
 	 * Returns the pattern config.
 	 * We start with 3 columns, but editors can easily remove and/or duplicate them.
+	 *
+	 * @param array $params Optional array of parameters for the config.
 	 */
-	public static function get_config(): array {
+	public static function get_config( $params = [] ): array {
 		return [
 			'title'      => __( 'Reality Check', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],

--- a/classes/patterns/class-sideimagewithtextandcta.php
+++ b/classes/patterns/class-sideimagewithtextandcta.php
@@ -24,8 +24,10 @@ class SideImageWithTextAndCta extends Block_Pattern {
 
 	/**
 	 * Returns the pattern config.
+	 *
+	 * @param array $params Optional array of parameters for the config.
 	 */
-	public static function get_config(): array {
+	public static function get_config( $params = [] ): array {
 		$media_link = esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-546x415.jpg';
 		return [
 			'title'      => __( 'Side image with text and CTA', 'planet4-blocks-backend' ),

--- a/classes/patterns/class-sideimagewithtextandcta.php
+++ b/classes/patterns/class-sideimagewithtextandcta.php
@@ -28,13 +28,14 @@ class SideImageWithTextAndCta extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
-		$media_link = esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-546x415.jpg';
+		$media_link           = esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-546x415.jpg';
+		$media_position_class = ! empty( $params ) && 'right' === $params['media_position'] ? 'has-media-on-the-right' : '';
 		return [
 			'title'      => __( 'Side image with text and CTA', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],
 			'content'    => '
-				<!-- wp:media-text {"mediaLink":"' . $media_link . '","mediaType":"image","className":"block"} -->
-					<div class="wp-block-media-text alignwide is-stacked-on-mobile block">
+				<!-- wp:media-text {"mediaLink":"' . $media_link . '","mediaType":"image","className":"block ' . $media_position_class . '"} -->
+					<div class="wp-block-media-text alignwide is-stacked-on-mobile block ' . $media_position_class . '">
 						<figure class="wp-block-media-text__media">
 							<img src="' . $media_link . '" alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '"/>
 						</figure>


### PR DESCRIPTION
### Description

This is needed for some of our page templates that need certain patterns variations, such as the [Get Informed one](https://jira.greenpeace.org/browse/PLANET-6523) that needs a variation of the "Side image with text and CTA" pattern where the image is on the right. This new parameter is also included in this PR.