### PR TITLE
Add background color param to Quick Links pattern

### DIFF
--- a/classes/patterns/class-quicklinks.php
+++ b/classes/patterns/class-quicklinks.php
@@ -63,19 +63,21 @@ class QuickLinks extends Block_Pattern {
 	/**
 	 * Returns the pattern config.
 	 * We start with 6 columns, but editors can easily remove and/or duplicate them.
+	 * This pattern should have grey 5% background by default.
 	 *
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
 		$classname         = self::get_classname();
 		$title_placeholder = $params['title_placeholder'] ?? '';
+		$background_color  = $params['background_color'] ?? 'grey-05';
 
 		return [
 			'title'      => __( 'Quick Links', 'planet4-blocks-backend' ),
 			'categories' => [ 'planet4' ],
 			'content'    => '
-				<!-- wp:group {"className":"block ' . $classname . '","align":"full","backgroundColor":"grey-05"} -->
-					<div class="wp-block-group alignfull block ' . $classname . ' has-grey-05-background-color has-background">
+				<!-- wp:group {"className":"block ' . $classname . '","align":"full","backgroundColor":"' . $background_color . '"} -->
+					<div class="wp-block-group alignfull block ' . $classname . ' has-' . $background_color . '-background-color has-background">
 						<!-- wp:group {"className":"container"} -->
 							<div class="wp-block-group container">
 								<!-- wp:spacer {"height":"24px"} -->


### PR DESCRIPTION
### Description

This pattern should have grey 5% as background color by default, but for some pattern layouts such as [Action](https://jira.greenpeace.org/browse/PLANET-6529) or [High-Level Topic](https://jira.greenpeace.org/browse/PLANET-6737), we need it to have white background

### Testing

On local, you can try manually adding the `background_color` attribute in the pattern's params (using a color from our [palette](https://github.com/greenpeace/planet4-master-theme/blob/master/theme.json#L12-L84)) and saving. After that, when adding the pattern to a page, you should see it with the chosen background color. It should also work as expected when there is no background color specified in the params, meaning it should have `grey-05` background color applied by default 🙂