### PR TITLE
Add coversV2 deprecated file to Covers block

### DIFF
--- a/assets/src/blocks/Covers/CoversEditorScript.js
+++ b/assets/src/blocks/Covers/CoversEditorScript.js
@@ -2,6 +2,7 @@ import { CoversEditor } from './CoversEditor.js';
 import { frontendRendered } from '../frontendRendered';
 import { Tooltip } from '@wordpress/components';
 import { coversV1 } from './deprecated/coversV1';
+import { coversV2 } from './deprecated/coversV2';
 import { COVERS_TYPES, COVERS_LAYOUTS } from './CoversConstants';
 import { example } from './example.js';
 
@@ -109,6 +110,7 @@ const registerCoversBlock = () => {
     ],
     deprecated: [
       coversV1,
+      coversV2,
     ],
     example,
   });

--- a/assets/src/blocks/Covers/deprecated/coversV2.js
+++ b/assets/src/blocks/Covers/deprecated/coversV2.js
@@ -1,0 +1,62 @@
+import { COVERS_LAYOUTS } from '../CoversConstants';
+
+const { __ } = wp.i18n;
+
+export const coversV2 = {
+  attributes: {
+    cover_type: {
+      type: 'string',
+      default: 'content',
+    },
+    initialRowsLimit: {
+      type: 'integer',
+      default: 1,
+    },
+    title: {
+      type: 'string',
+      default: '',
+    },
+    description: {
+      type: 'string',
+      default: '',
+    },
+    tags: {
+      type: 'array',
+      default: []
+    },
+    post_types: {
+      type: 'array',
+      default: []
+    },
+    posts: {
+      type: 'array',
+      default: []
+    },
+    version: {
+      type: 'integer',
+      default: 2,
+    },
+    layout: {
+      type: 'string',
+      default: COVERS_LAYOUTS.grid,
+    },
+    isExample: {
+      type: 'boolean',
+      default: false,
+    },
+    exampleCovers: { // Used for the block's preview, which can't extract items from anything.
+      type: 'object',
+    },
+  },
+  isEligible({ readMoreText }) {
+    return !readMoreText;
+  },
+  migrate({ className, ...attributes }) {
+    return {
+      ...attributes,
+      readMoreText: __('Load more', 'planet4-blocks'),
+      className,
+    };
+  },
+  save: () => null
+};

--- a/classes/blocks/class-covers.php
+++ b/classes/blocks/class-covers.php
@@ -148,8 +148,16 @@ class Covers extends Base_Block {
 						'type'    => 'string',
 						'default' => self::GRID_LAYOUT,
 					],
+					'isExample'        => [
+						'type'    => 'boolean',
+						'default' => false,
+					],
+					'exampleCovers'    => [
+						'type' => 'object',
+					],
 					'readMoreText'     => [
-						'type' => 'string',
+						'type'    => 'string',
+						'default' => __( 'Load more', 'planet4-blocks' ),
 					],
 				],
 			]


### PR DESCRIPTION
### Description

This is to add the sometimes missing `readMoreText` attribute, and fix the block validation errors that appear when using this block in certain patterns such as the Action one.

### Testing

This is mostly gonna be useful within patterns, but one way to test it would be to add a Take Action Covers block to a page via the code editor, such as 
```
<!-- wp:planet4-blocks/covers {"cover_type":"take-action","className":"is-style-take-action"} /-->
```
and then exit the code editor, on `master` branch it should give validation errors whereas on this branch it should work as expected.