### PR TITLE
Test on JS declared patterns

### DIFF
--- a/assets/src/block-patterns/block-attributes-i18n.json
+++ b/assets/src/block-patterns/block-attributes-i18n.json
@@ -1,0 +1,8 @@
+{
+    "core/heading": {
+      "placeholder": "heading placeholder text"
+    },
+    "core/paragraph": {
+      "placeholder": "paragraph placeholder text"
+    }
+}

--- a/assets/src/block-patterns/block-pattern-i18n.json
+++ b/assets/src/block-patterns/block-pattern-i18n.json
@@ -1,0 +1,5 @@
+{
+  "title": "pattern title",
+  "description": "pattern description",
+  "keywords": [ "pattern keyword" ]
+}

--- a/assets/src/block-patterns/content-from-layout.js
+++ b/assets/src/block-patterns/content-from-layout.js
@@ -1,0 +1,15 @@
+import {
+  serialize,
+  createBlock,
+  createBlocksFromInnerBlocksTemplate
+} from '@wordpress/blocks';
+
+const contentFromLayout = ( layout ) => serialize(
+  layout.map( ( [name, attributes, innerBlocks] ) => createBlock(
+    name,
+    attributes,
+    createBlocksFromInnerBlocksTemplate( innerBlocks || [] )
+  ) )
+);
+
+export default contentFromLayout;

--- a/assets/src/block-patterns/deep-dive/block-pattern.json
+++ b/assets/src/block-patterns/deep-dive/block-pattern.json
@@ -1,0 +1,8 @@
+{
+  "name": "p4/deep-dive",
+  "title": "Deep Dive",
+  "description": "Deep Dive",
+  "categories": ["planet4"],
+  "classname": "is-pattern-p4-deep-dive",
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/block-patterns/deep-dive/index.js
+++ b/assets/src/block-patterns/deep-dive/index.js
@@ -1,0 +1,6 @@
+import metadata from './block-pattern.json';
+import layout from './layout';
+
+const { name } = metadata;
+
+export { name, metadata, layout };

--- a/assets/src/block-patterns/deep-dive/innerBlocks.js
+++ b/assets/src/block-patterns/deep-dive/innerBlocks.js
@@ -1,0 +1,37 @@
+import { createBlock } from '@wordpress/blocks';
+import mainThemeUrl from '../main-theme-url';
+
+const column = ['core/column', {}, [
+  ['core/group', {className: 'group-stretched-link'}, [
+    ['core/image', {
+      align: 'center',
+      className: 'force-no-lightbox force-no-caption is-style-rounded-180',
+      url: `${mainThemeUrl}/images/placeholders/placeholder-180x180.jpg`
+    }],
+    ['core/heading', {
+      level: 5,
+      textAlign: 'center',
+      style: {typography:{fontSize:'1rem'}},
+      className: 'is-style-chevron',
+      placeholder: 'Enter topic'
+    }],
+    ['core/spacer', { height: '16px' }]
+  ]]
+]];
+
+const innerBlocks = ({
+  titlePlaceholder = 'Enter title'
+}) => ([
+  ['core/group', {className: 'container'}, [
+    ['core/spacer', { height: '24px' }],
+    ['core/heading', {
+      textAlign: 'center',
+      placeholder: titlePlaceholder
+    }],
+    ['core/columns', {}, [
+      column, column, column, column
+    ]]
+  ]]
+]);
+
+export default innerBlocks;

--- a/assets/src/block-patterns/deep-dive/layout.js
+++ b/assets/src/block-patterns/deep-dive/layout.js
@@ -1,0 +1,19 @@
+import metadata from './block-pattern.json';
+import innerBlocks from './innerBlocks';
+
+const layout = ({
+  titlePlaceholder = 'Enter title',
+  backgroundColor = 'grey-05',
+}) => ([
+  [
+    'core/group',
+    {
+      className: `block ${metadata.classname}`,
+      align: 'full',
+      backgroundColor
+    },
+    innerBlocks({titlePlaceholder})
+  ]
+]);
+
+export default layout;

--- a/assets/src/block-patterns/high-level-topic/block-pattern.json
+++ b/assets/src/block-patterns/high-level-topic/block-pattern.json
@@ -1,0 +1,9 @@
+{
+  "name": "p4/high-level-topic-pattern-layout",
+  "title": "High-Level Topic",
+  "description": "High-Level Topic",
+  "categories": ["layouts"],
+  "blockTypes": ["core/post-content"],
+  "classname": "is-pattern-p4-high-level-topic-pattern-layout",
+  "textdomain": "planet4-blocks"
+}

--- a/assets/src/block-patterns/high-level-topic/index.js
+++ b/assets/src/block-patterns/high-level-topic/index.js
@@ -1,0 +1,6 @@
+import metadata from './block-pattern.json';
+import layout from './layout';
+
+const { name } = metadata;
+
+export { name, metadata, layout };

--- a/assets/src/block-patterns/high-level-topic/layout.js
+++ b/assets/src/block-patterns/high-level-topic/layout.js
@@ -1,0 +1,48 @@
+import metadata from './block-pattern.json';
+import * as deepDive from '../deep-dive';
+import * as highlightedCta from '../highlighted-cta';
+import * as pageHeaderImgSide from '../page-header-img-side';
+import * as quickLinks from '../quick-links';
+import * as realityCheck from '../reality-check';
+import * as sideImgTextCta from '../side-image-with-text-and-cta';
+
+const layout = () => [
+  [
+    'core/group',
+    {
+      className: `block ${metadata.classname}`,
+    },
+    [
+      ...pageHeaderImgSide.variation('right').layout(),
+      ...realityCheck.layout(),
+      ...sideImgTextCta.layout({
+        titlePlaceholder: 'The problem',
+        backgroundColor: 'grey-05',
+        alignFull: true,
+      }),
+      ...deepDive.layout({
+        titlePlaceholder: 'Better understand the issues [deep dive topics]',
+        backgroundColor: 'white',
+      }),
+      ...sideImgTextCta.layout({
+        titlePlaceholder: 'What we do',
+        mediaPosition: 'right',
+        backgroundColor: 'grey-05',
+        alignFull: true,
+      }),
+      ...highlightedCta.layout({
+        titlePlaceholder: 'Featured action title',
+      }),
+      ['planet4-blocks/covers', {'cover_type': 'take-action'}],
+      ['planet4-blocks/articles', {}],
+      ['planet4-blocks/covers', {'cover_type': 'content'}],
+      // two columns gravity forms
+      ...quickLinks.layout({
+        titlePlaceholder: 'Explore by topics',
+        backgroundColor: 'white',
+      })
+    ]
+  ]
+];
+
+export default layout;

--- a/assets/src/block-patterns/highlighted-cta/block-pattern.json
+++ b/assets/src/block-patterns/highlighted-cta/block-pattern.json
@@ -1,0 +1,8 @@
+{
+  "name": "p4/highlighted-cta",
+  "title": "Highlighted CTA",
+  "description": "Highlighted CTA",
+  "categories": ["planet4"],
+  "classname": "is-pattern-p4-highlighted-cta",
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/block-patterns/highlighted-cta/index.js
+++ b/assets/src/block-patterns/highlighted-cta/index.js
@@ -1,0 +1,6 @@
+import metadata from './block-pattern.json';
+import layout from './layout';
+
+const { name } = metadata;
+
+export { name, metadata, layout };

--- a/assets/src/block-patterns/highlighted-cta/layout.js
+++ b/assets/src/block-patterns/highlighted-cta/layout.js
@@ -1,0 +1,36 @@
+import metadata from './block-pattern.json';
+import mainThemeUrl from '../main-theme-url';
+
+const layout = ({
+  titlePlaceholder = 'Enter title'
+}) => [
+  [
+    'core/columns',
+    {
+      className: `block ${metadata.classname}`,
+      textColor: 'white',
+      backgroundColor: 'dark-blue',
+    },
+    [
+      ['core/column', {}, [
+        ['core/image', {
+          align: 'center',
+          className: 'force-no-lightbox force-no-caption',
+          url: `${mainThemeUrl}/images/placeholders/placeholder-80x80.jpg`,
+        }],
+        ['core/heading', {
+          textAlign: 'center',
+          level: 3,
+          placeholder: titlePlaceholder
+        }],
+        ['core/spacer', {height: '16px'}],
+        ['core/buttons', {layout: {type: 'flex', justifyContent: 'center'}}, [
+          ['core/button', {className: 'is-style-transparent'}]
+        ]],
+        ['core/spacer', {height: '16px'}],
+      ]]
+    ]
+  ]
+];
+
+export default layout;

--- a/assets/src/block-patterns/issues/block-pattern.json
+++ b/assets/src/block-patterns/issues/block-pattern.json
@@ -1,0 +1,8 @@
+{
+  "name": "p4/issues",
+  "title": "Issues",
+  "description": "Issues",
+  "categories": ["planet4"],
+  "classname": "is-pattern-p4-issues",
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/block-patterns/issues/index.js
+++ b/assets/src/block-patterns/issues/index.js
@@ -1,0 +1,6 @@
+import metadata from './block-pattern.json';
+import layout from './layout';
+
+const { name } = metadata;
+
+export { name, metadata, layout };

--- a/assets/src/block-patterns/issues/layout.js
+++ b/assets/src/block-patterns/issues/layout.js
@@ -1,0 +1,64 @@
+import metadata from './block-pattern.json';
+import mainThemeUrl from '../main-theme-url';
+
+const mediaText = [
+  'core/media-text', {
+    mediaWidth: 15,
+    mediaUrl: `${mainThemeUrl}/images/placeholders/placeholder-40x40.jpg`,
+    mediaType: 'image',
+    mediaSizeSlug: 'thumbnail',
+    isStackedOnMobile: false,
+    verticalAlignment: 'center',
+    imageFille: false,
+    backgroundColor: 'white',
+    className: 'is-style-large-padding force-no-lightbox',
+  }, [
+    ['core/paragraph', {
+      align: 'left',
+      placeholder: 'Enter text',
+      style:{typography: {fontSize:'1rem', fontStyle:'normal', 'fontWeight': 700}},
+      className: 'is-style-roboto-font-family',
+    }]
+  ]
+]
+
+const layout = () => [
+  [
+    'core/group',
+    {
+      className: `${metadata.classname}`,
+      align: 'full',
+      backgroundColor: 'grey-05',
+    },
+    [
+      ['core/group', {className: 'container'}, [
+        ['core/spacer', {height: '60px'}],
+        ['core/heading', {
+          level: 1,
+          textAlign: 'center',
+          placeholder: 'Enter title',
+        }],
+        ['core/paragraph', {
+          align: 'center',
+          placeholder: 'Enter description',
+        }],
+        ['core/spacer', {height: '37px'}],
+        ['core/group', {
+          className: 'is-style-space-evenly',
+          layout: {type: 'flex', allowOrientation: false}
+        }, [
+          mediaText, mediaText, mediaText, mediaText
+        ]],
+        ['core/spacer', {height: '37px'}],
+        ['core/buttons', {
+          layout: {type: 'flex', justifyContent: 'center'}
+        }, [
+          ['core/button']
+        ]],
+        ['core/spacer', {height: '69px'}],
+      ]],
+    ]
+  ]
+];
+
+export default layout;

--- a/assets/src/block-patterns/main-theme-url.js
+++ b/assets/src/block-patterns/main-theme-url.js
@@ -1,0 +1,3 @@
+const mainThemeUrl = `${window.p4bk_vars.themeUrl || ''}`;
+
+export default mainThemeUrl;

--- a/assets/src/block-patterns/page-header-img-side/block-pattern.json
+++ b/assets/src/block-patterns/page-header-img-side/block-pattern.json
@@ -1,0 +1,8 @@
+{
+  "name": "p4/page-header-img",
+  "title": "Page Header with image",
+  "description": "Page Header with image",
+  "classname": "is-pattern-p4-page-header",
+  "categories": ["page-headers"],
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/block-patterns/page-header-img-side/index.js
+++ b/assets/src/block-patterns/page-header-img-side/index.js
@@ -1,0 +1,30 @@
+import { registerBlockVariation } from '@wordpress/blocks';
+import metadata from './block-pattern.json';
+import layout from './layout';
+import mediaTextVariation from './media-text-variation';
+
+[ 'left', 'right' ].map(
+  (imgSide) => registerBlockVariation(
+    ...mediaTextVariation({mediaPosition: imgSide})
+  )
+);
+
+const variation = (imgSide = 'right') => {
+  const [ blockname, props ] = mediaTextVariation({mediaPosition: imgSide});
+
+  return {
+    name: props.name,
+    metadata: {
+      ...metadata,
+      name: props.name,
+      title: props.title,
+      description: props.description
+    },
+    layout: (attrs = {}) => layout({mediaPosition: imgSide, ...attrs}),
+  }
+};
+
+const { name } = metadata;
+const defaultLayout = variation().layout;
+
+export { name, metadata, defaultLayout as layout, variation };

--- a/assets/src/block-patterns/page-header-img-side/innerBlocks.js
+++ b/assets/src/block-patterns/page-header-img-side/innerBlocks.js
@@ -1,0 +1,18 @@
+const innerBlocks = [
+    ['core/group', {}, [
+      ['core/heading', {
+        level: 1,
+        backgroundColor: 'white',
+        placeholder: 'Enter title'
+      }]
+    ]],
+    ['core/paragraph', {
+      placeholder: 'Enter description',
+      style: { typography: { fontSize: '1.25rem'} }
+    }],
+    ['core/buttons', {}, [
+      ['core/button', {className: 'is-style-cta'}]
+    ]],
+];
+
+export default innerBlocks;

--- a/assets/src/block-patterns/page-header-img-side/layout.js
+++ b/assets/src/block-patterns/page-header-img-side/layout.js
@@ -1,0 +1,11 @@
+import mediaTextVariation from './media-text-variation';
+
+const layout = (attrs) => {
+  const [ blockname, props ] = mediaTextVariation(attrs);
+
+  return [
+    [ blockname, props.attributes, props.innerBlocks ]
+  ];
+};
+
+export default layout;

--- a/assets/src/block-patterns/page-header-img-side/media-text-variation.js
+++ b/assets/src/block-patterns/page-header-img-side/media-text-variation.js
@@ -1,0 +1,31 @@
+import metadata from './block-pattern.json';
+import innerBlocks from './innerBlocks';
+import mainThemeUrl from '../main-theme-url';
+
+const blockAttributes = {
+  className: metadata.classname,
+  align: 'full',
+  mediaType: 'image',
+  mediaUrl: `${mainThemeUrl}/images/placeholders/placeholder-546x415.jpg`,
+  imageFill: false,
+};
+
+const mediaTextVariation = ({
+  mediaPosition = 'right'
+}) => ([
+  'core/media-text',
+  {
+    name: `${metadata.name}-${mediaPosition}`,
+    title: `${metadata.title} on the ${mediaPosition}`,
+    description: `${metadata.description} on the ${mediaPosition}`,
+    scope: ['inserter'],
+    attributes: { ...blockAttributes, mediaPosition },
+    innerBlocks,
+    isActive: (blockAttributes) => (
+      blockAttributes.className === metadata.classname
+      && blockAttributes.mediaPosition === mediaPosition
+    )
+  }
+]);
+
+export default mediaTextVariation;

--- a/assets/src/block-patterns/pattern-list.js
+++ b/assets/src/block-patterns/pattern-list.js
@@ -1,0 +1,24 @@
+import * as deepDive from './deep-dive';
+import * as highlightedCta from './highlighted-cta';
+import * as issues from './issues';
+import * as pageHeaderImgSide from './page-header-img-side';
+import * as quickLinks from './quick-links';
+import * as realityCheck from './reality-check';
+import * as sideImgTextCta from './side-image-with-text-and-cta';
+
+import * as highLevelTopic from './high-level-topic';
+
+const patternList = [
+  deepDive,
+  highlightedCta,
+  issues,
+  pageHeaderImgSide.variation('right'),
+  pageHeaderImgSide.variation('left'),
+  quickLinks,
+  realityCheck,
+  sideImgTextCta,
+  //
+  highLevelTopic,
+];
+
+export default patternList;

--- a/assets/src/block-patterns/quick-links/block-pattern.json
+++ b/assets/src/block-patterns/quick-links/block-pattern.json
@@ -1,0 +1,8 @@
+{
+  "name": "p4/quick-links",
+  "title": "Quick Links",
+  "description": "Quick Links",
+  "classname": "is-pattern-p4-quick-links",
+  "categories": ["planet4"],
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/block-patterns/quick-links/index.js
+++ b/assets/src/block-patterns/quick-links/index.js
@@ -1,0 +1,6 @@
+import metadata from './block-pattern.json';
+import layout from './layout';
+
+const { name } = metadata;
+
+export { name, metadata, layout };

--- a/assets/src/block-patterns/quick-links/layout.js
+++ b/assets/src/block-patterns/quick-links/layout.js
@@ -1,0 +1,43 @@
+import metadata from './block-pattern.json';
+import mainThemeUrl from '../main-theme-url';
+
+const category = ['core/column', {}, [
+  ['core/group', {className: 'group-stretched-link'}, [
+    ['core/image', {
+      align: 'center',
+      className: 'is-style-rounded-90 force-no-lightbox force-no-caption mb-0',
+      url: `${mainThemeUrl}/images/placeholders/placeholder-90x90.jpg`
+    }],
+    ['core/spacer', {height: '16px'}],
+    ['core/heading', {
+      level: 5,
+      style: {typography: {fontSize: '1rem'}},
+      textAlign: 'center',
+      placeholder: 'Category'
+    }]
+  ]]
+]];
+
+const layout = ({
+  titlePlaceholder = 'Enter title',
+  backgroundColor = 'grey-05',
+}) => ([
+  ['core/group', {
+    className: `block ${metadata.classname}`,
+    align: 'full',
+    backgroundColor
+  }, [
+    ['core/group', {className: 'container'}, [
+      ['core/spacer', {height: '24px'}],
+      ['core/heading', {level: 4, placeholder: titlePlaceholder}],
+      ['core/columns', {
+        isStackedOnMobile: false,
+        className: 'is-style-mobile-carousel'
+      }, [
+        category, category, category, category, category
+      ]]
+    ]]
+  ]]
+]);
+
+export default layout;

--- a/assets/src/block-patterns/readme.md
+++ b/assets/src/block-patterns/readme.md
@@ -1,0 +1,70 @@
+# Block patterns in javascript
+
+This code uses Gutenberg functions to generate valid HTML code for the editor from raw blocks declaration `[block name, block attributes, inner blocks]`.
+
+- [`createBlock( name, attributes = {}, innerBlocks = [] )`](https://github.com/WordPress/gutenberg/blob/c81fb68193ef25fb42a05f3f004a0c0921fd1643/packages/blocks/src/api/factory.js#L35-L61) returns a Block object given its attributes
+- [`createBlocksFromInnerBlocksTemplate( innerBlocksOrTemplate = [] )`](https://github.com/WordPress/gutenberg/blob/c81fb68193ef25fb42a05f3f004a0c0921fd1643/packages/blocks/src/api/factory.js#L63-L91) recursively creates Block object from inner blocks
+- [`serialize( blocks, options )`](https://github.com/WordPress/gutenberg/blob/c81fb68193ef25fb42a05f3f004a0c0921fd1643/packages/blocks/src/api/serializer.js#L396-L407) serializes the block objects as valid HTML for the editor, including the delimiter comments `<!-- wp -->`.
+
+## Creating a new block pattern
+
+Create a directory named after your pattern, with 3 files in it:
+- `block-pattern.json` is a direct transposition of the [`block.json` metadata file encouraged by WordPress](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/); it allows to share basic data between client and server in a format readable by both. It has to be valid JSON.
+- `layout.js` describes in the simplest template format the blocks used and their position.
+- `index.js` exports all relevant data (name, metadata, layout), allowing for more data process if needed.
+
+A simple block pattern as an example:
+
+_my-pattern/block-pattern.json_
+```json
+{
+  "name": "p4/my-pattern",
+  "title": "My Pattern",
+  "description": "My Pattern",
+  "categories": ["planet4"],
+  "classname": "is-pattern-p4-my-pattern",
+  "textdomain": "planet4-blocks-backend"
+}
+```
+
+_my-pattern/layout.js_
+```js
+import metadata from './block-pattern.json';
+
+const layout = () => ([
+    ['core/heading', {level: 2, placeholder: 'Enter title'}]
+    ['core/group', {}, [
+        ['core/paragraph', {align: 'center', placeholder: 'Paragraph 1 in group'}],
+        ['core/paragraph', {content: 'Paragraph 2 content'}]
+    ]]
+]);
+
+export default layout;
+```
+
+_my-pattern/index.js_
+```js
+import metadata from './block-pattern.json';
+import layout from './layout';
+
+const { name } = metadata;
+
+export { name, metadata, layout };
+```
+_Instead of a `layout()` function, you can also export a `content()` function that will replace the "translate and generate content from layout" process_
+
+## Registering block pattern and generating HTML code
+
+Include your block pattern in `pattern-list.js`.
+
+`register.js` takes all patterns declared in `patternList` and
+1. extracts pattern settings from `block-pattern.json`
+2. translates those settings according to `block-pattern-i18n.js` schema
+3. translates the blocks properties according to `block-attributes-i18n.js` schema
+4. generates the HTML content with `content-from-layout.js`
+5. registers the block pattern by pushing it to the editor settings
+
+## Translations
+
+Translation is based on https://github.com/WordPress/wordpress-develop/blob/ee26676d5029ca5dedc1e5de1be849cfff7c5cbf/src/wp-includes/l10n.php#L1751 used for blocks settings declaration.
+Given a schema of data to translate and [a text domain](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#text-domain), the function will return translated content.

--- a/assets/src/block-patterns/reality-check/block-pattern.json
+++ b/assets/src/block-patterns/reality-check/block-pattern.json
@@ -1,0 +1,8 @@
+{
+  "name": "p4/reality-check",
+  "title": "Reality Check",
+  "description": "Reality Check",
+  "classname": "is-pattern-p4-reality-check",
+  "categories": ["planet4"],
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/block-patterns/reality-check/index.js
+++ b/assets/src/block-patterns/reality-check/index.js
@@ -1,0 +1,6 @@
+import metadata from './block-pattern.json';
+import layout from './layout';
+
+const { name } = metadata;
+
+export { name, metadata, layout };

--- a/assets/src/block-patterns/reality-check/layout.js
+++ b/assets/src/block-patterns/reality-check/layout.js
@@ -1,0 +1,30 @@
+import metadata from './block-pattern.json';
+import mainThemeUrl from '../main-theme-url';
+
+const topic = ['core/column', {}, [
+  ['core/image', {
+    align: 'center',
+    className: 'mb-0 force-no-lightbox force-no-caption',
+    url: `${mainThemeUrl}/images/placeholders/placeholder-75x75.jpg`
+  }],
+  ['core/heading', {
+    level: 2,
+    style: {typography: {fontSize: '4rem'}},
+    textAlign: 'center',
+    className: 'mb-0',
+    placeholder: 'Enter title'
+  }],
+  ['core/paragraph', {
+    align: 'center',
+    placeholder: 'Enter description'
+  }],
+  ['core/spacer', {height: '16px'}],
+]];
+
+const layout = () => [
+  ['core/columns', {className: `block ${metadata.classname}`}, [
+    topic, topic, topic
+  ]]
+];
+
+export default layout;

--- a/assets/src/block-patterns/register.js
+++ b/assets/src/block-patterns/register.js
@@ -1,0 +1,58 @@
+import contentFromLayout from './content-from-layout';
+import { translateSettings, translateLayout } from './translate';
+import i18nBlockPatternSchema from './block-pattern-i18n.json';
+import i18nBlockAttrSchema from './block-attributes-i18n.json';
+
+import patternList from './pattern-list';
+
+const { getCurrentPostType } = wp.data.select('core/editor');
+const { getSettings } = wp.data.select('core/block-editor');
+const { updateSettings } = wp.data.dispatch('core/block-editor');
+
+const getPatternSettings = (metadata) => {
+  const props = [
+    'name', 'title', 'description',
+    'categories', 'keywords', 'viewportWidth',
+    'blockTypes', 'postTypes', 'inserter',
+  ];
+  let settings = Object.fromEntries(
+    Object.entries(metadata).filter(([key]) => props.includes(key))
+  );
+
+  return translateSettings(i18nBlockPatternSchema, settings, metadata.textdomain);
+};
+
+/**
+ * A pattern needs
+ * - metadata
+ * - layout function that will be translated and converted to content
+ *   - or content function
+ */
+export const registerBlockPatterns = () => {
+  const currentPostType = getCurrentPostType();
+  let settings = getSettings();
+
+  patternList.map((pattern) => {
+    const { metadata, layout, content = null } = pattern;
+
+    if (metadata.postTypes
+      && !metadata.postTypes.includes(currentPostType)
+    ) {
+      return null;
+    }
+
+    const patternSettings = getPatternSettings(metadata);
+    const patternContent = content ? content() : contentFromLayout(
+      translateLayout(
+        i18nBlockAttrSchema, layout({}), metadata.textdomain
+      )
+    );
+
+    settings.__experimentalBlockPatterns.push({
+      content: patternContent,
+      ...patternSettings
+    });
+  });
+
+  updateSettings( settings );
+};

--- a/assets/src/block-patterns/side-image-with-text-and-cta/block-pattern.json
+++ b/assets/src/block-patterns/side-image-with-text-and-cta/block-pattern.json
@@ -1,0 +1,8 @@
+{
+  "name": "p4/side-image-with-text-and-cta",
+  "title": "Side image with text and CTA",
+  "description": "Side image with text and CTA",
+  "classname": "is-pattern-p4-side-image-with-text-and-cta",
+  "categories": ["planet4"],
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/block-patterns/side-image-with-text-and-cta/index.js
+++ b/assets/src/block-patterns/side-image-with-text-and-cta/index.js
@@ -1,0 +1,6 @@
+import metadata from './block-pattern.json';
+import layout from './layout';
+
+const { name } = metadata;
+
+export { name, metadata, layout };

--- a/assets/src/block-patterns/side-image-with-text-and-cta/layout.js
+++ b/assets/src/block-patterns/side-image-with-text-and-cta/layout.js
@@ -1,0 +1,26 @@
+import metadata from './block-pattern.json';
+import mainThemeUrl from '../main-theme-url';
+
+const layout = ({
+  titlePlaceholder = 'Enter title',
+  backgroundColor = null,
+  alignFull = false,
+  mediaPosition = 'left,'
+}) => ([
+  ['core/media-text', {
+    mediaType: 'image',
+    mediaPosition,
+    mediaUrl: `${mainThemeUrl}/images/placeholders/placeholder-546x415.jpg`,
+    isStackedOnMobile: true,
+    backgroundColor,
+    alignFull
+  }, [
+    ['core/heading', {level: 2, placeholder: titlePlaceholder}],
+    ['core/paragraph', {placeholder: 'Enter description'}],
+    ['core/buttons', {}, [
+      ['core/button']
+    ]]
+  ]]
+]);
+
+export default layout;

--- a/assets/src/block-patterns/translate.js
+++ b/assets/src/block-patterns/translate.js
@@ -1,0 +1,103 @@
+import { _x } from '@wordpress/i18n';
+import { isEmpty } from 'lodash';
+
+function isObject( object ) {
+  return object !== null && typeof object === 'object';
+}
+
+/**
+ * Copy/paste of https://github.com/WordPress/gutenberg/blob/58c78ec5200a38401281c14186095bced2f6f12a/packages/blocks/src/api/registration.js#L296
+ *
+ * Translates block settings provided with metadata using the i18n schema.
+ *
+ * @param {string|string[]|Object[]} i18nSchema   I18n schema for the block setting.
+ * @param {string|string[]|Object[]} settingValue Value for the block setting.
+ * @param {string}                   textdomain   Textdomain to use with translations.
+ *
+ * @return {string|string[]|Object[]} Translated setting.
+ */
+function translateBlockSettingUsingI18nSchema(
+  i18nSchema,
+  settingValue,
+  textdomain
+) {
+  if ( typeof i18nSchema === 'string' && typeof settingValue === 'string' ) {
+    return _x( settingValue, i18nSchema, textdomain );
+  }
+  if (
+    Array.isArray( i18nSchema ) &&
+    ! isEmpty( i18nSchema ) &&
+    Array.isArray( settingValue )
+  ) {
+    return settingValue.map( ( value ) =>
+      translateBlockSettingUsingI18nSchema(
+        i18nSchema[ 0 ],
+        value,
+        textdomain
+      )
+    );
+  }
+  if (
+    isObject( i18nSchema ) &&
+    ! isEmpty( i18nSchema ) &&
+    isObject( settingValue )
+  ) {
+    return Object.keys( settingValue ).reduce( ( accumulator, key ) => {
+      if ( ! i18nSchema[ key ] ) {
+        accumulator[ key ] = settingValue[ key ];
+        return accumulator;
+      }
+      accumulator[ key ] = translateBlockSettingUsingI18nSchema(
+        i18nSchema[ key ],
+        settingValue[ key ],
+        textdomain
+      );
+      return accumulator;
+    }, {} );
+  }
+  return settingValue;
+}
+
+/**
+ * Simplified version of schema translation
+ *
+ * For each block, declare a list of properties that should be translated.
+ * No structure/depth notion.
+ *
+ * @example
+ * ```
+ * {
+ *   "block name": {
+ *     "property name": "property context for translators"
+ *   }
+ * }
+ * ```
+ * will call
+ * `_x(value of property in current block, property context, text domain)`
+ */
+export const translateBlock = (schema, blockDefinition, textdomain) => {
+  let [ name, attributes, innerBlocks = [] ] = blockDefinition;
+  let translated = attributes;
+
+  if ( schema[name] ) {
+    Object.keys(schema[name]).map((key) => {
+      if ( attributes[key] ) {
+        translated[key] = _x( attributes[key], schema[name][key], textdomain );
+      }
+    });
+  }
+
+  return [
+    name,
+    translated,
+    innerBlocks.map((b) => translateBlock(schema, b, textdomain))
+  ];
+};
+
+export const translateLayout = (schema, layout, textdomain) => {
+  return layout.map((block) => translateBlock(schema, block, textdomain));
+};
+
+export const translateSettings = (schema, settings, textdomain) => {
+  return translateBlockSettingUsingI18nSchema(schema, settings, textdomain);
+};

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -22,6 +22,8 @@ import { blockEditorValidation } from './BlockEditorValidation';
 import { registerGuestBookBlock } from './blocks/GuestBook/GuestBookBlock';
 import { registerBlock as registerShareButtonsBlock } from './blocks/ShareButtons/ShareButtonsBlock';
 
+import { registerBlockPatterns } from './block-patterns/register';
+
 blockEditorValidation();
 new ArticlesBlock();
 registerColumnsBlock();
@@ -62,3 +64,15 @@ registerBlockVariation('core/group', {
   },
   icon: 'admin-links',
 });
+
+window.onload = function() {
+  let obs = new MutationObserver((o, m) => {
+    let button = document.querySelector('.edit-post-header-toolbar__inserter-toggle');
+    if (button) {
+      button.addEventListener('click', () => registerBlockPatterns());
+      m.disconnect();
+      return;
+    }
+  });
+  obs.observe(document, { childList: true, subtree: true });
+};

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -103,6 +103,11 @@ final class Loader {
 			[ 'label' => __( 'Layouts', 'planet4-blocks-backend' ) ],
 		);
 
+		register_block_pattern_category(
+			'page-headers',
+			[ 'label' => __( 'Page headers', 'planet4-blocks-backend' ) ],
+		);
+
 		// Load block patterns.
 		Block_Pattern::register_all();
 	}

--- a/classes/patterns/class-block-pattern.php
+++ b/classes/patterns/class-block-pattern.php
@@ -41,13 +41,7 @@ abstract class Block_Pattern {
 	public static function get_list(): array {
 		return [
 			BlankPage::class,
-			DeepDive::class,
 			GetInformed::class,
-			HighlightedCta::class,
-			Issues::class,
-			QuickLinks::class,
-			RealityCheck::class,
-			SideImageWithTextAndCta::class,
 		];
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2449,6 +2449,12 @@
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.182",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -2459,6 +2465,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
       "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
+      "dev": true
+    },
+    "@types/mousetrap": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.9.tgz",
+      "integrity": "sha512-HUAiN65VsRXyFCTicolwb5+I7FM6f72zjMWr+ajGk+YTvzBgXqa2A5U7d+rtsouAkunJ5U4Sb5lNJjo9w+nmXg==",
       "dev": true
     },
     "@types/node": {
@@ -2479,10 +2491,42 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "dev": true
+    },
     "@types/q": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "17.0.47",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.47.tgz",
+      "integrity": "sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-dom": {
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.17.tgz",
+      "integrity": "sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "^17"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -2799,6 +2843,32 @@
         "@wordpress/dom-ready": "^2.5.1"
       }
     },
+    "@wordpress/autop": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.13.0.tgz",
+      "integrity": "sha512-EAVrb7KuSfCBDFnGJJxD/9TVkDZEi/A1F2YSOb0X8RPS6RQNtXU76aiNyrm/G8ovJ/ElRGfSiy/+hwqZlnQo+A==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.18.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+          "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+          "dev": true
+        }
+      }
+    },
     "@wordpress/babel-plugin-import-jsx-pragma": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-2.2.0.tgz",
@@ -2820,6 +2890,362 @@
         "@babel/runtime": "^7.4.4",
         "@wordpress/babel-plugin-import-jsx-pragma": "^2.2.0",
         "@wordpress/browserslist-config": "^2.5.0"
+      }
+    },
+    "@wordpress/blob": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.13.0.tgz",
+      "integrity": "sha512-ehWsapoUByU0Hn7i8ph7e6sLyj5D1gFAqYIV8VK4b76VP9TRu42M43veAdNoYpkkd6RUITJABXwTufC2bgo9CA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.18.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+          "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+          "dev": true
+        }
+      }
+    },
+    "@wordpress/block-serialization-default-parser": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.13.0.tgz",
+      "integrity": "sha512-ybvLS93jbQzsy4XpY3PMg3kacVm7e6xsY24KxApoTgQNUcmXnASkxL0ljv2Cwjpz5zD/mk07nc33CBahJfktZA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.18.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+          "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+          "dev": true
+        }
+      }
+    },
+    "@wordpress/blocks": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-11.12.0.tgz",
+      "integrity": "sha512-+krs+etDAuOW52eDk2gI2gzrnV3vWOFUgPM2sDrZk2C4qV/Dcq0Sp5fFV/CoQQECXuK8TvYanxNmMSPgZG3pYQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/autop": "^3.13.0",
+        "@wordpress/blob": "^3.13.0",
+        "@wordpress/block-serialization-default-parser": "^4.13.0",
+        "@wordpress/data": "^6.13.0",
+        "@wordpress/deprecated": "^3.13.0",
+        "@wordpress/dom": "^3.13.0",
+        "@wordpress/element": "^4.11.0",
+        "@wordpress/hooks": "^3.13.0",
+        "@wordpress/html-entities": "^3.13.0",
+        "@wordpress/i18n": "^4.13.0",
+        "@wordpress/is-shallow-equal": "^4.13.0",
+        "@wordpress/shortcode": "^3.13.0",
+        "colord": "^2.7.0",
+        "hpq": "^1.3.0",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "rememo": "^4.0.0",
+        "showdown": "^1.9.1",
+        "simple-html-tokenizer": "^0.5.7",
+        "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.18.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+          "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@tannin/compile": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
+          "integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
+          "dev": true,
+          "requires": {
+            "@tannin/evaluate": "^1.2.0",
+            "@tannin/postfix": "^1.1.0"
+          }
+        },
+        "@tannin/evaluate": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
+          "integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg==",
+          "dev": true
+        },
+        "@tannin/plural-forms": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
+          "integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
+          "dev": true,
+          "requires": {
+            "@tannin/compile": "^1.1.0"
+          }
+        },
+        "@tannin/postfix": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
+          "integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==",
+          "dev": true
+        },
+        "@wordpress/compose": {
+          "version": "5.11.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.11.0.tgz",
+          "integrity": "sha512-S6KABT9jB6ynvTIEHFnPjeT++xsmX3410ctTNNOiVY3HdcnVjzXcu6czqj/y3OWXupNn7WqRA9p9pWaSvSKMXQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@types/lodash": "^4.14.172",
+            "@types/mousetrap": "^1.6.8",
+            "@wordpress/deprecated": "^3.13.0",
+            "@wordpress/dom": "^3.13.0",
+            "@wordpress/element": "^4.11.0",
+            "@wordpress/is-shallow-equal": "^4.13.0",
+            "@wordpress/keycodes": "^3.13.0",
+            "@wordpress/priority-queue": "^2.13.0",
+            "clipboard": "^2.0.8",
+            "lodash": "^4.17.21",
+            "mousetrap": "^1.6.5",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/data": {
+          "version": "6.13.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.13.0.tgz",
+          "integrity": "sha512-9PRpBzxEqvgms4xegjvsujc9h5vDQibnZBEp7IBQEKUmPXM0nqp84c83skSVxs55yu3QVlKSK6WFg5Rr0fu2oA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@wordpress/compose": "^5.11.0",
+            "@wordpress/deprecated": "^3.13.0",
+            "@wordpress/element": "^4.11.0",
+            "@wordpress/is-shallow-equal": "^4.13.0",
+            "@wordpress/priority-queue": "^2.13.0",
+            "@wordpress/redux-routine": "^4.13.0",
+            "equivalent-key-map": "^0.2.2",
+            "is-promise": "^4.0.0",
+            "lodash": "^4.17.21",
+            "redux": "^4.1.2",
+            "turbo-combine-reducers": "^1.0.2",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/deprecated": {
+          "version": "3.13.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.13.0.tgz",
+          "integrity": "sha512-0k0/h5Y9a7bb5HEDK9yJI+NBVrO/YyGcnI87DIgMVXTysykRf78qQq4CUvFh8roo1aOAFIUQDYQrJttkbbWyhw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@wordpress/hooks": "^3.13.0"
+          }
+        },
+        "@wordpress/dom": {
+          "version": "3.13.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.13.0.tgz",
+          "integrity": "sha512-8fDWKGgAUrrJFeYm+ahlPRYzs5k2NmWNlw45SvH60nlkZjdjN5UuM8gEgVZadxNq+vCazuvSMGLesZXGuY4FRQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@wordpress/deprecated": "^3.8.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@wordpress/element": {
+          "version": "4.11.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.11.0.tgz",
+          "integrity": "sha512-3Ha/BChFgkzh8oKK/FxXLEYSobCAMfWKdK/anNTWqbGxZM0ue1kowu23D7gUCCugjKOZdkhAabgJIjPflrGQOg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@types/react": "^17.0.37",
+            "@types/react-dom": "^17.0.11",
+            "@wordpress/escape-html": "^2.13.0",
+            "lodash": "^4.17.21",
+            "react": "^17.0.2",
+            "react-dom": "^17.0.2"
+          }
+        },
+        "@wordpress/escape-html": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.13.0.tgz",
+          "integrity": "sha512-olUMVQehbNZJpn4C3ysUzh/70lEzeDZa309KuMX+8P17Mj+lgsjs7lkLqHKpxhXtsLic1lNsLCkCStDY4iiCqw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0"
+          }
+        },
+        "@wordpress/hooks": {
+          "version": "3.13.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.13.0.tgz",
+          "integrity": "sha512-N+82Dt3jsREtN0dCypehaWuwCjPOM3ljxyzVWULMDrIK9TaIvkunkHViIyoCkxWk3lolRRqh8XmD+ox/mF+n1A==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0"
+          }
+        },
+        "@wordpress/i18n": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.13.0.tgz",
+          "integrity": "sha512-25x0ylQzXxbaw3oM8afoahiPzzZfzikBNzkzlEJ4MuI9u61zmFedbkIrsmhXtYNlcZ/52RxeUcswHdVs4Hln9Q==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@wordpress/hooks": "^3.13.0",
+            "gettext-parser": "^1.3.1",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "sprintf-js": "^1.1.1",
+            "tannin": "^1.2.0"
+          }
+        },
+        "@wordpress/is-shallow-equal": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.13.0.tgz",
+          "integrity": "sha512-oUoMbEZwnbd4nfEo6uxkvrNCc/LnqC9MIY6kK3iWtMhcykQNpbK3XY/i/NvJb+QpRf7U6XhXyw4//HcQv39iOA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0"
+          }
+        },
+        "@wordpress/keycodes": {
+          "version": "3.13.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.13.0.tgz",
+          "integrity": "sha512-9uUjUebl9Lau43St9wXJnnkWhbjNsv6gF8Fd+KST5tCctwUWx+QDs7Qk5ciNSNp9FVwfACK/6fMz9r6Tr/f4Aw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@wordpress/i18n": "^4.13.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@wordpress/priority-queue": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.13.0.tgz",
+          "integrity": "sha512-c3xX+e1VjM3axm4pcQzlUuJgkEe4xtsMxW+dwHR6IWFruzDItPvLxIZaeP3aCMZvmd7KUdzzo5f/u0eq1xr9pw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0"
+          }
+        },
+        "@wordpress/redux-routine": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.13.0.tgz",
+          "integrity": "sha512-jmfllylWwEutaddPYWQjeRuLhsqQd8hqJeN9Pj8Sh7VABk0SWbPQWtfahPhfZj7kYGTcrxa6cquRNjwJ+VmcDg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "is-promise": "^4.0.0",
+            "lodash": "^4.17.21",
+            "rungen": "^0.3.2"
+          }
+        },
+        "clipboard": {
+          "version": "2.0.11",
+          "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
+          "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
+          "dev": true,
+          "requires": {
+            "good-listener": "^1.2.2",
+            "select": "^1.1.2",
+            "tiny-emitter": "^2.0.0"
+          }
+        },
+        "is-promise": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+          "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+          "dev": true
+        },
+        "memize": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+          "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+          "dev": true
+        },
+        "mousetrap": {
+          "version": "1.6.5",
+          "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
+          "integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==",
+          "dev": true
+        },
+        "react": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+          "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "redux": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+          "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.9.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+          "dev": true
+        },
+        "rememo": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.1.tgz",
+          "integrity": "sha512-x/T5q/pCDh8k4OlvJGqkI3eO+O8hmJv9HhJHo4avwlluwUpDbteDvyqw1PTarEITkeH9bfW6GSKeRke+XKgykw==",
+          "dev": true
+        },
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+          "dev": true
+        },
+        "tannin": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
+          "integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
+          "dev": true,
+          "requires": {
+            "@tannin/plural-forms": "^1.1.0"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "@wordpress/browserslist-config": {
@@ -3094,6 +3520,32 @@
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4"
+      }
+    },
+    "@wordpress/html-entities": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.13.0.tgz",
+      "integrity": "sha512-LMwQgBj0rPDrVoVrlx5ppXP2kWmenvpl9hQzodjFvbq8lRGyeJSKaHEJk1bU++X1q88hcd2ADrHezWPuy8hfZw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.18.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+          "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+          "dev": true
+        }
       }
     },
     "@wordpress/i18n": {
@@ -3840,6 +4292,39 @@
           "requires": {
             "camelcase": "^4.1.0"
           }
+        }
+      }
+    },
+    "@wordpress/shortcode": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.13.0.tgz",
+      "integrity": "sha512-8QIaU6uS3PDY93P3DSPO3FFloGVSLpYLT1q5f7iH+SQuzJr3tAbsAIAiBgbtUFZ4ilNcSbYxP78KrhmZYZnTMQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.16.0",
+        "memize": "^1.1.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.18.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+          "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "memize": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+          "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+          "dev": true
         }
       }
     },
@@ -5780,6 +6265,12 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "colord": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
+      "integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
+      "dev": true
+    },
     "colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
@@ -6728,6 +7219,12 @@
       "requires": {
         "cssom": "~0.3.6"
       }
+    },
+    "csstype": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
+      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -9830,6 +10327,12 @@
       "version": "3.8.7",
       "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.8.7.tgz",
       "integrity": "sha512-ckAx3EkUr5XjDwjEHDorHxRO2Kb7z6Z2Sxul4MbBkN8Nho7XDslQsgMJT+CiJ5Z4TgRxxvKHEpuLE3imzqy4Lg=="
+    },
+    "hpq": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/hpq/-/hpq-1.3.0.tgz",
+      "integrity": "sha512-fvYTvdCFOWQupGxqkahrkA+ERBuMdzkxwtUdKrxR6rmMd4Pfl+iZ1QiQYoaZ0B/v0y59MOMnz3XFUWbT50/NWA==",
+      "dev": true
     },
     "hsl-regex": {
       "version": "1.0.0",
@@ -16601,6 +17104,127 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
+    "showdown": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
+      "integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
+      "dev": true,
+      "requires": {
+        "yargs": "^14.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "yargs": {
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
+          "integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -16624,6 +17248,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "simple-html-tokenizer": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
+      "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
       "dev": true
     },
     "simple-swizzle": {
@@ -18992,6 +19622,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "use-memo-one": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
+      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
       "dev": true
     },
     "use-theme-editor": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/plugin-proposal-optional-chaining": "*",
     "@commitlint/cli": "^12.1.4",
     "@greenpeace/dashdash": "^1.1.2",
+    "@wordpress/blocks": "^11.12",
     "@wordpress/components": "^8.3.2",
     "@wordpress/data": "^4.9.2",
     "@wordpress/e2e-test-utils": "^4.5.0",


### PR DESCRIPTION
Cf [README file](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/b70350407c4ed50fb59889d08c63efe28fd4f311/assets/src/block-patterns/readme.md)

Using static output to declare patterns makes a lot of sense for editors to be able to exchange those patterns using just a  copy/paste - the [Block Pattern Directory](https://wordpress.org/patterns/) is exactly the goal of this.

But for developers, the way we do it currently requires a double declaration; for every change we make to various attributes of blocks, we also have to report them to the HTML output. This has several disadvantages:
- more work for reporting changes in both places
- more work for adding parameters to be able to extend those patterns without repetition
- error prone, using the wrong attribute output or value can break the pattern
- the block output is static, it won't evolve if the blocks used get new features or modifies its output with deprecations


This PR proposes to declare patterns only in the simplest JS declaration of blocks `[ block name, block attributes, inner blocks ]`, and use Gutenberg functions to generate the pattern HTML output when needed. 

## Features
- Block patterns declaration in JS
- HTML content generated at runtime from Gutenberg editor functions