### PR TITLE
Use TwoColumnsGravityForms template in Get Informed

### DIFF
--- a/classes/patterns/class-getinformed.php
+++ b/classes/patterns/class-getinformed.php
@@ -8,6 +8,8 @@
 
 namespace P4GBKS\Patterns;
 
+use P4GBKS\Patterns\Templates\TwoColumnsGravityForms;
+
 /**
  * Class Get Informed.
  *
@@ -52,11 +54,7 @@ class GetInformed extends Block_Pattern {
 							"gallery_block_title":"' . __( 'Our latest actions around the world', 'planet4-blocks' ) . '"
 						} /-->
 						<!-- wp:planet4-blocks/articles {"article_heading":"' . __( 'Latest news & stories', 'planet4-blocks' ) . '"} /-->
-						<!-- wp:group {"backgroundColor":"grey-05"} -->
-							<div class="wp-block-group has-grey-05-background-color has-background">
-								<!-- wp:gravityforms/form /-->
-							</div>
-						<!-- /wp:group -->
+						' . TwoColumnsGravityForms::get_content() . '
 					</div>
 				<!-- /wp:group -->
 			',


### PR DESCRIPTION
### Description

According to the [mockups](https://www.figma.com/file/leueo1LMrlPabJkZYs2NgW/IA%26nav_Final-mockups?node-id=1812%3A4965), the Get Informed pattern layout should also have a Gravity Forms with the possibility to add title/description on the side. Since we now have a template for this we need to use it here! 