### PR TITLE
PLANET-6862: Enable reusable blocks for editors

### DIFF
--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -158,13 +158,15 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 					'plugin_blocks_report',
 					[ $this, 'plugin_blocks_report' ]
 				);
+			}
 
+			if ( ( in_array( 'administrator', $current_user->roles, true ) || in_array( 'editor', $current_user->roles, true ) ) && current_user_can( 'edit_posts' ) ) {
 				// Experimental block usage page, hidden from menu.
 				add_submenu_page(
 					P4GBKS_PLUGIN_SLUG_NAME,
 					__( 'Report (Beta)', 'planet4-blocks-backend' ),
 					__( 'Report (Beta)', 'planet4-blocks-backend' ),
-					'manage_options',
+					'edit_posts',
 					'plugin_blocks_report_beta',
 					[ $this, 'plugin_blocks_report_beta' ]
 				);
@@ -173,7 +175,7 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 					P4GBKS_PLUGIN_SLUG_NAME,
 					__( 'Pattern Report (Beta)', 'planet4-blocks-backend' ),
 					__( 'Pattern Report (Beta)', 'planet4-blocks-backend' ),
-					'manage_options',
+					'edit_posts',
 					'plugin_patterns_report',
 					[ $this, 'plugin_patterns_report' ]
 				);

--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -146,15 +146,14 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 		 * Create menu/submenu entry.
 		 */
 		public function create_admin_menu() {
-
 			$current_user = wp_get_current_user();
 
-			if ( in_array( 'administrator', $current_user->roles, true ) && current_user_can( 'manage_options' ) ) {
+			if ( ( in_array( 'administrator', $current_user->roles, true ) || in_array( 'editor', $current_user->roles, true ) ) && current_user_can( 'edit_posts' ) ) {
 				add_submenu_page(
 					P4GBKS_PLUGIN_SLUG_NAME,
 					__( 'Usage', 'planet4-blocks-backend' ),
 					__( 'Usage', 'planet4-blocks-backend' ),
-					'manage_options',
+					'edit_posts',
 					'plugin_blocks_report',
 					[ $this, 'plugin_blocks_report' ]
 				);

--- a/classes/controller/menu/class-reusable-blocks-controller.php
+++ b/classes/controller/menu/class-reusable-blocks-controller.php
@@ -26,8 +26,7 @@ if ( ! class_exists( 'Reusable_Blocks_Controller' ) ) {
 
 			$current_user = wp_get_current_user();
 
-			if ( in_array( 'administrator', $current_user->roles, true ) && current_user_can( 'manage_options' ) ) {
-
+			if ( ( in_array( 'administrator', $current_user->roles, true ) || in_array( 'editor', $current_user->roles, true ) ) && current_user_can( 'edit_posts' ) ) {
 				add_submenu_page(
 					P4GBKS_PLUGIN_SLUG_NAME,
 					__( 'All Reusable blocks', 'planet4-blocks-backend' ),

--- a/classes/controller/menu/class-settings-controller.php
+++ b/classes/controller/menu/class-settings-controller.php
@@ -22,11 +22,12 @@ if ( ! class_exists( 'Settings_Controller' ) ) {
 
 			$current_user = wp_get_current_user();
 
-			if ( in_array( 'administrator', $current_user->roles, true ) && current_user_can( 'manage_options' ) ) {
+			if ( ( in_array( 'administrator', $current_user->roles, true ) || in_array( 'editor', $current_user->roles, true ) ) && current_user_can( 'edit_posts' ) ) {
+
 				add_menu_page(
 					__( 'Blocks', 'planet4-blocks-backend' ),
 					__( 'Blocks', 'planet4-blocks-backend' ),
-					'manage_options',
+					'edit_posts',
 					P4GBKS_PLUGIN_SLUG_NAME,
 					null,
 					'dashicons-layout'


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6862

## Description
This PR enables Editors to navigate through the reusable blocks page into the Admin panel.
I've also left more info into comments, please validate them 🙏 .

## Testing
Login within an Editor user and check if that user can navigate to `Blocks > Reusable blocks`
  