### PR TITLE
PLANET-6528 Implement Campaign pattern layout

### DIFF
--- a/classes/patterns/class-block-pattern.php
+++ b/classes/patterns/class-block-pattern.php
@@ -54,6 +54,7 @@ abstract class Block_Pattern {
 			SideImageWithTextAndCta::class,
 			Action::class,
 			HighLevelTopic::class,
+			Campaign::class,
 		];
 	}
 

--- a/classes/patterns/class-campaign.php
+++ b/classes/patterns/class-campaign.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Campaign pattern class.
+ *
+ * @package P4GBKS
+ * @since 0.1
+ */
+
+namespace P4GBKS\Patterns;
+
+use P4GBKS\Patterns\Templates\Covers;
+use P4GBKS\Patterns\Templates\GravityFormWithImage;
+
+/**
+ * Class Campaign.
+ *
+ * @package P4GBKS\Patterns
+ */
+class Campaign extends Block_Pattern {
+
+	/**
+	 * Returns the pattern name.
+	 */
+	public static function get_name(): string {
+		return 'p4/campaign-pattern-layout';
+	}
+
+	/**
+	 * Returns the pattern config.
+	 *
+	 * @param array $params Optional array of parameters for the config.
+	 */
+	public static function get_config( $params = [] ): array {
+		$classname = self::get_classname();
+
+		return [
+			'title'      => __( 'Campaign', 'planet4-blocks-backend' ),
+			'blockTypes' => [ 'core/post-content' ],
+			'categories' => [ 'layouts' ],
+			'content'    => '
+				<!-- wp:group {"className":"block ' . $classname . '"} -->
+					<div class="wp-block-group block ' . $classname . '">
+						' . PageHeader::get_config( [ 'title_placeholder' => __( 'Page header title', 'planet4-blocks' ) ] )['content'] . '
+						<!-- wp:spacer {"height":"64px"} -->
+							<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
+						<!-- /wp:spacer -->
+						' . SideImageWithTextAndCta::get_config( [ 'title_placeholder' => __( 'The problem', 'planet4-blocks' ) ] )['content'] . '
+						<!-- wp:spacer {"height":"32px"} -->
+							<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
+						<!-- /wp:spacer -->
+						' . SideImageWithTextAndCta::get_config(
+							[
+								'title_placeholder' => __( 'The solution', 'planet4-blocks' ),
+								'media_position'    => 'right',
+							]
+						)['content'] . '
+						<!-- wp:spacer {"height":"32px"} -->
+							<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
+						<!-- /wp:spacer -->
+						' . Covers::get_content( [ 'title_placeholder' => __( 'How you can help', 'planet4-blocks' ) ] ) . '
+						<!-- wp:spacer {"height":"48px"} -->
+							<div style="height:48px" aria-hidden="true" class="wp-block-spacer"></div>
+						<!-- /wp:spacer -->
+						' . GravityFormWithImage::get_content( [ 'background_color' => 'grey-05' ] ) . '
+					</div>
+				<!-- /wp:group -->
+			',
+		];
+	}
+}


### PR DESCRIPTION
### Description

See [PLANET-6528](https://jira.greenpeace.org/browse/PLANET-6528)
**Note:** there are some small differences with the [mockup](https://www.figma.com/file/leueo1LMrlPabJkZYs2NgW/IA%26nav_Final-mockups?node-id=1805%3A3486), due to some blocks not being implemented yet. So, the `P4 Custom block` is for now replaced by a `Covers` block, and the `Reality Check` pattern (which is here a different version from the one we currently have) is replaced by `Side Image with Text and CTA`. These changes have been approved by the design team.

### Testing

You can test the pattern layout either on local or on the [mars test instance](https://www-dev.greenpeace.org/test-mars), in all screen sizes. Also, make sure that the pattern layout shows in the page creation modal!