### PR TITLE
Add background_color param to Side Image with Text and CTA

### DIFF
--- a/classes/patterns/class-sideimagewithtextandcta.php
+++ b/classes/patterns/class-sideimagewithtextandcta.php
@@ -31,13 +31,16 @@ class SideImageWithTextAndCta extends Block_Pattern {
 		$media_link           = esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-546x415.jpg';
 		$media_position_class = array_key_exists( 'media_position', $params ) && 'right' === $params['media_position'] ? 'has-media-on-the-right' : '';
 		$title_placeholder    = $params['title_placeholder'] ?? '';
+		$background_color     = $params['background_color'] ?? null;
+		$background_attribute = $background_color ? ',"backgroundColor":"' . $background_color . '"' : '';
+		$background_classes   = $background_color ? 'has-' . $background_color . '-background-color has-background' : '';
 
 		return [
 			'title'      => __( 'Side image with text and CTA', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],
 			'content'    => '
-				<!-- wp:media-text {"mediaLink":"' . $media_link . '","mediaType":"image","className":"block ' . $media_position_class . '"} -->
-					<div class="wp-block-media-text alignwide is-stacked-on-mobile block ' . $media_position_class . '">
+				<!-- wp:media-text {"mediaLink":"' . $media_link . '","mediaType":"image","className":"block ' . $media_position_class . '"' . $background_attribute . '} -->
+					<div class="wp-block-media-text alignwide is-stacked-on-mobile block ' . $media_position_class . ' ' . $background_classes . '">
 						<figure class="wp-block-media-text__media">
 							<img src="' . $media_link . '" alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '"/>
 						</figure>


### PR DESCRIPTION
### Description

This will be needed for some patterns, such as the [High level topic one](https://jira.greenpeace.org/browse/PLANET-6737)

### Testing

On local, you can try manually adding the `background_color` attribute in the pattern's params (using a color from our [palette](https://github.com/greenpeace/planet4-master-theme/blob/master/theme.json#L12-L84)) and saving. After that, when adding the pattern to a page you should see it with the chosen background color. Of course it should also work as expected when there is no background color specified in the params 🙂 