### PR TITLE
PLANET-6890 Add option to hide page title in Actions

### DIFF
--- a/assets/src/components/HidePageTitle/HidePageTitle.js
+++ b/assets/src/components/HidePageTitle/HidePageTitle.js
@@ -1,0 +1,14 @@
+import { CheckboxControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Hide page title sidebar setting.
+ */
+export const HidePageTitle = ({ value, setValue }) => (
+  <CheckboxControl
+    label={__( 'Hide page title', 'planet4-blocks-backend' )}
+    checked={value === 'on'}
+    value={value === 'on'}
+    onChange={checked => setValue(checked ? 'on' : '')}
+  />
+);

--- a/assets/src/components/Sidebar/ActionSidebar.js
+++ b/assets/src/components/Sidebar/ActionSidebar.js
@@ -28,8 +28,8 @@ export const ActionSidebar = () => {
   return (
     <>
       <PluginDocumentSettingPanel
-        name="meta-options-panel"
-        title={ __( "Meta options", 'planet4-blocks-backend' ) }
+        name="page-header-panel"
+        title={ __( "Page header", 'planet4-blocks-backend' ) }
       >
         <HidePageTitle {...hidePageTitleParams} />
       </PluginDocumentSettingPanel>

--- a/assets/src/components/Sidebar/ActionSidebar.js
+++ b/assets/src/components/Sidebar/ActionSidebar.js
@@ -2,31 +2,44 @@ import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { NavigationType } from '../NavigationType/NavigationType';
+import { HidePageTitle } from '../HidePageTitle/HidePageTitle';
 
 const FIELD_NAVTYPE = 'nav_type';
+const HIDE_PAGE_TITLE = 'p4_hide_page_title_checkbox';
 
 /**
- * Add Document settings to Action pages
+ * Add settings to Action pages
  */
-export const ActionSidebar = (attributes) => {
+export const ActionSidebar = () => {
   const meta = useSelect(select => select('core/editor').getEditedPostAttribute('meta'),[]);
   const { editPost } = useDispatch('core/editor');
-  const updateValueAndDependencies = fieldId => value => {
-    editPost({ meta: {[fieldId]: value} });
-  }
+  const updateValueAndDependencies = fieldId => value => editPost({ meta: {[fieldId]: value} });
 
   const navParams = {
     value: meta[FIELD_NAVTYPE] || null,
     setValue: updateValueAndDependencies(FIELD_NAVTYPE),
   };
 
+  const hidePageTitleParams = {
+    value: meta[HIDE_PAGE_TITLE] || '',
+    setValue: updateValueAndDependencies(HIDE_PAGE_TITLE),
+  }
+
   return (
-    <PluginDocumentSettingPanel
-      name="navigation-panel"
-      title={ __( "Navigation", 'planet4-blocks-backend' ) }
-      className="navigation-panel"
-    >
-      <NavigationType {...navParams} />
-    </PluginDocumentSettingPanel>
+    <>
+      <PluginDocumentSettingPanel
+        name="meta-options-panel"
+        title={ __( "Meta options", 'planet4-blocks-backend' ) }
+      >
+        <HidePageTitle {...hidePageTitleParams} />
+      </PluginDocumentSettingPanel>
+      <PluginDocumentSettingPanel
+        name="navigation-panel"
+        title={ __( "Navigation", 'planet4-blocks-backend' ) }
+        className="navigation-panel"
+      >
+        <NavigationType {...navParams} />
+      </PluginDocumentSettingPanel>
+    </>
   );
 }


### PR DESCRIPTION
### Description

See [PLANET-6890](https://jira.greenpeace.org/browse/PLANET-6890)
This new meta setting is in the sidebar. It's needed to comply with the Action pages designs.

**Related PR:** https://github.com/greenpeace/planet4-master-theme/pull/1784

### Testing

You can test the new checkbox either on local on any Action page, or on [this one](https://www-dev.greenpeace.org/test-telesto/action/the-first-action-page/) that I created for UAT. Note that just like the corresponding meta option available in pages/posts, you need to update (and not just preview) the page before you see the change applied!