### PR TITLE
PLANET-6868: Improve block report API responsiveness

### DIFF
--- a/classes/search/class-patternsearch.php
+++ b/classes/search/class-patternsearch.php
@@ -23,9 +23,18 @@ class PatternSearch {
 
 	/**
 	 * @param Parameters $params Query parameters.
+	 * @param array      $opts   Search Options.
 	 * @return int[] list of posts IDs.
 	 */
-	public function get_posts( Parameters $params ): array {
+	public function get_posts( Parameters $params, array $opts = [] ): array {
+		$opts = array_merge(
+			[
+				'use_struct' => true,
+				'use_class'  => true,
+			],
+			$opts
+		);
+
 		$patterns = array_map(
 			fn ( $pattern ) => PatternData::from_name( $pattern ),
 			$params->name()
@@ -34,8 +43,8 @@ class PatternSearch {
 		return array_unique(
 			array_filter(
 				array_merge(
-					$this->query_by_pattern_classname( $params, ...$patterns ),
-					$this->query_by_pattern_blocks( $params, ...$patterns )
+					$opts['use_class'] ? $this->query_by_pattern_classname( $params, ...$patterns ) : [],
+					$opts['use_struct'] ? $this->query_by_pattern_blocks( $params, ...$patterns ) : []
 				)
 			)
 		);

--- a/classes/search/pattern/class-patternusageapi.php
+++ b/classes/search/pattern/class-patternusageapi.php
@@ -67,7 +67,10 @@ class PatternUsageApi {
 	 * Fetch parsed blocks
 	 */
 	private function fetch_items(): void {
-		$this->items = $this->usage->get_patterns( $this->params );
+		$this->items = $this->usage->get_patterns(
+			$this->params,
+			[ 'use_struct' => false ]
+		);
 	}
 
 	/**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6868

- Making optional the structure search
- Do not use structure search for the API count

On an international DB locally, this reduces the API call from 22 seconds to 3 seconds, for a Belgium DB 33s to 4s. Assuming the issue on large DBs is the pattern structure query, this should solve the timeout issue.

## Test

Flush the object cache between tests.
```console
> curl -k https://www-dev.greenpeace.org/test-sinope/wp-json/plugin_blocks/v3/plugin_blocks_report/ | jq
```

