### PR TITLE
PLANET-6843 Added a block filter to enforce "AJAX" toggle setting enabled by default on GF block.

### DIFF
--- a/assets/src/BlockFilters.js
+++ b/assets/src/BlockFilters.js
@@ -5,6 +5,7 @@ import { ImageBlockEdit } from './components/Image/ImageBlockEdit';
 export const addBlockFilters = () => {
   addFileBlockFilter();
   addImageBlockFilter();
+  addGravityFormsBlockFilter();
 };
 
 const addFileBlockFilter = () => {
@@ -23,3 +24,19 @@ const addFileBlockFilter = () => {
 };
 
 const addImageBlockFilter = () => addFilter('editor.BlockEdit', 'core/image/edit', ImageBlockEdit);
+
+// Enforce "AJAX" toggle setting enabled by default, on Gravity form block.
+const addGravityFormsBlockFilter = () => {
+  const setAJAXToggleDefaultTrue = (settings, name) => {
+
+    if ('gravityforms/form' !== name) {
+      return settings;
+    }
+
+    settings.attributes['ajax']['default'] = true;
+
+    return settings;
+  };
+
+  addFilter('blocks.registerBlockType', 'planet4-blocks/filters/file', setAJAXToggleDefaultTrue);
+};


### PR DESCRIPTION
Ref https://jira.greenpeace.org/browse/PLANET-6843

**Testing:**
- Add a gravity form block on page and check the "AJAX" toggle setting under Advanced tab, it should be by default enabled.

**eg.** 
https://www-dev.greenpeace.org/test-sinope/wp-admin/post-new.php?post_type=page