### PR TITLE
PLANET-6825: Page creation UI integration

### DIFF
--- a/classes/patterns/class-blankpage.php
+++ b/classes/patterns/class-blankpage.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * BlankPage pattern class.
+ *
+ * @package P4GBKS
+ * @since 0.1
+ */
+
+namespace P4GBKS\Patterns;
+
+/**
+ * This class is used for returning a blank page with a default content.
+ *
+ * @package P4GBKS\Patterns
+ */
+class BlankPage extends Block_Pattern {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_name(): string {
+		return 'p4/blank-page';
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @param array $params Optional array of parameters for the config.
+	 */
+	public static function get_config( $params = [] ): array {
+		return [
+			'title'      => __( 'Blank page', 'planet4-blocks-backend' ),
+			'blockTypes' => [ 'core/post-content' ],
+			'categories' => [ 'pages' ],
+			'content'    => '
+				<!-- wp:paragraph {"placeholder":"' . __( 'Enter text', 'planet4-blocks-backend' ) . '"} -->
+				<p></p>
+				<!-- /wp:paragraph -->
+			',
+		];
+	}
+}

--- a/classes/patterns/class-block-pattern.php
+++ b/classes/patterns/class-block-pattern.php
@@ -35,6 +35,7 @@ abstract class Block_Pattern {
 		}
 
 		$patterns = [
+			BlankPage::class,
 			SideImageWithTextAndCta::class,
 			HighlightedCta::class,
 			RealityCheck::class,


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6825

Create a new "blank page" pattern as a starting point.

## Testing Instructions
Go to the [sinope's instance](https://www-dev.greenpeace.org/test-sinope/wp-admin/) and create a new page. Then, you'll be able to pick the desired pattern (for now only a the Blank page) when the page is empty.

## More info about this feature
- https://wptavern.com/wordpress-6-0-might-ship-a-feature-for-picking-a-block-pattern-on-page-creation
- https://github.com/WordPress/gutenberg/pull/40034
