### PR TITLE
PLANET-6900 Add Open Graph fields to the sidebar

### DIFF
--- a/assets/src/components/Sidebar/ActionSidebar.js
+++ b/assets/src/components/Sidebar/ActionSidebar.js
@@ -1,9 +1,9 @@
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { NavigationType } from '../NavigationType/NavigationType';
 import { CheckboxSidebarField } from '../SidebarFields/CheckboxSidebarField';
 import { TextSidebarField } from '../SidebarFields/TextSidebarField';
+import { getSidebarFunctions } from './getSidebarFunctions';
 
 const FIELD_NAVTYPE = 'nav_type';
 const HIDE_PAGE_TITLE = 'p4_hide_page_title_checkbox';
@@ -15,24 +15,7 @@ const BUTTON_TEXT = 'action_button_text';
 export const ActionSidebar = {
   getId: () => 'planet4-action-sidebar',
   render: () => {
-    const meta = useSelect(select => select('core/editor').getEditedPostAttribute('meta'),[]);
-    const { editPost } = useDispatch('core/editor');
-    const updateValueAndDependencies = fieldId => value => editPost({ meta: {[fieldId]: value} });
-
-    const navParams = {
-      value: meta[FIELD_NAVTYPE] || null,
-      setValue: updateValueAndDependencies(FIELD_NAVTYPE),
-    };
-
-    const hidePageTitleParams = {
-      value: meta[HIDE_PAGE_TITLE] || '',
-      setValue: updateValueAndDependencies(HIDE_PAGE_TITLE),
-    }
-
-    const buttonTextParams = {
-      value: meta[BUTTON_TEXT],
-      setValue: updateValueAndDependencies(BUTTON_TEXT),
-    }
+    const { getParams } = getSidebarFunctions();
 
     return (
       <>
@@ -40,7 +23,7 @@ export const ActionSidebar = {
           name='page-header-panel'
           title={ __( 'Page header', 'planet4-blocks-backend' ) }
         >
-          <CheckboxSidebarField label={__( 'Hide page title', 'planet4-blocks-backend' )} {...hidePageTitleParams} />
+          <CheckboxSidebarField label={__( 'Hide page title', 'planet4-blocks-backend' )} {...getParams(HIDE_PAGE_TITLE)} />
         </PluginDocumentSettingPanel>
         <PluginDocumentSettingPanel
           name='button-text-panel'
@@ -48,7 +31,7 @@ export const ActionSidebar = {
         >
           <TextSidebarField
             label={__( 'Edit the button text shown on the Action covers block', 'planet4-blocks-backend' )}
-            {...buttonTextParams}
+            {...getParams(BUTTON_TEXT)}
           />
         </PluginDocumentSettingPanel>
         <PluginDocumentSettingPanel
@@ -56,7 +39,7 @@ export const ActionSidebar = {
           title={ __( 'Navigation', 'planet4-blocks-backend' ) }
           className='navigation-panel'
         >
-          <NavigationType {...navParams} />
+          <NavigationType {...getParams(FIELD_NAVTYPE)} />
         </PluginDocumentSettingPanel>
       </>
     );

--- a/assets/src/components/Sidebar/OpenGraphSidebar.js
+++ b/assets/src/components/Sidebar/OpenGraphSidebar.js
@@ -1,0 +1,34 @@
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { __ } from '@wordpress/i18n';
+import { TextareaSidebarField } from '../SidebarFields/TextareaSidebarField';
+import { ImageSidebarField } from '../SidebarFields/ImageSidebarField';
+import { TextSidebarField } from '../SidebarFields/TextSidebarField';
+import { getSidebarFunctions } from './getSidebarFunctions';
+
+// The various meta fields
+const OG_TITLE = 'p4_og_title';
+const OG_DESCRIPTION = 'p4_og_description';
+const OG_IMAGE_ID = 'p4_og_image_id';
+const OG_IMAGE_URL = 'p4_og_image';
+
+/**
+ * Open Graph settings for the sidebar
+ */
+ export const OpenGraphSidebar = {
+  getId: () => 'planet4-open-graph-sidebar',
+  render: () => {
+    const { getParams, getImageParams } = getSidebarFunctions();
+
+    return (
+      <PluginDocumentSettingPanel
+        name='open-graph-panel'
+        title={ __( 'Open Graph/Social Fields', 'planet4-blocks-backend' ) }
+      >
+        <TextSidebarField label={__( 'Title', 'planet4-blocks-backend' )} {...getParams(OG_TITLE)} />
+        <TextareaSidebarField label={__( 'Description', 'planet4-blocks-backend' )} {...getParams(OG_DESCRIPTION)} />
+        <ImageSidebarField label={__('Image override', 'planet4-blocks-backend')} {...getImageParams(OG_IMAGE_ID, OG_IMAGE_URL)} />
+      </PluginDocumentSettingPanel>
+    );
+  }
+}
+

--- a/assets/src/components/Sidebar/PageHeaderSidebar.js
+++ b/assets/src/components/Sidebar/PageHeaderSidebar.js
@@ -1,10 +1,11 @@
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { CheckboxSidebarField } from '../SidebarFields/CheckboxSidebarField';
 import { TextareaSidebarField } from '../SidebarFields/TextareaSidebarField';
 import { ImageSidebarField } from '../SidebarFields/ImageSidebarField';
 import { TextSidebarField } from '../SidebarFields/TextSidebarField';
+import { getSidebarFunctions } from './getSidebarFunctions';
 
 // The various meta fields
 const HIDE_PAGE_TITLE = 'p4_hide_page_title_checkbox';
@@ -23,29 +24,10 @@ const HEADER_BUTTON_NEW_TAB = 'p4_button_link_checkbox';
  export const PageHeaderSidebar = {
   getId: () => 'planet4-page-header-sidebar',
   render: () => {
-    const meta = useSelect(select => select('core/editor').getEditedPostAttribute('meta'),[]);
     const postType = useSelect(select => select('core/editor').getCurrentPostType());
     const isCampaign = postType === 'campaign';
 
-    const { editPost } = useDispatch('core/editor');
-
-    const updateValueAndDependencies = fieldId => value => editPost({ meta: {[fieldId]: value} });
-
-    const getParams = name => ({
-      value: meta[name] || '',
-      setValue: updateValueAndDependencies(name),
-    });
-
-    const imageParams = {
-      value: {
-        id: meta[BACKGROUND_IMAGE_ID] || '',
-        url: meta[BACKGROUND_IMAGE_URL] || '',
-      },
-      setValue: (id, url) => {
-        updateValueAndDependencies(BACKGROUND_IMAGE_ID)(id);
-        updateValueAndDependencies(BACKGROUND_IMAGE_URL)(url);
-      }
-    };
+    const { getParams, getImageParams } = getSidebarFunctions();
 
     return (
       <PluginDocumentSettingPanel
@@ -62,7 +44,7 @@ const HEADER_BUTTON_NEW_TAB = 'p4_button_link_checkbox';
             <CheckboxSidebarField label={__( 'Open header button link in new tab', 'planet4-blocks-backend' )} {...getParams(HEADER_BUTTON_NEW_TAB)} />
           </>
         )}
-        <ImageSidebarField label={__('Background image override', 'planet4-blocks-backend')} {...imageParams} />
+        <ImageSidebarField label={__('Background image override', 'planet4-blocks-backend')} {...getImageParams(BACKGROUND_IMAGE_ID, BACKGROUND_IMAGE_URL)} />
         <CheckboxSidebarField label={__( 'Hide page title', 'planet4-blocks-backend' )} {...getParams(HIDE_PAGE_TITLE)} />
       </PluginDocumentSettingPanel>
     );

--- a/assets/src/components/Sidebar/getSidebarFunctions.js
+++ b/assets/src/components/Sidebar/getSidebarFunctions.js
@@ -1,0 +1,30 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+
+export const getSidebarFunctions = () => {
+  const meta = useSelect(select => select('core/editor').getEditedPostAttribute('meta'),[]);
+
+  const { editPost } = useDispatch('core/editor');
+
+  const updateValueAndDependencies = fieldId => value => editPost({ meta: {[fieldId]: value} });
+
+  const getParams = name => ({
+    value: meta[name] || '',
+    setValue: updateValueAndDependencies(name),
+  });
+
+  const getImageParams = (idField, urlField) => ({
+    value: {
+      id: meta[idField] || '',
+      url: meta[urlField] || '',
+    },
+    setValue: (id, url) => {
+      updateValueAndDependencies(idField)(id);
+      updateValueAndDependencies(urlField)(url);
+    }
+  });
+
+  return {
+    getImageParams,
+    getParams,
+  };
+};

--- a/assets/src/components/SidebarFields/ImageSidebarField.js
+++ b/assets/src/components/SidebarFields/ImageSidebarField.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 
 export const ImageSidebarField = ({ value, setValue, label }) => (
   <div className="components-base-control mb-3">
-    <label className="components-base-control__label mb-2">
+    <label className="components-base-control__label mb-2 d-block">
       {label}
     </label>
     <MediaUploadCheck>

--- a/assets/src/setupCustomSidebar.js
+++ b/assets/src/setupCustomSidebar.js
@@ -2,6 +2,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import { PageHeaderSidebar } from './components/Sidebar/PageHeaderSidebar';
 import { CampaignThemeSidebar } from './components/Sidebar/CampaignThemeSidebar';
 import { ActionSidebar } from './components/Sidebar/ActionSidebar';
+import { OpenGraphSidebar } from './components/Sidebar/OpenGraphSidebar';
 
 const sidebarsForPostType = postType => {
   switch (postType) {
@@ -13,14 +14,21 @@ const sidebarsForPostType = postType => {
         getIcon: CampaignThemeSidebar.getIcon,
         render: CampaignThemeSidebar,
       },
+      OpenGraphSidebar,
     ];
   case 'p4_action':
     return [
       ActionSidebar,
+      OpenGraphSidebar,
     ];
   case 'page':
     return [
       PageHeaderSidebar,
+      OpenGraphSidebar,
+    ];
+  case 'post':
+    return [
+      OpenGraphSidebar,
     ];
   default:
     return null;


### PR DESCRIPTION
### Description

See [PLANET-6900](https://jira.greenpeace.org/browse/PLANET-6900)
These fields were removed from the metabox (see [related PR](https://github.com/greenpeace/planet4-master-theme/pull/1810)) and are now in the sidebar.

### Testing

On your local or on the [mars test instance](https://www-dev.greenpeace.org/test-mars/), you can add the Open Graph meta fields from the sidebar to any post/campaign/page/action and update the page. On reload in the editor you should still see the data that you entered, and when inspecting the page in the frontend you should see the correct meta fields added to the `head`:

<img width="396" alt="Screenshot 2022-10-17 at 10 56 49" src="https://user-images.githubusercontent.com/6949075/196134852-97c9fe4e-886a-4162-8134-cfea858b772c.png">

You can also test the fields using this tool: https://www.opengraph.xyz/