### PR TITLE
Maintenance: Implement the ability to abort API fetch requests

### DIFF
--- a/assets/src/blocks/Articles/useArticlesFetch.js
+++ b/assets/src/blocks/Articles/useArticlesFetch.js
@@ -11,6 +11,7 @@ export const useArticlesFetch = (attributes, postType, postId, baseUrl = null, p
   const [displayedPosts, setDisplayedPosts] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [controller, setController] = useState();
 
   const loadPage = async (reset = false) => {
     if (loading) {
@@ -59,8 +60,22 @@ export const useArticlesFetch = (attributes, postType, postId, baseUrl = null, p
 
   useEffect(() => {
     setDisplayedPosts([]);
-    loadPage(true);
+    setController(typeof AbortController === 'undefined' ? undefined : new AbortController());
   }, [ article_count, post_types, posts, tags, ignore_categories ]);
+
+  useEffect(() => {
+    if(controller) {
+      loadPage(true);
+    }
+
+    return () => {
+      if(controller) {
+        setLoading(false);
+        controller.abort();
+        setController(null);
+      }
+    }
+  }, [ controller ]);
 
   return {
     posts: displayedPosts,

--- a/assets/src/blocks/Articles/useArticlesFetch.js
+++ b/assets/src/blocks/Articles/useArticlesFetch.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from '@wordpress/element';
 import { fetchJson } from '../../functions/fetchJson';
 import { addQueryArgs } from '../../functions/addQueryArgs';
+import { getAbortController } from '../../functions/getAbortController';
 
 const { apiFetch } = wp;
 
@@ -60,7 +61,7 @@ export const useArticlesFetch = (attributes, postType, postId, baseUrl = null, p
 
   useEffect(() => {
     setDisplayedPosts([]);
-    setController(typeof AbortController === 'undefined' ? undefined : new AbortController());
+    setController(getAbortController());
   }, [ article_count, post_types, posts, tags, ignore_categories ]);
 
   useEffect(() => {

--- a/assets/src/blocks/Covers/useCovers.js
+++ b/assets/src/blocks/Covers/useCovers.js
@@ -8,7 +8,7 @@ const { apiFetch } = wp;
 const isMobile = () => window.innerWidth < 768;
 const isMediumWindow = () => window.innerWidth >= 768 && window.innerWidth < 992;
 
-export const useCovers = ({ post_types, tags, cover_type, initialRowsLimit, posts, layout }, noLoading) => {
+export const useCovers = ({ post_types, tags, cover_type, initialRowsLimit, posts, layout }, noLoading = false) => {
   const [covers, setCovers] = useState([]);
   const [loading, setLoading] = useState(false);
   const [row, setRow] = useState(initialRowsLimit);
@@ -71,7 +71,7 @@ export const useCovers = ({ post_types, tags, cover_type, initialRowsLimit, post
     if (!noLoading) {
       setController(getAbortController());
     }
-  }, [cover_type, post_types, tags, posts, layout]);
+  }, [cover_type, post_types, tags, posts, layout, noLoading]);
 
   useEffect(() => {
     if(controller) {
@@ -81,7 +81,6 @@ export const useCovers = ({ post_types, tags, cover_type, initialRowsLimit, post
     return () => {
       if(controller) {
         setLoading(false);
-        controller.abort();
         setController(null);
       }
     }

--- a/assets/src/blocks/Covers/useCovers.js
+++ b/assets/src/blocks/Covers/useCovers.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from '@wordpress/element';
 import { addQueryArgs } from '../../functions/addQueryArgs';
+import { getAbortController } from '../../functions/getAbortController';
 import { COVERS_TYPES, COVERS_LAYOUTS } from './CoversConstants';
 
 const { apiFetch } = wp;
@@ -68,7 +69,7 @@ export const useCovers = ({ post_types, tags, cover_type, initialRowsLimit, post
 
   useEffect(() => {
     if (!noLoading) {
-      setController(typeof AbortController === 'undefined' ? undefined : new AbortController());
+      setController(getAbortController());
     }
   }, [cover_type, post_types, tags, posts, layout]);
 

--- a/assets/src/blocks/Gallery/useGalleryImages.js
+++ b/assets/src/blocks/Gallery/useGalleryImages.js
@@ -12,6 +12,7 @@ const GALLERY_IMAGE_SIZES = {
 
 export const useGalleryImages = ({ multiple_image, gallery_block_focus_points }, layout, baseUrl = null) => {
   const [images, setImages] = useState([]);
+  const [controller, setController] = useState();
 
   const imageSize = GALLERY_IMAGE_SIZES[layout];
 
@@ -35,8 +36,21 @@ export const useGalleryImages = ({ multiple_image, gallery_block_focus_points },
 
   useEffect(() => {
     setImages([]);
-    loadPage();
+    setController(typeof AbortController === 'undefined' ? undefined : new AbortController());
   }, [multiple_image, gallery_block_focus_points]);
+
+  useEffect(() => {
+    if(controller) {
+      loadPage();
+    }
+
+    return () => {
+      if(controller) {
+        controller.abort();
+        setController(null);
+      }
+    }
+  }, [ controller ]);
 
   return { images };
 };

--- a/assets/src/blocks/Gallery/useGalleryImages.js
+++ b/assets/src/blocks/Gallery/useGalleryImages.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from '@wordpress/element';
 import { fetchJson } from '../../functions/fetchJson';
 import { addQueryArgs } from '../../functions/addQueryArgs';
+import { getAbortController } from '../../functions/getAbortController';
 
 const { apiFetch } = wp;
 
@@ -36,7 +37,7 @@ export const useGalleryImages = ({ multiple_image, gallery_block_focus_points },
 
   useEffect(() => {
     setImages([]);
-    setController(typeof AbortController === 'undefined' ? undefined : new AbortController());
+    setController(getAbortController());
   }, [multiple_image, gallery_block_focus_points]);
 
   useEffect(() => {

--- a/assets/src/functions/getAbortController.js
+++ b/assets/src/functions/getAbortController.js
@@ -1,0 +1,9 @@
+/**
+ * Returns a new AbortController in case of being supported by the Browser
+ * Through this method you could abort any request in case of it's needed.
+ *
+ * @returns {AbortController | undefined}
+ */
+export const getAbortController = () => (
+  typeof AbortController === 'undefined' ? undefined : new AbortController()
+);


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6921

## Description
We're currently getting this log error when any Cover, Article or Gallery block is unmounted without finishing the request.

We solve this by implementing a clean up function (i.e. [here](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/940#discussion_r978820100)) and aborting all the API fetch that were requested by the Block.  

Doing this we will avoid to run a ton of unexpected requests.

```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
```

## Testing
1. Create a new page
2. Close the Search pattern modal after 10 seconds, this is depending on your connection, or wait to start loading the block you want to test. For instance, if you want to test the `Articles block`, then you should wait the `Deep Dive Topic` which is using it.
3. Open the console and see the logged errors. You ought to see any related to `cancel all subscriptions and asynchronous tasks`.

### Covers Block (fix and solution)

https://user-images.githubusercontent.com/77975803/192011383-8971f9c9-b818-4eaf-8dde-8c4a6c343e52.mov

https://user-images.githubusercontent.com/77975803/192011276-246409d3-34ad-4d7c-b79f-6266af3fb37f.mov

### Articles block (fix and solution)

https://user-images.githubusercontent.com/77975803/192013772-fd8a6db6-2671-481c-8819-3c808c9a37df.mov

### Gallery Block (fix and solution)

https://user-images.githubusercontent.com/77975803/192029312-b14e9676-2d8f-4baf-8cf2-c5a8830d917d.mov


