### PR TITLE
PLANET-6859 Fix undefined description in EN form

### DIFF
--- a/assets/src/blocks/ENForm/ENFormFrontend.js
+++ b/assets/src/blocks/ENForm/ENFormFrontend.js
@@ -163,8 +163,9 @@ const Signup = ({attributes, fields, form_data, onInputChange, onBlur, onFormSub
             <div className="enform-extra-header-placeholder"
               dangerouslySetInnerHTML={{ __html: extra_content ? unescape(extra_content) : '' }} />
           }
-          <div className="form-description"
-            dangerouslySetInnerHTML={{ __html: unescape(description) }} />
+          {description &&
+            <div className="form-description" dangerouslySetInnerHTML={{ __html: unescape(description) }} />
+          }
         </div>
 
         <div className="form-container">


### PR DESCRIPTION
### Description

See [PLANET-6859](https://jira.greenpeace.org/browse/PLANET-6859)
This happens on the frontend when the block's description is left empty in the backend

### Testing

You can compare the fixed version [here](https://www-dev.greenpeace.org/test-titan/en-form-with-no-description/) with the broken version [here](https://www-dev.greenpeace.org/test-telesto/en-form-with-no-description/) for example! 