### PR TITLE
Add grey background color to PageHeader pattern

### DIFF
--- a/classes/patterns/class-pageheader.php
+++ b/classes/patterns/class-pageheader.php
@@ -43,39 +43,48 @@ class PageHeader extends Block_Pattern {
 		$pos_class         = 'left' === static::$media_position ? ''
 			: 'has-media-on-the-' . static::$media_position;
 		$title_placeholder = $params['title_placeholder'] ?? '';
+		$background_color  = $params['background_color'] ?? 'grey-05';
 
 		return [
 			'title'      => __( static::$title, 'planet4-blocks-backend' ), // phpcs:ignore
 			'categories' => [ 'page-headers' ],
 			'content'    => '
-				<!-- wp:media-text {"align":"full","mediaPosition":"' . static::$media_position . '","mediaType":"image","imageFill":false,"className":"' . $classname . '"} -->
-				<div class="wp-block-media-text alignfull ' . $pos_class . ' is-stacked-on-mobile ' . $classname . '">
+				<!-- wp:group {"backgroundColor":"' . $background_color . '","align":"full","style":{"spacing":{"padding":{"top":"56px","bottom":"56px"}}}} -->
+					<div class="wp-block-group alignfull has-' . $background_color . '-background-color has-background" style="padding-top:56px;padding-bottom:56px;">
+						<!-- wp:group {"className":"container"} -->
+							<div class="wp-block-group container">
+								<!-- wp:media-text {"align":"full","mediaPosition":"' . static::$media_position . '","mediaType":"image","imageFill":false,"className":"' . $classname . '"} -->
+								<div class="wp-block-media-text alignfull ' . $pos_class . ' is-stacked-on-mobile ' . $classname . '">
 
-					<figure class="wp-block-media-text__media">
-						<img src="' . $media_link . '" alt=""/>
-					</figure>
+									<figure class="wp-block-media-text__media">
+										<img src="' . $media_link . '" alt=""/>
+									</figure>
 
-					<div class="wp-block-media-text__content">
-						<!-- wp:group -->
-						<div class="wp-block-group">
-							<!-- wp:heading {"level":1,"placeholder":"' . __( 'Enter title', 'planet4-blocks-backend' ) . '","backgroundColor":"white"} -->
-							<h1 class="has-white-background-color has-background">' . $title_placeholder . '</h1>
-							<!-- /wp:heading -->
-						</div>
+									<div class="wp-block-media-text__content">
+										<!-- wp:group -->
+										<div class="wp-block-group">
+											<!-- wp:heading {"level":1,"placeholder":"' . __( 'Enter title', 'planet4-blocks-backend' ) . '","backgroundColor":"' . $background_color . '"} -->
+											<h1 class="has-' . $background_color . '-background-color has-background">' . $title_placeholder . '</h1>
+											<!-- /wp:heading -->
+										</div>
+										<!-- /wp:group -->
+
+										<!-- wp:paragraph {"placeholder":"' . __( 'Enter description', 'planet4-blocks-backend' ) . '","style":{"typography":{"fontSize":"1.25rem"}}} -->
+										<p style="font-size:1.25rem"></p>
+										<!-- /wp:paragraph -->
+
+										<!-- wp:buttons -->
+										<div class="wp-block-buttons">
+											<!-- wp:button {"className":"is-style-cta"} /-->
+										</div>
+										<!-- /wp:buttons -->
+									</div>
+								</div>
+								<!-- /wp:media-text -->
+							</div>
 						<!-- /wp:group -->
-
-						<!-- wp:paragraph {"placeholder":"' . __( 'Enter description', 'planet4-blocks-backend' ) . '","style":{"typography":{"fontSize":"1.25rem"}}} -->
-						<p style="font-size:1.25rem"></p>
-						<!-- /wp:paragraph -->
-
-						<!-- wp:buttons -->
-						<div class="wp-block-buttons">
-							<!-- wp:button {"className":"is-style-cta"} /-->
-						</div>
-						<!-- /wp:buttons -->
 					</div>
-				</div>
-				<!-- /wp:media-text -->
+				<!-- /wp:group -->
 			',
 		];
 	}


### PR DESCRIPTION
### Description

This is needed for some pattern layouts such as the [Take Action](https://jira.greenpeace.org/browse/PLANET-6525) one.

### Testing

On local, you can try manually adding the `background_color` attribute in the pattern's params (using a color from our [palette](https://github.com/greenpeace/planet4-master-theme/blob/master/theme.json#L12-L84)) and saving. After that, when adding the pattern to a page, you should see the header with the chosen background color. It should also work as expected when there is no background color specified in the params, meaning it should have `grey-05` background color applied by default 🙂 You can also test the High Level Topic pattern layout since it has the Page Header pattern.