### PR TITLE
Change the order of the Cover's deprecated versions

### DIFF
--- a/assets/src/blocks/Covers/CoversEditorScript.js
+++ b/assets/src/blocks/Covers/CoversEditorScript.js
@@ -109,8 +109,8 @@ const registerCoversBlock = () => {
       }
     ],
     deprecated: [
-      coversV1,
       coversV2,
+      coversV1,
     ],
     example,
   });


### PR DESCRIPTION
This is a revert change of this [change](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/890/files#diff-cb6127d4a739490c5949afeb7be94a62cad0ae08b836460cc20db94f69a5a8f4R113) which is already merged.

> @mleray I've just figured out that the order of this array is wrong since according to the [documentation](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-deprecation/) the newer version must be always at the top of the array. For example [v3, v2, v1]. We might revert it.

<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
