### PR TITLE
PLANET-6901 Move Page Header metabox fields to sidebar

### DIFF
--- a/assets/src/components/Sidebar/ActionSidebar.js
+++ b/assets/src/components/Sidebar/ActionSidebar.js
@@ -2,7 +2,7 @@ import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { NavigationType } from '../NavigationType/NavigationType';
-import { HidePageTitle } from '../HidePageTitle/HidePageTitle';
+import { CheckboxSidebarField } from '../SidebarFields/CheckboxSidebarField';
 
 const FIELD_NAVTYPE = 'nav_type';
 const HIDE_PAGE_TITLE = 'p4_hide_page_title_checkbox';
@@ -10,36 +10,39 @@ const HIDE_PAGE_TITLE = 'p4_hide_page_title_checkbox';
 /**
  * Add settings to Action pages
  */
-export const ActionSidebar = () => {
-  const meta = useSelect(select => select('core/editor').getEditedPostAttribute('meta'),[]);
-  const { editPost } = useDispatch('core/editor');
-  const updateValueAndDependencies = fieldId => value => editPost({ meta: {[fieldId]: value} });
+export const ActionSidebar = {
+  getId: () => 'planet4-action-sidebar',
+  render: () => {
+    const meta = useSelect(select => select('core/editor').getEditedPostAttribute('meta'),[]);
+    const { editPost } = useDispatch('core/editor');
+    const updateValueAndDependencies = fieldId => value => editPost({ meta: {[fieldId]: value} });
 
-  const navParams = {
-    value: meta[FIELD_NAVTYPE] || null,
-    setValue: updateValueAndDependencies(FIELD_NAVTYPE),
-  };
+    const navParams = {
+      value: meta[FIELD_NAVTYPE] || null,
+      setValue: updateValueAndDependencies(FIELD_NAVTYPE),
+    };
 
-  const hidePageTitleParams = {
-    value: meta[HIDE_PAGE_TITLE] || '',
-    setValue: updateValueAndDependencies(HIDE_PAGE_TITLE),
+    const hidePageTitleParams = {
+      value: meta[HIDE_PAGE_TITLE] || '',
+      setValue: updateValueAndDependencies(HIDE_PAGE_TITLE),
+    }
+
+    return (
+      <>
+        <PluginDocumentSettingPanel
+          name='page-header-panel'
+          title={ __( 'Page header', 'planet4-blocks-backend' ) }
+        >
+          <CheckboxSidebarField label={__( 'Hide page title', 'planet4-blocks-backend' )} {...hidePageTitleParams} />
+        </PluginDocumentSettingPanel>
+        <PluginDocumentSettingPanel
+          name='navigation-panel'
+          title={ __( 'Navigation', 'planet4-blocks-backend' ) }
+          className='navigation-panel'
+        >
+          <NavigationType {...navParams} />
+        </PluginDocumentSettingPanel>
+      </>
+    );
   }
-
-  return (
-    <>
-      <PluginDocumentSettingPanel
-        name="page-header-panel"
-        title={ __( "Page header", 'planet4-blocks-backend' ) }
-      >
-        <HidePageTitle {...hidePageTitleParams} />
-      </PluginDocumentSettingPanel>
-      <PluginDocumentSettingPanel
-        name="navigation-panel"
-        title={ __( "Navigation", 'planet4-blocks-backend' ) }
-        className="navigation-panel"
-      >
-        <NavigationType {...navParams} />
-      </PluginDocumentSettingPanel>
-    </>
-  );
 }

--- a/assets/src/components/Sidebar/CampaignThemeSidebar.js
+++ b/assets/src/components/Sidebar/CampaignThemeSidebar.js
@@ -57,9 +57,9 @@ const gotInvalidated = (field, options, meta) => {
   return !(resolvedField.options.some( option => option.value === currentValue) );
 }
 
-export class CampaignSidebar extends Component {
+export class CampaignThemeSidebar extends Component {
   static getId() {
-    return 'planet4-campaign-sidebar';
+    return 'planet4-campaign-theme-sidebar';
   }
 
   static getIcon() {
@@ -147,12 +147,12 @@ export class CampaignSidebar extends Component {
     return (
       <>
         <PluginSidebarMoreMenuItem
-          target={ CampaignSidebar.getId() }
-          icon={ CampaignSidebar.getIcon() }>
+          target={ CampaignThemeSidebar.getId() }
+          icon={ CampaignThemeSidebar.getIcon() }>
           { __('Theme Options', 'planet4-blocks-backend') }
         </PluginSidebarMoreMenuItem>
         <PluginSidebar
-          name={ CampaignSidebar.getId() }
+          name={ CampaignThemeSidebar.getId() }
           title={ __('Theme Options', 'planet4-blocks-backend') }
         >
           { !!parent && <PostParentLink parent={ parent }/> }

--- a/assets/src/components/Sidebar/PageHeaderSidebar.js
+++ b/assets/src/components/Sidebar/PageHeaderSidebar.js
@@ -1,0 +1,71 @@
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { CheckboxSidebarField } from '../SidebarFields/CheckboxSidebarField';
+import { TextareaSidebarField } from '../SidebarFields/TextareaSidebarField';
+import { ImageSidebarField } from '../SidebarFields/ImageSidebarField';
+import { TextSidebarField } from '../SidebarFields/TextSidebarField';
+
+// The various meta fields
+const HIDE_PAGE_TITLE = 'p4_hide_page_title_checkbox';
+const HEADER_TITLE = 'p4_title';
+const HEADER_SUBTITLE = 'p4_subtitle';
+const HEADER_DESCRIPTION = 'p4_description';
+const BACKGROUND_IMAGE_ID = 'background_image_id';
+const BACKGROUND_IMAGE_URL = 'background_image';
+const HEADER_BUTTON_TITLE = 'p4_button_title';
+const HEADER_BUTTON_LINK = 'p4_button_link';
+const HEADER_BUTTON_NEW_TAB = 'p4_button_link_checkbox';
+
+/**
+ * Page header settings for the sidebar
+ */
+ export const PageHeaderSidebar = {
+  getId: () => 'planet4-page-header-sidebar',
+  render: () => {
+    const meta = useSelect(select => select('core/editor').getEditedPostAttribute('meta'),[]);
+    const postType = useSelect(select => select('core/editor').getCurrentPostType());
+    const isCampaign = postType === 'campaign';
+
+    const { editPost } = useDispatch('core/editor');
+
+    const updateValueAndDependencies = fieldId => value => editPost({ meta: {[fieldId]: value} });
+
+    const getParams = name => ({
+      value: meta[name] || '',
+      setValue: updateValueAndDependencies(name),
+    });
+
+    const imageParams = {
+      value: {
+        id: meta[BACKGROUND_IMAGE_ID] || '',
+        url: meta[BACKGROUND_IMAGE_URL] || '',
+      },
+      setValue: (id, url) => {
+        updateValueAndDependencies(BACKGROUND_IMAGE_ID)(id);
+        updateValueAndDependencies(BACKGROUND_IMAGE_URL)(url);
+      }
+    };
+
+    return (
+      <PluginDocumentSettingPanel
+        name='page-header-panel'
+        title={ __( 'Page header', 'planet4-blocks-backend' ) }
+      >
+        <TextSidebarField label={__( 'Header title', 'planet4-blocks-backend' )} {...getParams(HEADER_TITLE)} />
+        <TextSidebarField label={__( 'Header subtitle', 'planet4-blocks-backend' )} {...getParams(HEADER_SUBTITLE)} />
+        <TextareaSidebarField label={__( 'Header description', 'planet4-blocks-backend' )} {...getParams(HEADER_DESCRIPTION)} />
+        {!isCampaign && (
+          <>
+            <TextSidebarField label={__( 'Header button title', 'planet4-blocks-backend' )} {...getParams(HEADER_BUTTON_TITLE)} />
+            <TextSidebarField label={__( 'Header button link', 'planet4-blocks-backend' )} {...getParams(HEADER_BUTTON_LINK)} />
+            <CheckboxSidebarField label={__( 'Open header button link in new tab', 'planet4-blocks-backend' )} {...getParams(HEADER_BUTTON_NEW_TAB)} />
+          </>
+        )}
+        <ImageSidebarField label={__('Background image override', 'planet4-blocks-backend')} {...imageParams} />
+        <CheckboxSidebarField label={__( 'Hide page title', 'planet4-blocks-backend' )} {...getParams(HIDE_PAGE_TITLE)} />
+      </PluginDocumentSettingPanel>
+    );
+  }
+}
+

--- a/assets/src/components/SidebarFields/CheckboxSidebarField.js
+++ b/assets/src/components/SidebarFields/CheckboxSidebarField.js
@@ -1,12 +1,9 @@
 import { CheckboxControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-/**
- * Hide page title sidebar setting.
- */
-export const HidePageTitle = ({ value, setValue }) => (
+export const CheckboxSidebarField = ({ value, setValue, label }) => (
   <CheckboxControl
-    label={__( 'Hide page title', 'planet4-blocks-backend' )}
+    label={label}
     checked={value === 'on'}
     value={value === 'on'}
     onChange={checked => setValue(checked ? 'on' : '')}

--- a/assets/src/components/SidebarFields/ImageSidebarField.js
+++ b/assets/src/components/SidebarFields/ImageSidebarField.js
@@ -1,0 +1,36 @@
+import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
+import { Button } from '@wordpress/components';
+import { ImageHoverControls } from '../ImageHoverControls';
+import { __ } from '@wordpress/i18n';
+
+export const ImageSidebarField = ({ value, setValue, label }) => (
+  <div className="components-base-control mb-3">
+    <label className="components-base-control__label mb-2">
+      {label}
+    </label>
+    <MediaUploadCheck>
+      <MediaUpload
+        title={label}
+        type='image'
+        value={value.id}
+        onSelect={({ id, url }) => setValue(id.toString(), url)}
+        allowedTypes={[ 'image' ]}
+        render={({ open }) => value.url ?
+          <div style={{ position: 'relative' }}>
+            <ImageHoverControls
+              onEdit={open}
+              onRemove={() => setValue('', '')}
+            />
+            <img src={value.url} />
+          </div> :
+          <Button
+            onClick={open}
+            className='button'
+          >
+            {__('Select image', 'planet4-blocks-backend')}
+          </Button>
+        }
+      />
+    </MediaUploadCheck>
+  </div>
+);

--- a/assets/src/components/SidebarFields/TextSidebarField.js
+++ b/assets/src/components/SidebarFields/TextSidebarField.js
@@ -1,0 +1,10 @@
+import { TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export const TextSidebarField = ({ value, setValue, label }) => (
+  <TextControl
+    label={label}
+    value={value}
+    onChange={setValue}
+  />
+);

--- a/assets/src/components/SidebarFields/TextareaSidebarField.js
+++ b/assets/src/components/SidebarFields/TextareaSidebarField.js
@@ -1,0 +1,10 @@
+import { TextareaControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export const TextareaSidebarField = ({ value, setValue, label }) => (
+  <TextareaControl
+    label={label}
+    value={value}
+    onChange={setValue}
+  />
+);


### PR DESCRIPTION
### Description

See [PLANET-6901](https://jira.greenpeace.org/browse/PLANET-6901)
These settings used to be in the metabox (see [related PR](https://github.com/greenpeace/planet4-master-theme/pull/1803) to remove them from there) but we move them to the sidebar in order to keep all settings in the same place

### Testing

You can test the changes in any page or campaign, either on local or on the tavros test instance!