### PR TITLE
PLANET-6917: Migrate frontendRendered function to hydrate

### DIFF
--- a/assets/src/blocks/GuestBook/GuestBookBlock.js
+++ b/assets/src/blocks/GuestBook/GuestBookBlock.js
@@ -1,4 +1,6 @@
+import ReactDOMServer from 'react-dom/server';
 import { frontendRendered } from '../frontendRendered';
+import { GuestBookFrontend } from './GuestBookFrontend';
 const { registerBlockType } = wp.blocks;
 const { __ } = wp.i18n;
 
@@ -18,5 +20,22 @@ export const registerGuestBookBlock = () =>
         {__('This block only renders in the frontend', 'planet4-blocks-backend')}
       </p>
     ),
-    save: frontendRendered(BLOCK_NAME),
-  });
+    save: (props) => {
+      const attributes = {...props.attributes};
+      const markup = ReactDOMServer.renderToString(
+        <div
+          data-hydrate={BLOCK_NAME}
+          data-attributes={JSON.stringify(attributes)}
+        >
+          <GuestBookFrontend {...props} />
+        </div>
+      );
+      return <wp.element.RawHTML>{ markup }</wp.element.RawHTML>;
+    },
+    deprecated: [
+      {
+        save: frontendRendered(BLOCK_NAME),
+      }
+    ],
+  }
+);

--- a/assets/src/blocks/GuestBook/GuestBookScript.js
+++ b/assets/src/blocks/GuestBook/GuestBookScript.js
@@ -1,0 +1,4 @@
+import { GuestBookFrontend } from './GuestBookFrontend';
+import { hydrateBlock } from '../../functions/hydrateBlock';
+
+hydrateBlock('planet4-blocks/guestbook', GuestBookFrontend);

--- a/assets/src/frontendIndex.js
+++ b/assets/src/frontendIndex.js
@@ -6,7 +6,6 @@ import { HappypointFrontend } from './blocks/Happypoint/HappypointFrontend';
 import { SubmenuFrontend } from './blocks/Submenu/SubmenuFrontend';
 import { MediaFrontend } from './blocks/Media/MediaFrontend';
 import { ColumnsFrontend } from './blocks/Columns/ColumnsFrontend';
-import { GuestBookFrontend } from './blocks/GuestBook/GuestBookFrontend';
 import { setupMediaElementJS } from './blocks/Media/setupMediaElementJS';
 import { setupLightboxForImages } from './components/Lightbox/setupLightboxForImages';
 import { ENFormFrontend } from './blocks/ENForm/ENFormFrontend';
@@ -22,7 +21,6 @@ const COMPONENTS = {
   'planet4-blocks/submenu': SubmenuFrontend,
   'planet4-blocks/media-video': MediaFrontend,
   'planet4-blocks/columns': ColumnsFrontend,
-  'planet4-blocks/guestbook': GuestBookFrontend,
   'planet4-blocks/enform': ENFormFrontend,
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,7 @@ const publicJsConfig = {
     TimelineScript: './assets/src/blocks/Timeline/TimelineScript.js',
     GalleryScript: './assets/src/blocks/Gallery/GalleryScript.js',
     HubspotFormScript: './assets/src/blocks/HubspotForm/HubspotFormScript.js',
+    GuestBookScript: './assets/src/blocks/GuestBook/GuestBookScript.js',
   },
 };
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6917

Related (merged) PR: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/652 

**Included blocks**
- **Guestbook**
In progress..

## Testing

Open the console and run:
```
document.querySelectorAll(`[data-render]`)
```

```
document.querySelectorAll(`[data-hydrate]`)
```