### PR TITLE
PLANET-4444 Add action button text to Action sidebar

### DIFF
--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -16,7 +16,7 @@ import { ImagePlaceholder } from './ImagePlaceholder';
 import { ImageHoverControls } from '../../components/ImageHoverControls';
 
 // Planet 4 settings (Planet 4 >> Defaults content >> Take Action Covers default button text).
-const DEFAULT_BUTTON_TEXT = window.p4bk_vars.take_action_covers_button_text;
+const DEFAULT_BUTTON_TEXT = window.p4bk_vars.take_action_covers_button_text || __('Take action', 'planet4-blocks');
 
 const {
   RichText,
@@ -93,7 +93,8 @@ export const TakeActionBoxoutEditor = ({
     const title = !take_action_page ? customTitle : actPage.title.raw;
     const excerpt = !take_action_page ? customExcerpt : actPage.excerpt.raw;
     const link = !take_action_page ? customLink : actPage.link;
-    const linkText = !take_action_page ? customLinkText : DEFAULT_BUTTON_TEXT || __('Take action', 'planet4-blocks');
+
+    let linkText = !take_action_page ? customLinkText : actPage?.meta?.action_button_text || DEFAULT_BUTTON_TEXT;
 
     const imageId = !take_action_page ? customImageId : actPageImageId;
     const imageUrl = !take_action_page ? customImageFromId : select('core').getMedia(actPageImageId)?.source_url;

--- a/assets/src/components/Sidebar/ActionSidebar.js
+++ b/assets/src/components/Sidebar/ActionSidebar.js
@@ -3,9 +3,11 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { NavigationType } from '../NavigationType/NavigationType';
 import { CheckboxSidebarField } from '../SidebarFields/CheckboxSidebarField';
+import { TextSidebarField } from '../SidebarFields/TextSidebarField';
 
 const FIELD_NAVTYPE = 'nav_type';
 const HIDE_PAGE_TITLE = 'p4_hide_page_title_checkbox';
+const BUTTON_TEXT = 'action_button_text';
 
 /**
  * Add settings to Action pages
@@ -27,6 +29,11 @@ export const ActionSidebar = {
       setValue: updateValueAndDependencies(HIDE_PAGE_TITLE),
     }
 
+    const buttonTextParams = {
+      value: meta[BUTTON_TEXT],
+      setValue: updateValueAndDependencies(BUTTON_TEXT),
+    }
+
     return (
       <>
         <PluginDocumentSettingPanel
@@ -34,6 +41,15 @@ export const ActionSidebar = {
           title={ __( 'Page header', 'planet4-blocks-backend' ) }
         >
           <CheckboxSidebarField label={__( 'Hide page title', 'planet4-blocks-backend' )} {...hidePageTitleParams} />
+        </PluginDocumentSettingPanel>
+        <PluginDocumentSettingPanel
+          name='button-text-panel'
+          title={ __( 'Covers block button text', 'planet4-blocks-backend' ) }
+        >
+          <TextSidebarField
+            label={__( 'Edit the button text shown on the Action covers block', 'planet4-blocks-backend' )}
+            {...buttonTextParams}
+          />
         </PluginDocumentSettingPanel>
         <PluginDocumentSettingPanel
           name='navigation-panel'

--- a/classes/blocks/class-covers.php
+++ b/classes/blocks/class-covers.php
@@ -460,8 +460,6 @@ class Covers extends Base_Block {
 		$covers = [];
 
 		if ( $actions ) {
-			$cover_button_text = $options['take_action_covers_button_text'] ?? __( 'Take action', 'planet4-blocks' );
-
 			foreach ( $actions as $action ) {
 				$tags    = [];
 				$wp_tags = wp_get_post_tags( $action->ID );
@@ -476,6 +474,14 @@ class Covers extends Base_Block {
 				}
 
 				$img_id = get_post_thumbnail_id( $action );
+
+				// Get the button text from the meta data (for Actions), the P4 settings, or use the default value.
+				$meta = get_post_meta( $action->ID );
+				if ( isset( $meta['action_button_text'] ) && $meta['action_button_text'][0] ) {
+					$cover_button_text = $meta['action_button_text'][0];
+				} else {
+					$cover_button_text = $options['take_action_covers_button_text'] ?? __( 'Take action', 'planet4-blocks' );
+				}
 
 				$covers[] = [
 					'tags'        => $tags ?? [],

--- a/classes/blocks/class-takeactionboxout.php
+++ b/classes/blocks/class-takeactionboxout.php
@@ -141,13 +141,20 @@ class TakeActionBoxout extends Base_Block {
 			$image_alt = get_post_meta( $img_id, '_wp_attachment_image_alt', true );
 		}
 
+		$meta = get_post_meta( $page_id );
+		if ( isset( $meta['action_button_text'] ) && $meta['action_button_text'][0] ) {
+			$cover_button_text = $meta['action_button_text'][0];
+		} else {
+			$cover_button_text = $options['take_action_covers_button_text'] ?? __( 'Take action', 'planet4-blocks' );
+		}
+
 		return [
 			'boxout' => [
 				'title'        => null === $page ? '' : $page->post_title,
 				'excerpt'      => null === $page ? '' : $page->post_excerpt,
 				'link'         => null === $page ? '' : get_permalink( $page ),
 				'new_tab'      => false,
-				'link_text'    => $options['take_action_covers_button_text'] ?? __( 'Take action', 'planet4-blocks' ),
+				'link_text'    => $cover_button_text,
 				'image'        => $image ?? '',
 				'image_alt'    => $image_alt ?? '',
 				'image_srcset' => $src_set ?? '',


### PR DESCRIPTION
### Description

See [PLANET-4444](https://jira.greenpeace.org/browse/PLANET-4444)
This text will be shown in the Covers block, the Take Action boxout, and in search results.

**Related PR:** https://github.com/greenpeace/planet4-master-theme/pull/1824

### Testing

You can test the 3 possibilities (no button text, default button text, and custom button text)

- in the Covers block on [this page](https://www-dev.greenpeace.org/test-titan/text-actions-button-texts/) for example
- in the Search page [here](https://www-dev.greenpeace.org/test-titan/?s=button+text&orderby=_score) for example

You can also test changing the default text in the [P4 settings](https://www-dev.greenpeace.org/test-titan/wp-admin/admin.php?page=planet4_settings_defaults_content) to see how the block and search results are impacted!