### PR TITLE
Small CSS fixes for image hover buttons

### DIFF
--- a/assets/src/styles/blocks/ColumnsEditor.scss
+++ b/assets/src/styles/blocks/ColumnsEditor.scss
@@ -2,55 +2,6 @@
   position: relative;
 }
 
-.buttons-overlay {
-  position: absolute;
-  z-index: 2;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  display: flex;
-
-  button {
-    display: none;
-  }
-
-  &:hover {
-    background: rgba(255, 255, 255, 0.3);
-
-    button {
-      display: inline-flex;
-    }
-  }
-
-  .block-style-icons & {
-    justify-content: flex-start;
-    margin-left: 10px;
-
-    .edit-image .dashicon {
-      margin: 0;
-    }
-  }
-
-  .block-style-tasks & {
-    height: calc(100% - 32px);
-  }
-
-  .remove-image {
-    margin-inline-start: 10px;
-    background: $grey-80;
-    color: $white;
-
-    .dashicon {
-      margin: 0;
-    }
-
-    &:hover {
-      background: $grey-60;
-    }
-  }
-}
-
 .column-wrap {
   position: relative;
 
@@ -107,5 +58,6 @@
 
   &:hover .image-placeholder-button {
     display: inline-flex;
+    width: fit-content;
   }
 }

--- a/assets/src/styles/blocks/TakeActionBoxout/edit.scss
+++ b/assets/src/styles/blocks/TakeActionBoxout/edit.scss
@@ -22,6 +22,9 @@
   height: 100%;
   width: 336px;
   padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   img {
     width: 100%;

--- a/assets/src/styles/components/ImageHoverButtons.scss
+++ b/assets/src/styles/components/ImageHoverButtons.scss
@@ -1,0 +1,51 @@
+.buttons-overlay {
+  position: absolute;
+  z-index: 2;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  display: flex;
+
+  button {
+    display: none;
+  }
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.3);
+
+    button {
+      display: inline-flex;
+    }
+  }
+
+  .block-style-icons & {
+    justify-content: flex-start;
+
+    .edit-image {
+      margin-inline-start: $sp-1;
+
+      .dashicon {
+        margin: 0;
+      }
+    }
+  }
+
+  .block-style-tasks & {
+    height: calc(100% - 32px);
+  }
+
+  .remove-image {
+    margin-inline-start: $sp-1;
+    background: $grey-80;
+    color: $white;
+
+    .dashicon {
+      margin: 0;
+    }
+
+    &:hover {
+      background: $grey-60;
+    }
+  }
+}

--- a/assets/src/styles/editorStyle.scss
+++ b/assets/src/styles/editorStyle.scss
@@ -27,6 +27,7 @@
 @import "components/ValidationMessage";
 @import "components/FormField";
 @import "components/HTMLSidebarHelp";
+@import "components/ImageHoverButtons";
 @import "editorFonts";
 
 .block-edit-mode-warning {


### PR DESCRIPTION
### Description

These looked off in the editor:
- Take Action boxout (placeholder not centered):
<img width="552" alt="Screenshot 2022-09-27 at 14 05 58" src="https://user-images.githubusercontent.com/6949075/192520850-a187324a-22ce-4d31-a4c6-55d9d38b93d6.png">

- P4 Columns (button full width):
<img width="670" alt="Screenshot 2022-09-27 at 14 06 10" src="https://user-images.githubusercontent.com/6949075/192521061-9dedb4e0-785d-4cec-896f-2c019ad2b941.png">


### Testing

You can compare the fixed version [here](https://www-dev.greenpeace.org/test-oberon/wp-admin/post.php?post=51128&action=edit) with the broken version [here](https://www-dev.greenpeace.org/test-leda/wp-admin/post.php?post=1171&action=edit).