### PR TITLE
PLANET-6850 Add allow-plugns config to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,11 @@
   "scripts": {
     "fixes": "vendor/bin/phpcbf",
     "sniffs": "vendor/bin/phpcs"
+  },
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }


### PR DESCRIPTION
Ref: https://getcomposer.org/doc/06-config.md#allow-plugins
Ref: https://jira.greenpeace.org/browse/PLANET-6850

---

This is required by newer composer versions.

Main PR: https://github.com/greenpeace/planet4-docker/pull/101
