### PR TITLE
PLANET-6828 Fix Covers carousel layout in Safari

### DIFF
--- a/assets/src/styles/blocks/Covers/layouts/CoversCarouselLayout.scss
+++ b/assets/src/styles/blocks/Covers/layouts/CoversCarouselLayout.scss
@@ -18,10 +18,6 @@
     &::-webkit-scrollbar {
       display: none;
     }
-
-    @include large-and-up {
-      overflow-x: hidden;
-    }
   }
 
   .carousel-control-prev,


### PR DESCRIPTION
### Description

See [PLANET-6828](https://jira.greenpeace.org/browse/PLANET-6828)
In Safari, it's possible to click on the arrows/indicators and they seem to update properly (showing which ones are active or disabled) but the covers don't change accordingly.
It seems that removing this `overflow-x: hidden;` solves the issue without breaking the behaviour in other screen sizes and browsers, but ~I'm not sure why it was added in the first place~ then people can manually scroll through the covers which is not ideal 🤷‍♀️ Maybe we could find a CSS way to apply this only in Safari 🤔 

There is [another PR](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/915) open for this issue which hides the covers instead of scrolling through them, it works as expected but removes the nice scrolling animation so I'm not sure which solution is best 🤷‍♀️ 

### Testing

Add a Covers block to a page, with the Carousel layout selected, and enough covers so that you see the indicators/arrows to show the following covers. Then in Safari, you can see that on `master` branch clicking on these indicators will not change the covers that you see, whereas on this branch they should change accordingly. Please test different screen sizes, and also make sure that the Covers' behaviour still works fine in other browsers too!