### PR TITLE
Save full HTML output for Columns block

### DIFF
--- a/assets/src/blocks/Columns/ColumnsBlock.js
+++ b/assets/src/blocks/Columns/ColumnsBlock.js
@@ -1,10 +1,12 @@
 import { ColumnsEditor } from './ColumnsEditor.js';
+import { ColumnsFrontend } from './ColumnsFrontend.js'
 import { LAYOUT_NO_IMAGE, LAYOUT_IMAGES, LAYOUT_ICONS, LAYOUT_TASKS } from './ColumnConstants.js';
 import { example } from './example';
 import { getStyleLabel } from '../../functions/getStyleLabel';
 
 const { __ } = wp.i18n;
 const { registerBlockType } = wp.blocks;
+import ReactDOMServer from 'react-dom/server';
 
 export const registerColumnsBlock = () =>
   registerBlockType('planet4-blocks/columns', {
@@ -54,8 +56,15 @@ export const registerColumnsBlock = () =>
       },
     },
     edit: ColumnsEditor,
-    save() {
-      return null;
+    save: ({ attributes }) => {
+        const markup = ReactDOMServer.renderToString(
+          <div data-hydrate={'planet4-blocks/columns'}
+            data-attributes={JSON.stringify(attributes)}>
+            <ColumnsFrontend { ...attributes } />
+          </div>
+        );
+
+        return <wp.element.RawHTML>{ markup }</wp.element.RawHTML>;
     },
     styles: [
       {

--- a/classes/blocks/class-columns.php
+++ b/classes/blocks/class-columns.php
@@ -39,11 +39,6 @@ class Columns extends Base_Block {
 			self::get_full_block_name(),
 			[
 				'editor_script'   => 'planet4-blocks',
-				'render_callback' => static function ( $attributes ) {
-					$attributes['columns'] = self::get_columns_data( $attributes );
-
-					return self::render_frontend( $attributes );
-				},
 				'attributes'      => [
 					'columns_block_style' => [
 						'type'    => 'string',


### PR DESCRIPTION
A basic way to save HTML output for blocks, to replace `null` or `frontendRendered`.
Using `ReactDOMServer.renderToString` allows to skip errors given by `wp.element.renderToString` about hooks used at the wrong place.