### PR TITLE
Fix deprecated wp.editor elements console warnings

### DIFF
--- a/assets/src/ImageBlockExtension.js
+++ b/assets/src/ImageBlockExtension.js
@@ -1,4 +1,5 @@
 import { Button, ButtonGroup, PanelBody } from '@wordpress/components';
+import { InspectorControls } from '@wordpress/block-editor';
 import assign from 'lodash.assign';
 
 const { addFilter } = wp.hooks;
@@ -64,7 +65,6 @@ const addExtraAttributes = function() {
 const addExtraControls = function() {
   const { createHigherOrderComponent } = wp.compose;
   const { Fragment } = wp.element;
-  const { InspectorControls } = wp.editor;
 
   const withCaptionStyle = createHigherOrderComponent( ( BlockEdit ) => {
     return ( props ) => {

--- a/assets/src/blocks/Counter/CounterEditor.js
+++ b/assets/src/blocks/Counter/CounterEditor.js
@@ -10,7 +10,7 @@ import { URLInput } from "../../components/URLInput/URLInput";
 
 import { CounterFrontend } from './CounterFrontend';
 
-const { RichText } = wp.editor;
+const { RichText } = wp.blockEditor;
 const { __ } = wp.i18n;
 
 export class CounterEditor extends Component {


### PR DESCRIPTION
### Description

Some of these will be removed very soon so we need to stop using them:

```
wp.editor.RichText is deprecated since version 5.3 and will be removed in version 6.2. Please use wp.blockEditor.RichText instead.
```
```
wp.editor.InspectorControls is deprecated since version 5.3 and will be removed in version 6.2. Please use wp.blockEditor.InspectorControls instead.
```

### Testing

On local, you can add an Image block or a Counter block to any page and on `master` branch you'll see the console warnings, but not on this branch. Both blocks should still work as expected!