### PR TITLE
Add title_placeholder param to Deep Dive and Highlighted CTA patterns

### DIFF
--- a/classes/patterns/class-deepdive.php
+++ b/classes/patterns/class-deepdive.php
@@ -58,7 +58,9 @@ class DeepDive extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
-		$classname = self::get_classname();
+		$classname         = self::get_classname();
+		$title_placeholder = $params['title_placeholder'] ?? '';
+
 		return [
 			'title'      => __( 'Deep Dive', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],
@@ -71,7 +73,7 @@ class DeepDive extends Block_Pattern {
 									<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
 								<!-- /wp:spacer -->
 								<!-- wp:heading {"textAlign":"center","placeholder":"' . __( 'Enter title', 'planet4-blocks-backend' ) . '"} -->
-									<h2 class="has-text-align-center"></h2>
+									<h2 class="has-text-align-center">' . $title_placeholder . '</h2>
 								<!-- /wp:heading -->
 								<!-- wp:columns -->
 									<div class="wp-block-columns">

--- a/classes/patterns/class-highlightedcta.php
+++ b/classes/patterns/class-highlightedcta.php
@@ -28,7 +28,9 @@ class HighlightedCta extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
-		$classname = self::get_classname();
+		$classname         = self::get_classname();
+		$title_placeholder = $params['title_placeholder'] ?? '';
+
 		return [
 			'title'      => __( 'Highlighted CTA', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],
@@ -45,7 +47,7 @@ class HighlightedCta extends Block_Pattern {
 									</div>
 								<!-- /wp:image -->
 								<!-- wp:heading {"placeholder":"' . __( 'Enter text', 'planet4-blocks-backend' ) . '","align":"center","className":"has-text-align-center","level":3} -->
-									<h3 class="has-text-align-center"></h3>
+									<h3 class="has-text-align-center">' . $title_placeholder . '</h3>
 								<!-- /wp:heading -->
 								<!-- wp:spacer {"height":"16px"} -->
 									<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>


### PR DESCRIPTION
### Description

This will be needed for some pattern layouts, such as the [High-Level Topic one](https://jira.greenpeace.org/browse/PLANET-6737)

### Testing

On local, you can try manually adding the `title_placeholder` attribute in the patterns' params and saving. After that, when adding the patterns to a page you should see them with the chosen titles. Of course they should also work as expected when there is no title placeholder specified in the params 🙂