### PR TITLE
Fix gravity forms wp name

### DIFF
--- a/classes/patterns/templates/class-twocolumnsgravityforms.php
+++ b/classes/patterns/templates/class-twocolumnsgravityforms.php
@@ -51,7 +51,7 @@ class TwoColumnsGravityForms extends TemplatePattern {
 
 					<!-- wp:column -->
 					<div class="wp-block-column">
-						<!-- wp:TwoColumnsGravityForms/form {"title":false,"description":false} /-->
+						<!-- wp:gravityforms/form {"title":false,"description":false} /-->
 					</div>
 					<!-- /wp:column -->
 


### PR DESCRIPTION
We wrongly merged the [gravity forms name](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/classes/patterns/templates/class-twocolumnsgravityforms.php#L54).

<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
