### PR TITLE
PLANET-6738: Deep Dive Topic pattern

### DIFF
--- a/classes/patterns/class-block-pattern.php
+++ b/classes/patterns/class-block-pattern.php
@@ -42,6 +42,7 @@ abstract class Block_Pattern {
 		return [
 			BlankPage::class,
 			DeepDive::class,
+			DeepDiveTopic::class,
 			GetInformed::class,
 			Homepage::class,
 			HighlightedCta::class,

--- a/classes/patterns/class-deepdivetopic.php
+++ b/classes/patterns/class-deepdivetopic.php
@@ -10,7 +10,7 @@ namespace P4GBKS\Patterns;
 use P4GBKS\Patterns\Templates\Covers;
 
 /**
- * Class Deep Dive.
+ * Class Deep Dive Topic.
  *
  * @package P4GBKS\Patterns
  */
@@ -20,13 +20,11 @@ class DeepDiveTopic extends Block_Pattern {
 	 * Returns the pattern name.
 	 */
 	public static function get_name(): string {
-		return 'p4/deep-dive-topic';
+		return 'p4/deep-dive-topic-pattern-layout';
 	}
 
 	/**
 	 * Returns the pattern config.
-	 * We start with 4 columns, but editors can easily remove and/or duplicate them.
-	 * This pattern should have grey 5% background by default.
 	 *
 	 * @param array $params Optional array of parameters for the config.
 	 */
@@ -49,7 +47,6 @@ class DeepDiveTopic extends Block_Pattern {
 					' . SideImageWithTextAndCta::get_config(
 						[
 							'title_placeholder' => __( 'The problem', 'planet4-blocks' ),
-							'media_position'    => 'left',
 						]
 					)['content'] . '
 					' . SideImageWithTextAndCta::get_config(
@@ -61,7 +58,6 @@ class DeepDiveTopic extends Block_Pattern {
 					' . Covers::get_content(
 						[
 							'title_placeholder' => __( 'How you can help', 'planet4-blocks' ),
-							'cover_type'        => 'take-action',
 						]
 					) . '
 					<!-- wp:planet4-blocks/articles {"article_heading":"' . __( 'Latest news & stories', 'planet4-blocks' ) . '"} /-->

--- a/classes/patterns/class-deepdivetopic.php
+++ b/classes/patterns/class-deepdivetopic.php
@@ -43,30 +43,36 @@ class DeepDiveTopic extends Block_Pattern {
 					' . PageHeader::get_config(
 						[ 'title_placeholder' => __( 'Page header title', 'planet4-blocks' ) ]
 					)['content'] . '
+					<!-- wp:spacer {"height":"64px"} -->
+						<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
+					<!-- /wp:spacer -->
 					' . SideImageWithTextAndCta::get_config(
 						[
 							'title_placeholder' => __( 'The problem', 'planet4-blocks' ),
-							'alignfull'         => true,
 							'media_position'    => 'left',
 						]
 					)['content'] . '
 					' . SideImageWithTextAndCta::get_config(
 						[
 							'title_placeholder' => __( 'What can be done', 'planet4-blocks' ),
-							'alignfull'         => true,
 							'media_position'    => 'right',
 						]
 					)['content'] . '
 					' . Covers::get_content(
 						[
-							'cover_type'        => 'take-action',
 							'title_placeholder' => __( 'How you can help', 'planet4-blocks' ),
+							'cover_type'        => 'take-action',
 						]
 					) . '
 					<!-- wp:planet4-blocks/articles {"article_heading":"' . __( 'Latest news & stories', 'planet4-blocks' ) . '"} /-->
-					' . DeepDive::get_config()['content'] . '
+					' . DeepDive::get_config(
+						[ 'title_placeholder' => __( 'Keep learning about', 'planet4-blocks' ) ]
+					)['content'] . '
 					' . QuickLinks::get_config(
-						[ 'background_color' => 'white' ]
+						[
+							'title_placeholder' => __( 'Explore other topics', 'planet4-blocks' ),
+							'background_color'  => 'white',
+						]
 					)['content'] . '
 					</div>
 				<!-- /wp:group -->

--- a/classes/patterns/class-deepdivetopic.php
+++ b/classes/patterns/class-deepdivetopic.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Deep Dive Topic pattern class.
+ *
+ * @package P4GBKS
+ */
+
+namespace P4GBKS\Patterns;
+
+use P4GBKS\Patterns\Templates\Covers;
+
+/**
+ * Class Deep Dive.
+ *
+ * @package P4GBKS\Patterns
+ */
+class DeepDiveTopic extends Block_Pattern {
+
+	/**
+	 * Returns the pattern name.
+	 */
+	public static function get_name(): string {
+		return 'p4/deep-dive-topic';
+	}
+
+	/**
+	 * Returns the pattern config.
+	 * We start with 4 columns, but editors can easily remove and/or duplicate them.
+	 * This pattern should have grey 5% background by default.
+	 *
+	 * @param array $params Optional array of parameters for the config.
+	 */
+	public static function get_config( $params = [] ): array {
+		$classname = self::get_classname();
+
+		return [
+			'title'      => __( 'Deep Dive Topic', 'planet4-blocks-backend' ),
+			'categories' => [ 'layouts' ],
+			'blockTypes' => [ 'core/post-content' ],
+			'content'    => '
+				<!-- wp:group {"className":"block ' . $classname . '"} -->
+					<div class="wp-block-group ' . $classname . '">
+					' . PageHeader::get_config(
+						[ 'title_placeholder' => __( 'Page header title', 'planet4-blocks' ) ]
+					)['content'] . '
+					' . SideImageWithTextAndCta::get_config(
+						[
+							'title_placeholder' => __( 'The problem', 'planet4-blocks' ),
+							'alignfull'         => true,
+							'media_position'    => 'left',
+						]
+					)['content'] . '
+					' . SideImageWithTextAndCta::get_config(
+						[
+							'title_placeholder' => __( 'What can be done', 'planet4-blocks' ),
+							'alignfull'         => true,
+							'media_position'    => 'right',
+						]
+					)['content'] . '
+					' . Covers::get_content(
+						[
+							'cover_type'        => 'take-action',
+							'title_placeholder' => __( 'How you can help', 'planet4-blocks' ),
+						]
+					) . '
+					<!-- wp:planet4-blocks/articles {"article_heading":"' . __( 'Latest news & stories', 'planet4-blocks' ) . '"} /-->
+					' . DeepDive::get_config()['content'] . '
+					' . QuickLinks::get_config(
+						[ 'background_color' => 'white' ]
+					)['content'] . '
+					</div>
+				<!-- /wp:group -->
+			',
+		];
+	}
+}

--- a/tests/acceptance/PatternsCept.php
+++ b/tests/acceptance/PatternsCept.php
@@ -10,16 +10,16 @@ $I->amOnPage('/wp-admin/post-new.php?post_type=page');
 
 // Close Welcome modal
 try {
-	$closeWelcomeGuide = '//[contains(@class, \'.edit-post-welcome-guide\')]'
+	$closeWelcomeGuide = '//div[contains(@class, "edit-post-welcome-guide")]'
 		. '//button[contains(@aria-label, "Close dialog")]';
 	$I->waitForElement($closeWelcomeGuide);
 	$I->click($closeWelcomeGuide);
 } catch (\Exception $e) {
+	// No welcome guide found
 }
 
 // We need to chek these class names since we've overriden its layout
 // https://github.com/greenpeace/planet4-master-theme/blob/master/assets/src/scss/editorStyle.scss
 $I->wantTo('check pattern modal styles');
-$I->waitForElement('.block-editor-block-patterns-list__item');
-$I->seeElement('.block-editor-block-patterns-list__item');
+$I->waitForElement('.block-editor-block-patterns-list__item', 30);
 $I->seeElement('.block-editor-block-patterns-list__item-title');

--- a/tests/acceptance/PatternsCept.php
+++ b/tests/acceptance/PatternsCept.php
@@ -9,8 +9,13 @@ $I->loginAsAdminCached();
 $I->amOnPage('/wp-admin/post-new.php?post_type=page');
 
 // Close Welcome modal
-$I->waitForElement('//button[contains(@aria-label, "Close dialog")]');
-$I->click('//button[contains(@aria-label, "Close dialog")]');
+try {
+	$closeWelcomeGuide = '//[contains(@class, \'.edit-post-welcome-guide\')]'
+		. '//button[contains(@aria-label, "Close dialog")]';
+	$I->waitForElement($closeWelcomeGuide);
+	$I->click($closeWelcomeGuide);
+} catch (\Exception $e) {
+}
 
 // We need to chek these class names since we've overriden its layout
 // https://github.com/greenpeace/planet4-master-theme/blob/master/assets/src/scss/editorStyle.scss


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6738

> Create the "Deep dive topic" block pattern layout made up of P4 blocks and block patterns based on these [high-fidelity mockups](https://www.figma.com/file/leueo1LMrlPabJkZYs2NgW/IA%26nav_Final-mockups?node-id=1814%3A6708) for desktop and mobile.

Also trying to fix the failing Acceptance test (probably coming for a previous PR, it also fails for docker-compose nightly build) ~(doesn't look like it's working :thinking: )~

## Test

On an empty page, add the Deep Dive Topic layout either via the block inserter or via the page creation modal.