### PR TITLE
PLANET-6529 Create Action pattern layout

### DIFF
--- a/assets/src/blocks/ActionPageDummy/ActionPageDummyBlock.js
+++ b/assets/src/blocks/ActionPageDummy/ActionPageDummyBlock.js
@@ -1,0 +1,13 @@
+const { registerBlockType } = wp.blocks;
+
+export const registerActionPageDummyBlock = () => {
+  registerBlockType('planet4-blocks/action-page-dummy', {
+    title: 'Action Page Dummy',
+    category: 'planet4-blocks',
+    supports: {
+      inserter: false,
+    },
+    edit: () => null,
+    save: () => null,
+  });
+};

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -22,6 +22,7 @@ import { blockEditorValidation } from './BlockEditorValidation';
 import { registerGuestBookBlock } from './blocks/GuestBook/GuestBookBlock';
 import { registerBlock as registerShareButtonsBlock } from './blocks/ShareButtons/ShareButtonsBlock';
 import { registerPageHeaderBlock } from './blocks/PageHeader/PageHeaderBlock';
+import { registerActionPageDummyBlock } from './blocks/ActionPageDummy/ActionPageDummyBlock';
 
 blockEditorValidation();
 new ArticlesBlock();
@@ -41,6 +42,7 @@ registerTimelineBlock();
 registerGuestBookBlock();
 registerShareButtonsBlock();
 registerPageHeaderBlock();
+registerActionPageDummyBlock();
 
 addBlockFilters();
 setupImageBlockExtension();

--- a/classes/blocks/class-actionpagedummy.php
+++ b/classes/blocks/class-actionpagedummy.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * ActionPageDummy block class.
+ *
+ * @package P4GBKS
+ * @since 0.1
+ */
+
+namespace P4GBKS\Blocks;
+
+/**
+ * Class ActionPageDummy
+ *
+ * @package P4GBKS\Blocks
+ */
+class ActionPageDummy extends Base_Block {
+
+	/**
+	 * Block name.
+	 *
+	 * @const string BLOCK_NAME.
+	 */
+	const BLOCK_NAME = 'action-page-dummy';
+
+	/**
+	 * ActionPageDummy constructor.
+	 */
+	public function __construct() {
+		add_action( 'init', [ $this, 'register_actionpagedummy_block' ] );
+	}
+
+	/**
+	 * Register ActionPageDummy block.
+	 */
+	public function register_actionpagedummy_block() {
+		register_block_type(
+			self::get_full_block_name(),
+		);
+	}
+
+	/**
+	 * Required by the `Base_Block` class.
+	 *
+	 * @param array $fields Unused, required by the abstract function.
+	 */
+	public function prepare_data( $fields ): array {
+		return [];
+	}
+}

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -85,6 +85,7 @@ final class Loader {
 		new Blocks\ENForm();
 		new Blocks\GuestBook();
 		new Blocks\HubspotForm();
+		new Blocks\ActionPageDummy();
 
 		/**
 		 * Create Planet 4 block patterns categories.

--- a/classes/patterns/class-action.php
+++ b/classes/patterns/class-action.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Action pattern class.
+ *
+ * @package P4GBKS
+ * @since 0.1
+ */
+
+namespace P4GBKS\Patterns;
+
+use P4GBKS\Patterns\Templates\Covers;
+
+/**
+ * Class Action.
+ *
+ * @package P4GBKS\Patterns
+ */
+class Action extends Block_Pattern {
+
+	/**
+	 * Returns the pattern name.
+	 */
+	public static function get_name(): string {
+		return 'p4/action-pattern-layout';
+	}
+
+	/**
+	 * Returns the pattern config.
+	 *
+	 * @param array $params Optional array of parameters for the config.
+	 */
+	public static function get_config( $params = [] ): array {
+		$media_link = esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-546x415.jpg';
+
+		return [
+			'title'      => __( 'Action', 'planet4-blocks-backend' ),
+			'categories' => [ 'layouts' ],
+			'content'    => '
+				<!-- wp:group {"className":"block"} -->
+					<div class="wp-block-group">
+						<!-- wp:media-text {"mediaLink":"' . $media_link . '","mediaType":"image"} -->
+							<div class="wp-block-media-text is-stacked-on-mobile">
+								<figure class="wp-block-media-text__media">
+									<img src="' . $media_link . '" alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '"/>
+								</figure>
+								<div class="wp-block-media-text__content">
+									<!-- wp:gravityforms/form /-->
+								</div>
+							</div>
+						<!-- /wp:media-text -->
+						<!-- wp:group {"backgroundColor":"grey-05","align":"full","className":"is-style-large-padding"} -->
+							<div class="wp-block-group alignfull has-grey-05-background-color has-background is-style-large-padding">
+								<!-- wp:group {"className":"container"} -->
+									<div class="wp-block-group container">
+										' . SideImageWithTextAndCta::get_config(
+										[
+											'media_position'    => 'right',
+											'title_placeholder' => __( 'The problem', 'planet4-blocks' ),
+										]
+									)['content'] . '
+									</div>
+								<!-- /wp:group -->
+							</div>
+						<!-- /wp:group -->
+						' . Covers::get_content( [ 'cover_type' => 'take-action' ] ) . '
+						<!-- wp:separator {"backgroundColor":"grey-20","className":"has-text-color has-grey-20-color has-grey-20-background-color has-background is-style-wide"} -->
+						<hr class="wp-block-separator has-text-color has-grey-20-color has-alpha-channel-opacity has-grey-20-background-color has-background is-style-wide"/>
+						<!-- /wp:separator -->
+						' . QuickLinks::get_config(
+							[
+								'background_color'  => 'white',
+								'title_placeholder' => __( 'Explore by topics', 'planet4-blocks' ),
+							]
+						)['content'] . '
+					</div>
+					<!-- wp:planet4-blocks/action-page-dummy /-->
+				<!-- /wp:group -->
+			',
+		];
+	}
+}

--- a/classes/patterns/class-block-pattern.php
+++ b/classes/patterns/class-block-pattern.php
@@ -51,6 +51,7 @@ abstract class Block_Pattern {
 			QuickLinks::class,
 			RealityCheck::class,
 			SideImageWithTextAndCta::class,
+			Action::class,
 		];
 	}
 

--- a/classes/patterns/class-sideimagewithtextandcta.php
+++ b/classes/patterns/class-sideimagewithtextandcta.php
@@ -28,21 +28,23 @@ class SideImageWithTextAndCta extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
-		$media_link           = esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-546x415.jpg';
-		$media_position_class = array_key_exists( 'media_position', $params ) && 'right' === $params['media_position'] ? 'has-media-on-the-right' : '';
-		$title_placeholder    = $params['title_placeholder'] ?? '';
-		$background_color     = $params['background_color'] ?? null;
-		$background_attribute = $background_color ? ',"backgroundColor":"' . $background_color . '"' : '';
-		$background_classes   = $background_color ? 'has-' . $background_color . '-background-color has-background' : '';
-		$alignfull            = $params['alignfull'] ?? false;
-		$alignment_class      = $alignfull ? 'alignfull' : '';
-		$alignment_attribute  = $alignfull ? ',"align":"full"' : '';
+		$media_link               = esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-546x415.jpg';
+		$media_position           = $params['media_position'] ?? '';
+		$media_position_class     = 'right' === $media_position ? 'has-media-on-the-right' : '';
+		$media_position_attribute = 'right' === $media_position ? ',"mediaPosition":"right"' : '';
+		$title_placeholder        = $params['title_placeholder'] ?? '';
+		$background_color         = $params['background_color'] ?? null;
+		$background_attribute     = $background_color ? ',"backgroundColor":"' . $background_color . '"' : '';
+		$background_classes       = $background_color ? 'has-' . $background_color . '-background-color has-background' : '';
+		$alignfull                = $params['alignfull'] ?? false;
+		$alignment_class          = $alignfull ? 'alignfull' : '';
+		$alignment_attribute      = $alignfull ? ',"align":"full"' : '';
 
 		return [
 			'title'      => __( 'Side image with text and CTA', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],
 			'content'    => '
-				<!-- wp:media-text {"mediaLink":"' . $media_link . '","mediaType":"image","className":"block ' . $media_position_class . '"' . $background_attribute . $alignment_attribute . '} -->
+				<!-- wp:media-text {"mediaLink":"' . $media_link . '","mediaType":"image","className":"block ' . $media_position_class . '"' . $background_attribute . $alignment_attribute . $media_position_attribute . '} -->
 					<div class="wp-block-media-text ' . $alignment_class . ' is-stacked-on-mobile block ' . $media_position_class . ' ' . $background_classes . '">
 						<figure class="wp-block-media-text__media">
 							<img src="' . $media_link . '" alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '"/>

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -197,6 +197,7 @@ const ACTION_BLOCK_TYPES = [
 	'leadin/hubspot-form-block',
 	'gravityforms/form',
 	'planet4-blocks/sub-pages',
+	'planet4-blocks/action-page-dummy',
 ];
 
 const BETA_ACTION_BLOCK_TYPES = [


### PR DESCRIPTION
### Description

See [PLANET-6529](https://jira.greenpeace.org/browse/PLANET-6529)

~There's a [related PR](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/890) to fix the block validation errors that occur with the Covers block, it's in a separate PR since it's also needed for other templates such as the Homepage one.~ Merged!

In order to hide this pattern in post types other than Action pages, we need to add a dummy block (literally called `ActionDummyBlock`, but that's open to discussion 😁) that will be allowed only in this post type. It's hidden from the block list/inserter too, so the only way to add it is via code like we do here in the pattern.

### Testing

On local or on the umbriel test instance, you can create a new **Action** page and add the `Action` pattern to it, to see the initial state of the template and then see how you can edit the various blocks within it!
The template should not appear in other post types (Page, Post, etc) and also not in the page creation modal.
The new `Action Dummy Block` used to hide the pattern in other post types should not be available in the block list/inserter.