### PR TITLE
Remove lightbox and image captions in patterns

### DIFF
--- a/classes/patterns/class-highlightedcta.php
+++ b/classes/patterns/class-highlightedcta.php
@@ -36,8 +36,8 @@ class HighlightedCta extends Block_Pattern {
 					<div class="wp-block-columns block has-dark-blue-background-color has-text-color has-background has-white-color">
 						<!-- wp:column -->
 							<div class="wp-block-column">
-								<!-- wp:image {"align":"center","className":"force-no-lightbox"} -->
-									<div class="wp-block-image force-no-lightbox">
+								<!-- wp:image {"align":"center","className":"force-no-lightbox force-no-caption"} -->
+									<div class="wp-block-image force-no-lightbox force-no-caption">
 										<figure class="aligncenter">
 											<img src="' . esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-80x80.jpg" alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '"/>
 										</figure>

--- a/classes/patterns/class-issues.php
+++ b/classes/patterns/class-issues.php
@@ -29,8 +29,8 @@ class Issues extends Block_Pattern {
 	public static function get_media_text_template(): string {
 		$media_link = esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-40x40.jpg';
 		return '
-			<!-- wp:media-text {"mediaWidth":15,"mediaLink":"' . $media_link . '","mediaType":"image","mediaSizeSlug":"thumbnail","isStackedOnMobile":false,"verticalAlignment":"center","imageFill":false,"backgroundColor":"white","className":"is-style-large-padding"} -->
-			<div class="wp-block-media-text alignwide is-vertically-aligned-center has-white-background-color is-style-large-padding has-background" style="grid-template-columns:15% auto">
+			<!-- wp:media-text {"mediaWidth":15,"mediaLink":"' . $media_link . '","mediaType":"image","mediaSizeSlug":"thumbnail","isStackedOnMobile":false,"verticalAlignment":"center","imageFill":false,"backgroundColor":"white","className":"is-style-large-padding force-no-lightbox"} -->
+			<div class="wp-block-media-text alignwide is-vertically-aligned-center has-white-background-color is-style-large-padding has-background force-no-lightbox" style="grid-template-columns:15% auto">
 			<figure class="wp-block-media-text__media"><img src="' . $media_link . '" alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '"/></figure>
 			<div class="wp-block-media-text__content">
 			<!-- wp:paragraph {"align":"left","placeholder":"' . __( 'Enter text', 'planet4-blocks-backend' ) . '","style":{"typography":{"fontSize":"1rem","fontStyle":"normal","fontWeight":"700"}},"className":"is-style-roboto-font-family"} -->

--- a/classes/patterns/class-realitycheck.php
+++ b/classes/patterns/class-realitycheck.php
@@ -29,8 +29,8 @@ class RealityCheck extends Block_Pattern {
 		return '
 			<!-- wp:column -->
 				<div class="wp-block-column">
-					<!-- wp:image {"align":"center","className":"mb-0 force-no-lightbox"} -->
-						<div class="wp-block-image mb-0 force-no-lightbox">
+					<!-- wp:image {"align":"center","className":"mb-0 force-no-lightbox force-no-caption"} -->
+						<div class="wp-block-image mb-0 force-no-lightbox force-no-caption">
 							<figure class="aligncenter">
 								<img src="' . esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-75x75.jpg" alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '"/>
 							</figure>


### PR DESCRIPTION
### Description

These functionalities don't make sense in our patterns.

### Testing

On local, you can add these patterns (`Issues`, `Reality Check` or `Highlighted CTA`) or you can go to [this page](https://www-dev.greenpeace.org/test-neptune/various-patterns/) I created, and then test the following:
- Make sure the Lightbox is not added to these patterns in the frontend
- Make sure images' captions (& credits) are never displayed in both the frontend and the backend

Our other patterns already have these disabled.