### PR TITLE
PLANET-6829 Fix block style label

### DIFF
--- a/assets/src/blocks/Columns/ColumnsBlock.js
+++ b/assets/src/blocks/Columns/ColumnsBlock.js
@@ -1,21 +1,10 @@
 import { ColumnsEditor } from './ColumnsEditor.js';
-import { Tooltip } from '@wordpress/components';
 import { LAYOUT_NO_IMAGE, LAYOUT_IMAGES, LAYOUT_ICONS, LAYOUT_TASKS } from './ColumnConstants.js';
 import { example } from './example';
+import { getStyleLabel } from '../../functions/getStyleLabel';
 
 const { __ } = wp.i18n;
 const { registerBlockType } = wp.blocks;
-
-const getStyleLabel = (label, help) => {
-  if (help) {
-    return (
-      <Tooltip text={help}>
-        <span>{label}</span>
-      </Tooltip>
-    );
-  }
-  return label;
-};
 
 export const registerColumnsBlock = () =>
   registerBlockType('planet4-blocks/columns', {

--- a/assets/src/blocks/Covers/CoversEditorScript.js
+++ b/assets/src/blocks/Covers/CoversEditorScript.js
@@ -1,25 +1,14 @@
 import { CoversEditor } from './CoversEditor.js';
 import { frontendRendered } from '../frontendRendered';
-import { Tooltip } from '@wordpress/components';
 import { coversV1 } from './deprecated/coversV1';
 import { COVERS_TYPES, COVERS_LAYOUTS } from './CoversConstants';
 import { example } from './example.js';
+import { getStyleLabel } from '../../functions/getStyleLabel';
 
 const { __ } = wp.i18n;
 
 const BLOCK_NAME = 'planet4-blocks/covers';
 const VERSION = 2;
-
-const getStyleLabel = (label, help) => {
-  if (help) {
-    return (
-      <Tooltip text={help}>
-        <span>{label}</span>
-      </Tooltip>
-    );
-  }
-  return label;
-};
 
 const registerCoversBlock = () => {
   const { registerBlockType } = wp.blocks;

--- a/assets/src/blocks/Gallery/GalleryBlock.js
+++ b/assets/src/blocks/Gallery/GalleryBlock.js
@@ -1,22 +1,11 @@
 import { GalleryEditor } from './GalleryEditor';
-import { Tooltip } from '@wordpress/components';
 import { frontendRendered } from '../frontendRendered';
+import { getStyleLabel } from '../../functions/getStyleLabel';
 
 const { __ } = wp.i18n;
 const { registerBlockType } = wp.blocks;
 
 const BLOCK_NAME = 'planet4-blocks/gallery';
-
-const getStyleLabel = (label, help) => {
-  if (help) {
-    return (
-      <Tooltip text={help}>
-        <span>{label}</span>
-      </Tooltip>
-    );
-  }
-  return label;
-};
 
 const attributes = {
   gallery_block_style: { // Needed for existing blocks conversion

--- a/assets/src/blocks/HubspotForm/HubspotFormBlock.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormBlock.js
@@ -1,19 +1,10 @@
 import ReactDOMServer from 'react-dom/server';
-import { Tooltip } from '@wordpress/components';
 import { HubspotFormEditor } from './HubspotFormEditor';
 import { HubspotFormFrontend } from './HubspotFormFrontend';
 const { registerBlockType } = wp.blocks;
 const { __ } = wp.i18n;
 
 const BLOCK_NAME = 'planet4-blocks/hubspot-form';
-
-const getStyleLabel = (label, help) => (
-  (help)
-    ? <Tooltip text={help}>
-        <span>{label}</span>
-      </Tooltip>
-    : label
-);
 
 export const registerHubspotFormBlock = () => {
   return registerBlockType(BLOCK_NAME, {
@@ -76,10 +67,7 @@ export const registerHubspotFormBlock = () => {
     styles: [
       {
         name: 'image-full-width',
-        label: getStyleLabel(
-          __('Image full width', 'planet4-blocks-backend'),
-          __('https://p4-designsystem.greenpeace.org/05f6e9516/p/213df0-hubspot-forms/b/99e047', 'planet4-blocks-backend'),
-        ),
+        label: __('Image full width', 'planet4-blocks-backend'),
         isDefault: true,
       },
     ],

--- a/assets/src/blocks/HubspotForm/HubspotFormSidebar.js
+++ b/assets/src/blocks/HubspotForm/HubspotFormSidebar.js
@@ -102,6 +102,11 @@ export const Sidebar = ({
           />}
         </PanelRowWrapper>
       </PanelRow>
+      <PanelRow>
+        <PanelRowWrapper>
+          <p className='FieldHelp'><a target='_blank' href='https://p4-designsystem.greenpeace.org/05f6e9516/p/213df0-hubspot-forms/b/99e047'>{__('Read more about Hubspot form styles.', 'planet4-blocks-backend')}</a></p>
+        </PanelRowWrapper>
+      </PanelRow>
     </PanelBody>
   </InspectorControls>
 };

--- a/assets/src/blocks/Submenu/SubmenuBlock.js
+++ b/assets/src/blocks/Submenu/SubmenuBlock.js
@@ -1,21 +1,11 @@
 import { SubmenuEditor } from './SubmenuEditor.js';
-import { Tooltip } from '@wordpress/components';
 import {example} from './example';
+import { getStyleLabel } from '../../functions/getStyleLabel';
 
 const { __ } = wp.i18n;
 
 const BLOCK_NAME = 'planet4-blocks/submenu';
 
-const getStyleLabel = (label, help) => {
-  if (help) {
-    return (
-      <Tooltip text={ help }>
-        <span>{label}</span>
-      </Tooltip>
-    );
-  }
-  return label;
-}
 export const registerSubmenuBlock = () => {
   const { registerBlockType } = wp.blocks;
 

--- a/assets/src/functions/getStyleLabel.js
+++ b/assets/src/functions/getStyleLabel.js
@@ -1,0 +1,6 @@
+export const getStyleLabel = (label, help) => {
+  if (help) {
+    return `${label} - ${help}`;
+  }
+  return label;
+};


### PR DESCRIPTION
The block style label no more accept tooltip component from wp6 upgrade, hence concat a label and help text

https://jira.greenpeace.org/browse/PLANET-6829

<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->

**Testing:**
- Test below blocks for block style on local or test instance.
   - Covers
   - Gallery
   - Submenu
   - Columns
   - Hubspot form