### PR TITLE
Register new margin style to core/wp-group

### DIFF
--- a/admin/js/editor.js
+++ b/admin/js/editor.js
@@ -49,10 +49,16 @@ wp.domReady(() => {
   );
 
   ['core/group'].forEach(block => {
-    registerBlockStyle(block, {
-      name: 'space-evenly',
-      label: __('Space evenly', 'planet4-blocks-backend'),
-    });
+    registerBlockStyle(block, [
+      {
+        name: 'space-evenly',
+        label: __('Space evenly', 'planet4-blocks-backend'),
+      },
+      {
+        name: 'reset-margin',
+        label: __('Reset margin', 'planet4-blocks-backend'),
+      }
+    ]);
   });
 
   ['core/paragraph'].forEach(block => {

--- a/assets/src/styles/blocks.scss
+++ b/assets/src/styles/blocks.scss
@@ -54,6 +54,10 @@
   }
 }
 
+.is-style-reset-margin {
+  margin: 0 !important;
+}
+
 .is-style-roboto-font-family {
   font-family: $roboto;
 }


### PR DESCRIPTION
**Description**

This new style reset the margin applied to `.page-content > .wp-block-group` and it would be very useful especially for page layout patterns.

**Example with margin**
![Screenshot 2022-07-15 at 11 19 39](https://user-images.githubusercontent.com/77975803/179242656-2772e913-3d10-4dd7-b374-5e0bc5a616e4.png)
<img width="1004" alt="Touch Bar Shot 2022-07-11 at 14 21 41" src="https://user-images.githubusercontent.com/77975803/179242677-052696c9-f199-4187-83d8-a4c4d492f7bf.png">


**Example without margin**
![Screenshot 2022-07-15 at 11 14 06](https://user-images.githubusercontent.com/77975803/179242691-44f9b6f8-1a45-4b59-999c-1efeb15fe1ca.png)
![Screenshot 2022-07-15 at 11 19 31](https://user-images.githubusercontent.com/77975803/179242694-5e19bb5c-81a9-4973-b966-3ee0bb3f2e36.png)

