### PR TITLE
Fix Media & Text block padding

### DIFF
--- a/assets/src/styles/blocks/core-overrides/_media-text.scss
+++ b/assets/src/styles/blocks/core-overrides/_media-text.scss
@@ -1,12 +1,26 @@
+@mixin adapt-padding-inline-start($containerWidth) {
+  padding-inline-start: calc(100% - (#{$containerWidth} / 2) + 0.75rem);
+}
+
+@mixin adapt-padding-inline-end($containerWidth) {
+  padding-inline-end: calc(100% - (#{$containerWidth} / 2) + 0.75rem);
+}
+
 .wp-block-media-text {
   &:not(.force-no-lightbox) img {
     cursor: pointer;
   }
 
+  // 601px is when the block is no longer stacked
   @media (max-width: 600px) {
+    &.alignfull .wp-block-media-text__content {
+      max-width: 540px;
+      width: 100%;
+      margin: auto;
+    }
+
     .wp-block-media-text__content {
-      padding: 0;
-      margin-top: $sp-2;
+      padding: $sp-2;
     }
 
     .wp-block-button,
@@ -16,14 +30,58 @@
   }
 
   @media (min-width: 601px) {
+    &.alignfull.has-media-on-the-right .wp-block-media-text__content {
+      @include adapt-padding-inline-start(540px);
+    }
+
+    &.alignfull:not(.has-media-on-the-right) .wp-block-media-text__content {
+      @include adapt-padding-inline-end(540px);
+    }
+
     &.has-media-on-the-right .wp-block-media-text__content {
-      padding-inline-start: 0;
       padding-inline-end: $sp-3;
     }
 
     &:not(.has-media-on-the-right) .wp-block-media-text__content {
-      padding-inline-end: 0;
       padding-inline-start: $sp-3;
+    }
+  }
+
+  &.alignfull.has-media-on-the-right .wp-block-media-text__content {
+    @include medium-and-up {
+      max-width: none;
+      @include adapt-padding-inline-start(720px);
+    }
+
+    @include large-and-up {
+      @include adapt-padding-inline-start(960px);
+    }
+
+    @include x-large-and-up {
+      @include adapt-padding-inline-start(1140px);
+    }
+
+    @include xx-large-and-up {
+      @include adapt-padding-inline-start(1320px);
+    }
+  }
+
+  &.alignfull:not(.has-media-on-the-right) .wp-block-media-text__content {
+    @include medium-and-up {
+      max-width: none;
+      @include adapt-padding-inline-end(720px);
+    }
+
+    @include large-and-up {
+      @include adapt-padding-inline-end(960px);
+    }
+
+    @include x-large-and-up {
+      @include adapt-padding-inline-end(1140px);
+    }
+
+    @include xx-large-and-up {
+      @include adapt-padding-inline-end(1320px);
     }
   }
 


### PR DESCRIPTION
### Description

Before this fix, the block looks weird when it has a background or when it has full alignment (which will be needed for the [High-Level Topic](https://jira.greenpeace.org/browse/PLANET-6737)), especially with the image on the right:

<img width="1137" alt="Screenshot 2022-07-27 at 09 58 41" src="https://user-images.githubusercontent.com/6949075/181193914-7bd9ab90-e773-4cc2-984f-d52d48b94aeb.png">

When the block is full width, the content part should follow our grid.

### Testing

You can either test the changes on local, or check [this page](https://www-dev.greenpeace.org/test-titan/media-text-improvements/) and compare it with the "broken" version [here](https://www-dev.greenpeace.org/test-leda/1090-2/). Please make sure you check all screen sizes, and also the RTL direction 🙂 