### PR TITLE
PLANET-6828 Fix Covers carousel layout in Safari

### DIFF
--- a/assets/src/blocks/Covers/CampaignCovers.js
+++ b/assets/src/blocks/Covers/CampaignCovers.js
@@ -5,19 +5,16 @@ const { __ } = wp.i18n;
 
 export const CampaignCovers = ({
   covers,
-  initialRowsLimit,
-  row,
   inEditor = false,
-  isCarouselLayout,
-  amountOfCoversPerRow,
   isExample,
+  hideCover,
 }) => (
   <div className='covers'>
     {covers.map((cover, index) => {
       const { image, alt_text } = cover;
-      const hideCover = !isCarouselLayout && !!initialRowsLimit && index >= row * amountOfCoversPerRow;
+      const hideThisCover = hideCover(index);
 
-      if (hideCover) {
+      if (hideThisCover) {
         return null;
       }
 

--- a/assets/src/blocks/Covers/ContentCovers.js
+++ b/assets/src/blocks/Covers/ContentCovers.js
@@ -5,11 +5,8 @@ const { __ } = wp.i18n;
 
 export const ContentCovers = ({
   covers,
-  initialRowsLimit,
-  row,
+  hideCover,
   inEditor = false,
-  isCarouselLayout,
-  amountOfCoversPerRow,
   isExample,
 }) => (
   <div className='covers'>
@@ -21,9 +18,9 @@ export const ContentCovers = ({
         date_formatted,
       } = cover;
 
-      const hideCover = !isCarouselLayout && !!initialRowsLimit && index >= row * amountOfCoversPerRow;
+      const hideThisCover = hideCover(index);
 
-      if (hideCover) {
+      if (hideThisCover) {
         return null;
       }
 

--- a/assets/src/blocks/Covers/CoversEditor.js
+++ b/assets/src/blocks/Covers/CoversEditor.js
@@ -108,21 +108,16 @@ const renderView = (attributes, toAttribute) => {
     exampleCovers,
     readMoreText,
   } = attributes;
-  const { covers, loading, row, amountOfCoversPerRow } = useCovers(attributes);
+  const { covers, loading, row, amountOfCoversPerRow, hideCover } = useCovers(attributes);
 
   const isCarouselLayout = layout === COVERS_LAYOUTS.carousel;
 
   const coversProps = {
     covers: isExample ? exampleCovers[cover_type] : covers,
-    initialRowsLimit,
-    row,
-    showMoreCovers: () => {},
     cover_type,
     inEditor: true,
-    isCarouselLayout,
-    amountOfCoversPerRow,
     isExample,
-    readMoreText,
+    hideCover,
   };
 
   const showLoadMoreButton = !isCarouselLayout && !!initialRowsLimit && covers.length > (amountOfCoversPerRow * row);

--- a/assets/src/blocks/Covers/CoversFrontend.js
+++ b/assets/src/blocks/Covers/CoversFrontend.js
@@ -14,18 +14,15 @@ export const CoversFrontend = attributes => {
     row,
     amountOfCoversPerRow,
     setRow,
+    hideCover,
   } = useCovers(attributes, true);
 
   const isCarouselLayout = layout === COVERS_LAYOUTS.carousel;
 
   const coversProps = {
     covers,
-    initialRowsLimit,
-    row,
-    showMoreCovers,
     cover_type,
-    isCarouselLayout,
-    amountOfCoversPerRow
+    hideCover,
   };
 
   if (!covers.length) {
@@ -55,11 +52,8 @@ export const CoversFrontend = attributes => {
     }
 
     if (direction) {
-      const initialScrollPosition = covers.scrollLeft;
-      covers.scrollLeft = initialScrollPosition + (direction === 'next' ? scrollOffset : -scrollOffset);
       setRow(direction === 'next' ? row + 1 : row - 1);
     } else if (rowNumber) {
-      covers.scrollLeft = (rowNumber - 1) * scrollOffset;
       setRow(rowNumber);
     }
   };

--- a/assets/src/blocks/Covers/TakeActionCovers.js
+++ b/assets/src/blocks/Covers/TakeActionCovers.js
@@ -4,12 +4,9 @@ import { IMAGE_SIZES } from './imageSizes';
 const { __ } = wp.i18n;
 
 export const TakeActionCovers = ({
-  initialRowsLimit,
   covers,
-  row,
+  hideCover,
   inEditor = false,
-  isCarouselLayout,
-  amountOfCoversPerRow,
   isExample,
 }) => (
   <div className='covers'>
@@ -23,9 +20,10 @@ export const TakeActionCovers = ({
         excerpt,
         button_text,
       } = cover;
-      const hideCover = !isCarouselLayout && !!initialRowsLimit && index >= row * amountOfCoversPerRow;
 
-      if (hideCover) {
+      const hideThisCover = hideCover(index);
+
+      if (hideThisCover) {
         return null;
       }
 

--- a/assets/src/blocks/Covers/useCovers.js
+++ b/assets/src/blocks/Covers/useCovers.js
@@ -15,15 +15,17 @@ export const useCovers = ({ post_types, tags, cover_type, initialRowsLimit, post
   const [amountOfCoversPerRow, setAmountOfCoversPerRow] = useState(null);
   const [error, setError] = useState(null);
 
+  const isCarouselLayout = layout === COVERS_LAYOUTS.carousel;
+
   const updateRowCoversAmount = () => {
     if(cover_type === COVERS_TYPES.campaign || cover_type === COVERS_TYPES.takeAction) {
-      if (layout === COVERS_LAYOUTS.carousel) {
+      if (isCarouselLayout) {
         setAmountOfCoversPerRow(3);
       } else {
         setAmountOfCoversPerRow(isSmallWindow() ? 2 : 3);
       }
     } else {
-      if (layout === COVERS_LAYOUTS.carousel) {
+      if (isCarouselLayout) {
         setAmountOfCoversPerRow(4);
       } else {
         if (isMobile()) {
@@ -66,6 +68,14 @@ export const useCovers = ({ post_types, tags, cover_type, initialRowsLimit, post
     }
   };
 
+  const hideCover = index => {
+    if (isCarouselLayout && !isSmallWindow()) {
+      return index >= row * amountOfCoversPerRow || index < (row - 1) * amountOfCoversPerRow;
+    } else if (!isCarouselLayout) {
+      return !!initialRowsLimit && index >= row * amountOfCoversPerRow;
+    }
+  };
+
   useEffect(() => {
     if (!noLoading) {
       loadCovers();
@@ -95,5 +105,6 @@ export const useCovers = ({ post_types, tags, cover_type, initialRowsLimit, post
     setRow,
     row,
     amountOfCoversPerRow,
+    hideCover,
   };
 };

--- a/assets/src/styles/blocks/Covers/layouts/CoversCarouselLayout.scss
+++ b/assets/src/styles/blocks/Covers/layouts/CoversCarouselLayout.scss
@@ -9,7 +9,6 @@
     overflow-x: scroll;
     flex-wrap: nowrap;
     scrollbar-width: none;
-    scroll-behavior: smooth;
 
     .cover {
       margin-bottom: 24px;


### PR DESCRIPTION
### Description

See [PLANET-6828](https://jira.greenpeace.org/browse/PLANET-6828)
By hiding some of the covers we make sure that they are updated in Safari too, but unfortunately we lose the smooth scrolling animation... On the plus side, the code is a bit simplified with this solution!

### Testing

You can test the changes on [this page](https://www-dev.greenpeace.org/test-venus/custom-paddings-demo-page/) for example, it should work in all browsers and also in all screen sizes!