### PR TITLE
PLANET-6817 Add hover zoom effect to images in Stretched links

### DIFF
--- a/assets/src/variations/stretched-link/index.scss
+++ b/assets/src/variations/stretched-link/index.scss
@@ -1,6 +1,21 @@
 .group-stretched-link {
   position: relative;
 
+  [class*="is-style-rounded-"].force-no-caption {
+    overflow: hidden;
+    border-radius: 50%;
+
+    img {
+      transition: all .2s ease-in-out;
+    }
+  }
+
+  &:hover {
+    [class*="is-style-rounded-"] img {
+      transform: scale(1.3);
+    }
+  }
+
   // Ensure it's only applying to the first link.
   a:first-of-type {
     &:before {


### PR DESCRIPTION
### Description

See the [ticket](https://jira.greenpeace.org/browse/PLANET-6817) and the [example](https://www-dev.greenpeace.org/gutenberg/topics-link-animate-both-image-title-on-hover/) that Houssam implemented.

This is mostly for block patterns such as Deep Dive or Quick Links, but with this implementation it will be applied to all Stretched links that contain a rounded image.

### Testing

You can check out [this page](https://www-dev.greenpeace.org/test-oberon/patterns-with-image-zoom-on-hover/) that I prepared for UAT! Otherwise on local you can test it in any Quick Links or Deep Dive pattern.