### PR TITLE
Override pagination native functionality

### DIFF
--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -440,6 +440,44 @@ $breakpoints = [
 ];
 
 add_filter(
+	'render_block_core/query-pagination-previous',
+	function ( $content, $parsed, $block ) {
+		if ( empty( $block->attributes['label'] ) ) {
+			$block->attributes['label'] = __( 'Prev', 'planet4-blocks' );
+			return $block->render();
+		}
+
+		// Check if the button isn't rendered, then return it.
+		if ( empty( $content ) ) {
+			return '<a href="/" class="wp-block-query-pagination-previous disabled">' . __( 'Prev', 'planet4-blocks' ) . '</a>';
+		}
+
+		return $content;
+	},
+	10,
+	3
+);
+
+add_filter(
+	'render_block_core/query-pagination-next',
+	function ( $content, $parsed, $block ) {
+		if ( empty( $block->attributes['label'] ) ) {
+			$block->attributes['label'] = __( 'Next', 'planet4-blocks' );
+			return $block->render();
+		}
+
+		// Check if the button isn't rendered, then return it.
+		if ( empty( $content ) ) {
+			return '<a href="/" class="wp-block-query-pagination-next disabled">' . __( 'Next', 'planet4-blocks' ) . '</a>';
+		}
+
+		return $content;
+	},
+	10,
+	3
+);
+
+add_filter(
 	'render_block',
 	function ( $block_content, $block, WP_Block $instance ) use ( $breakpoints ) {
 		if ( 'core/query' === $block['blockName'] ) {

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -442,14 +442,16 @@ $breakpoints = [
 add_filter(
 	'render_block_core/query-pagination-previous',
 	function ( $content, $parsed, $block ) {
-		if ( empty( $block->attributes['label'] ) ) {
-			$block->attributes['label'] = __( 'Prev', 'planet4-blocks' );
+		$button_label = __( 'Prev', 'planet4-blocks' );
+
+		if ( ! array_key_exists( 'label', $block->attributes ) ) {
+			$block->attributes['label'] = $button_label;
 			return $block->render();
 		}
 
 		// Check if the button isn't rendered, then return it.
 		if ( empty( $content ) ) {
-			return '<a href="/" class="wp-block-query-pagination-previous disabled">' . __( 'Prev', 'planet4-blocks' ) . '</a>';
+			return '<a href="/" class="wp-block-query-pagination-previous disabled">' . $button_label . '</a>';
 		}
 
 		return $content;
@@ -461,14 +463,16 @@ add_filter(
 add_filter(
 	'render_block_core/query-pagination-next',
 	function ( $content, $parsed, $block ) {
-		if ( empty( $block->attributes['label'] ) ) {
-			$block->attributes['label'] = __( 'Next', 'planet4-blocks' );
+		$button_label = __( 'Next', 'planet4-blocks' );
+
+		if ( ! array_key_exists( 'label', $block->attributes ) ) {
+			$block->attributes['label'] = $button_label;
 			return $block->render();
 		}
 
 		// Check if the button isn't rendered, then return it.
 		if ( empty( $content ) ) {
-			return '<a href="/" class="wp-block-query-pagination-next disabled">' . __( 'Next', 'planet4-blocks' ) . '</a>';
+			return '<a href="/" class="wp-block-query-pagination-next disabled">' . $button_label . '</a>';
 		}
 
 		return $content;


### PR DESCRIPTION
## Description

Because of the new listing pages, we should override the WP native functionality.
- Change "Previous Page" button text to "Prev"
- Change "Next Page" button text to "Next"
- Show always both buttons despite of being in the first or last page.

Related to [#1759]( https://github.com/greenpeace/planet4-master-theme/pull/1759)

**Demo page**: We'll set the same as [#1759]( https://github.com/greenpeace/planet4-master-theme/pull/1759)

### Before
![Screenshot 2022-07-27 at 11 13 01](https://user-images.githubusercontent.com/77975803/181269693-242e756c-65ff-4028-8288-81b62e74ac4f.png)


### After
![Screenshot 2022-07-27 at 11 12 22](https://user-images.githubusercontent.com/77975803/181269717-ec9208a2-8b25-408a-b3ed-ffddcb72f4ad.png)
