### PR TITLE
Add title placeholder param to some patterns

### DIFF
--- a/classes/patterns/class-issues.php
+++ b/classes/patterns/class-issues.php
@@ -46,6 +46,8 @@ class Issues extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
+		$title_placeholder = $params['title_placeholder'] ?? '';
+
 		return [
 			'title'      => __( 'Issues', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],
@@ -61,7 +63,7 @@ class Issues extends Block_Pattern {
 						<!-- /wp:spacer -->
 
 						<!-- wp:heading {"textAlign":"center","level":1, "placeholder":"' . __( 'Enter title', 'planet4-blocks-backend' ) . '"} -->
-						<h1 class="has-text-align-center"></h1>
+						<h1 class="has-text-align-center">' . $title_placeholder . '</h1>
 						<!-- /wp:heading -->
 
 						<!-- wp:paragraph {"align":"center", "placeholder":"' . __( 'Enter description', 'planet4-blocks-backend' ) . '"} -->

--- a/classes/patterns/class-quicklinks.php
+++ b/classes/patterns/class-quicklinks.php
@@ -67,6 +67,8 @@ class QuickLinks extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
+		$title_placeholder = $params['title_placeholder'] ?? '';
+
 		return [
 			'title'      => __( 'Quick Links', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],
@@ -79,7 +81,7 @@ class QuickLinks extends Block_Pattern {
 									<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
 								<!-- /wp:spacer -->
 								<!-- wp:heading {"level":4,"placeholder":"' . __( 'Enter title', 'planet4-blocks-backend' ) . '"} -->
-									<h4></h4>
+									<h4>' . $title_placeholder . '</h4>
 								<!-- /wp:heading -->
 								<!-- wp:columns {"isStackedOnMobile":false,"className":"is-style-mobile-carousel"} -->
 									<div class="wp-block-columns is-not-stacked-on-mobile is-style-mobile-carousel">

--- a/classes/patterns/class-sideimagewithtextandcta.php
+++ b/classes/patterns/class-sideimagewithtextandcta.php
@@ -29,7 +29,9 @@ class SideImageWithTextAndCta extends Block_Pattern {
 	 */
 	public static function get_config( $params = [] ): array {
 		$media_link           = esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-546x415.jpg';
-		$media_position_class = ! empty( $params ) && 'right' === $params['media_position'] ? 'has-media-on-the-right' : '';
+		$media_position_class = array_key_exists( 'media_position', $params ) && 'right' === $params['media_position'] ? 'has-media-on-the-right' : '';
+		$title_placeholder    = $params['title_placeholder'] ?? '';
+
 		return [
 			'title'      => __( 'Side image with text and CTA', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],
@@ -41,7 +43,7 @@ class SideImageWithTextAndCta extends Block_Pattern {
 						</figure>
 						<div class="wp-block-media-text__content">
 							<!-- wp:heading {"placeholder":"' . __( 'Enter title', 'planet4-blocks-backend' ) . '"} -->
-								<h2></h2>
+								<h2>' . $title_placeholder . '</h2>
 							<!-- /wp:heading -->
 							<!-- wp:paragraph {"placeholder":"' . __( 'Enter description', 'planet4-blocks-backend' ) . '"} -->
 								<p></p>


### PR DESCRIPTION
### Description

This is needed for some page templates, such as the [Action](https://jira.greenpeace.org/browse/PLANET-6529) one or the [Get Informed](https://jira.greenpeace.org/browse/PLANET-6523) one. We want to be able to add some placeholders when creating these patterns. You can see how it would be used for example [here](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/877/files#diff-59777031749d62dcf9c1abe1512e44340868b40c3004277c5357267891d3bfecR37).