### PR TITLE
Create GravityFormWithImage template

### DIFF
--- a/classes/patterns/class-action.php
+++ b/classes/patterns/class-action.php
@@ -9,6 +9,7 @@
 namespace P4GBKS\Patterns;
 
 use P4GBKS\Patterns\Templates\Covers;
+use P4GBKS\Patterns\Templates\GravityFormWithImage;
 
 /**
  * Class Action.
@@ -30,27 +31,15 @@ class Action extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
-		$media_link = esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-546x415.jpg';
-
 		return [
 			'title'      => __( 'Action', 'planet4-blocks-backend' ),
 			'categories' => [ 'layouts' ],
 			'content'    => '
 				<!-- wp:group {"className":"block"} -->
 					<div class="wp-block-group">
-						<!-- wp:media-text {"mediaLink":"' . $media_link . '","mediaType":"image"} -->
-							<div class="wp-block-media-text is-stacked-on-mobile">
-								<figure class="wp-block-media-text__media">
-									<img src="' . $media_link . '" alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '"/>
-								</figure>
-								<div class="wp-block-media-text__content">
-									<!-- wp:gravityforms/form /-->
-								</div>
-							</div>
-						<!-- /wp:media-text -->
+						' . GravityFormWithImage::get_content() . '
 						<!-- wp:group {"backgroundColor":"grey-05","align":"full","style":{"spacing":{"padding":{"top":"80px","bottom":"80px"}}}} -->
 							<div class="wp-block-group alignfull has-grey-05-background-color has-background" style="padding-top:80px;padding-bottom:80px;">
-								<!-- wp:group {"className":"container"} -->
 									<div class="wp-block-group container">
 										' . SideImageWithTextAndCta::get_config(
 										[

--- a/classes/patterns/class-action.php
+++ b/classes/patterns/class-action.php
@@ -31,12 +31,14 @@ class Action extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
+		$classname = self::get_classname();
+
 		return [
 			'title'      => __( 'Action', 'planet4-blocks-backend' ),
 			'categories' => [ 'layouts' ],
 			'content'    => '
-				<!-- wp:group {"className":"block"} -->
-					<div class="wp-block-group">
+				<!-- wp:group {"className":"block ' . $classname . '"} -->
+					<div class="wp-block-group block ' . $classname . '">
 						' . GravityFormWithImage::get_content() . '
 						<!-- wp:group {"backgroundColor":"grey-05","align":"full","style":{"spacing":{"padding":{"top":"80px","bottom":"80px"}}}} -->
 							<div class="wp-block-group alignfull has-grey-05-background-color has-background" style="padding-top:80px;padding-bottom:80px;">

--- a/classes/patterns/class-action.php
+++ b/classes/patterns/class-action.php
@@ -41,12 +41,12 @@ class Action extends Block_Pattern {
 						<!-- wp:group {"backgroundColor":"grey-05","align":"full","style":{"spacing":{"padding":{"top":"80px","bottom":"80px"}}}} -->
 							<div class="wp-block-group alignfull has-grey-05-background-color has-background" style="padding-top:80px;padding-bottom:80px;">
 									<div class="wp-block-group container">
-										' . SideImageWithTextAndCta::get_config(
-										[
-											'media_position'    => 'right',
-											'title_placeholder' => __( 'The problem', 'planet4-blocks' ),
-										]
-									)['content'] . '
+						' . SideImageWithTextAndCta::get_config(
+							[
+								'media_position'    => 'right',
+								'title_placeholder' => __( 'The problem', 'planet4-blocks' ),
+							]
+						)['content'] . '
 									</div>
 								<!-- /wp:group -->
 							</div>

--- a/classes/patterns/class-action.php
+++ b/classes/patterns/class-action.php
@@ -42,6 +42,7 @@ class Action extends Block_Pattern {
 						' . GravityFormWithImage::get_content() . '
 						<!-- wp:group {"backgroundColor":"grey-05","align":"full","style":{"spacing":{"padding":{"top":"80px","bottom":"80px"}}}} -->
 							<div class="wp-block-group alignfull has-grey-05-background-color has-background" style="padding-top:80px;padding-bottom:80px;">
+								<!-- wp:group {"className":"container"} -->
 									<div class="wp-block-group container">
 						' . SideImageWithTextAndCta::get_config(
 							[

--- a/classes/patterns/class-getinformed.php
+++ b/classes/patterns/class-getinformed.php
@@ -8,7 +8,7 @@
 
 namespace P4GBKS\Patterns;
 
-use P4GBKS\Patterns\Templates\TwoColumnsGravityForms;
+use P4GBKS\Patterns\Templates\GravityFormWithText;
 
 /**
  * Class Get Informed.
@@ -54,7 +54,7 @@ class GetInformed extends Block_Pattern {
 							"gallery_block_title":"' . __( 'Our latest actions around the world', 'planet4-blocks' ) . '"
 						} /-->
 						<!-- wp:planet4-blocks/articles {"article_heading":"' . __( 'Latest news & stories', 'planet4-blocks' ) . '"} /-->
-						' . TwoColumnsGravityForms::get_content() . '
+						' . GravityFormWithText::get_content() . '
 					</div>
 				<!-- /wp:group -->
 			',

--- a/classes/patterns/class-homepage.php
+++ b/classes/patterns/class-homepage.php
@@ -10,7 +10,7 @@ namespace P4GBKS\Patterns;
 
 use P4GBKS\Patterns\Templates\CarouselHeader;
 use P4GBKS\Patterns\Templates\Covers;
-use P4GBKS\Patterns\Templates\TwoColumnsGravityForms;
+use P4GBKS\Patterns\Templates\GravityFormWithText;
 
 /**
  * This class is used for returning a homepage pattern layout template.
@@ -82,7 +82,7 @@ class Homepage extends Block_Pattern {
 				<div style="height:72px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
-				' . TwoColumnsGravityForms::get_content() . '
+				' . GravityFormWithText::get_content() . '
 
 			</div>
 			<!-- /wp:group -->

--- a/classes/patterns/templates/class-gravityformwithimage.php
+++ b/classes/patterns/templates/class-gravityformwithimage.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Gravity Form reusable pattern class.
+ *
+ * @package P4GBKS
+ * @since 0.1
+ */
+
+namespace P4GBKS\Patterns\Templates;
+
+use P4GBKS\Patterns\Templates\TemplatePattern;
+
+/**
+ * This class is used for returning a Gravity Form block with an image on the side.
+ *
+ * @package P4GBKS\Patterns\Templates
+ */
+class GravityFormWithImage extends TemplatePattern {
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @param array $params Optional array of parameters for the content.
+	 */
+	public static function get_content( $params = [] ): string {
+		$media_link           = esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-546x415.jpg';
+		$background_color     = $params['background_color'] ?? null;
+		$background_attribute = $background_color ? ',"backgroundColor":"' . $background_color . '"' : '';
+		$background_classes   = $background_color ? 'has-' . $background_color . '-background-color has-background' : '';
+
+		return '
+			<!-- wp:media-text {"mediaLink":"' . $media_link . '","mediaType":"image","align":"full"' . $background_attribute . '} -->
+				<div class="wp-block-media-text is-stacked-on-mobile alignfull ' . $background_classes . '">
+					<figure class="wp-block-media-text__media">
+						<img src="' . $media_link . '" alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '"/>
+					</figure>
+					<div class="wp-block-media-text__content">
+						<!-- wp:gravityforms/form /-->
+					</div>
+				</div>
+			<!-- /wp:media-text -->
+		';
+	}
+}

--- a/classes/patterns/templates/class-gravityformwithtext.php
+++ b/classes/patterns/templates/class-gravityformwithtext.php
@@ -11,11 +11,11 @@ namespace P4GBKS\Patterns\Templates;
 use P4GBKS\Patterns\Templates\TemplatePattern;
 
 /**
- * This class is used for returning a blank page with a default content.
+ * This class is used to return a Gravity Form block with text on the side.
  *
  * @package P4GBKS\Patterns\Templates
  */
-class TwoColumnsGravityForms extends TemplatePattern {
+class GravityFormWithText extends TemplatePattern {
 
 	/**
 	 * @inheritDoc

--- a/classes/patterns/templates/class-gravityformwithtext.php
+++ b/classes/patterns/templates/class-gravityformwithtext.php
@@ -23,11 +23,8 @@ class GravityFormWithText extends TemplatePattern {
 	 * @param array $params Optional array of parameters for the content.
 	 */
 	public static function get_content( $params = [] ): string {
-		return '<!-- wp:group {"align":"full","backgroundColor":"grey-05"} -->
-			<div class="wp-block-group alignfull has-grey-05-background-color has-background">
-				<!-- wp:spacer {"height":"80px"} -->
-				<div style="height:80px" aria-hidden="true" class="wp-block-spacer"></div>
-				<!-- /wp:spacer -->
+		return '<!-- wp:group {"align":"full","backgroundColor":"grey-05","style":{"spacing":{"padding":{"top":"80px","bottom":"50px"}}}} -->
+			<div class="wp-block-group alignfull has-grey-05-background-color has-background" style="padding-top:80px;padding-bottom:50px;">
 
 				<!-- wp:group {"className":"container"} -->
 				<div class="wp-block-group container">
@@ -60,10 +57,6 @@ class GravityFormWithText extends TemplatePattern {
 
 				</div>
 				<!-- /wp:group -->
-
-				<!-- wp:spacer {"height":"50px"} -->
-				<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
-				<!-- /wp:spacer -->
 			</div>
 			<!-- /wp:group -->
 		';


### PR DESCRIPTION
### Description

This is to avoid duplicates (this will be needed in other pattern layouts too, such as the [Campaign](https://jira.greenpeace.org/browse/PLANET-6528) one) and also to make the code more readable.
To have more consistent naming, I've also renamed the `TwoColumnsGravityForm` template to `GravityFormWithText` (it also describes the template better I think!)
Also while working on this I noticed that the Action pattern layout didn't have a classname set, so I added a small commit to fix this 🙂 Aaaaand I've also added a commit using the theme spacing options rather than spacers in the `GravityFormWithText` template.

### Testing

All the impacted pattern layouts (Action, Homepage and Get Informed) should still look as expected!