### PR TITLE
Update carousel header styles

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselHeaderBlock.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderBlock.js
@@ -46,6 +46,13 @@ export const registerCarouselHeaderBlock = () =>
       html: false, // Disable "Edit as HTMl" block option.
     },
     attributes,
+    styles: [
+      {
+        name: 'fit-height-to-content',
+        label: __('Fit height to content', 'planet4-blocks-backend'),
+        isDefault: false,
+      },
+    ],
     edit: CarouselHeaderEditor,
     save: ({ attributes }) => {
       const markup = ReactDOMServer.renderToString(<div

--- a/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
+++ b/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
@@ -78,6 +78,16 @@ $medium-image-height: 600px;
 .carousel-header {
   position: relative;
   width: 100vw;
+
+  &.is-style-fit-height-to-content {
+    &.block {
+      display: block;
+    }
+
+    &.block-header {
+      margin-bottom: 0;
+    }
+  }
 }
 
 .carousel-inner {


### PR DESCRIPTION
## Description
These styles are rendered an unnecessary white space to its bottom and fix the reported issue from [here](https://jira.greenpeace.org/browse/PLANET-6524).

From my point of view, we would need to keep the carousel header with its natural height without adding any extra space in its bottom. That space could be added for instance by a `Spacer` block.

Related PR: #884 

[Demo page of the current Homepage implementation](https://www-dev.greenpeace.org/test-phobos/51534-2/)

### Before
![Screenshot 2022-07-21 at 12 15 54](https://user-images.githubusercontent.com/77975803/180252066-0377c75c-22e6-4e94-916c-d30abd001a32.png)

### After
![Screenshot 2022-07-21 at 12 16 39](https://user-images.githubusercontent.com/77975803/180251999-9a10ea00-d099-4986-ae0c-28c9e311d924.png)

## Demo pages
- [With margin to bottom](https://www-dev.greenpeace.org/test-neptune/)
- [Without margin to bottom](https://www-dev.greenpeace.org/test-neptune/33089-2/)

I'm open for suggestions :) What do you all think?
