### PR TITLE
PLANET-6939 Convert Quick Links pattern into a block template

### DIFF
--- a/assets/src/block-templates/quick-links/block.json
+++ b/assets/src/block-templates/quick-links/block.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-block-templates/quick-links",
+  "title": "Quick Links",
+  "category": "planet4-block-templates",
+  "textdomain": "planet4-blocks-backend",
+  "attributes": {
+    "title": { "type": "string" },
+    "backgroundColor": { "type": "string" }
+  }
+}

--- a/assets/src/block-templates/quick-links/index.js
+++ b/assets/src/block-templates/quick-links/index.js
@@ -1,0 +1,4 @@
+import metadata from './block.json';
+import template from './template';
+
+export { metadata, template };

--- a/assets/src/block-templates/quick-links/template.js
+++ b/assets/src/block-templates/quick-links/template.js
@@ -1,0 +1,42 @@
+import metadata from './block.json';
+import mainThemeUrl from '../main-theme-url';
+
+const category = ['core/column', {}, [
+  ['core/group', {className: 'group-stretched-link'}, [
+    ['core/image', {
+      align: 'center',
+      className: 'is-style-rounded-90 force-no-lightbox force-no-caption mb-0',
+      url: `${mainThemeUrl}/images/placeholders/placeholder-90x90.jpg`
+    }],
+    ['core/spacer', {height: '16px'}],
+    ['core/heading', {
+      level: 5,
+      style: {typography: {fontSize: '1rem'}},
+      textAlign: 'center',
+      placeholder: 'Category'
+    }]
+  ]]
+]];
+
+const template = ({
+  title = '',
+  backgroundColor = 'grey-05',
+}) => ([
+  ['core/group', {
+    className: `block ${metadata.classname}`,
+    align: 'full',
+    backgroundColor
+  }, [
+    ['core/group', {className: 'container'}, [
+      ['core/spacer', {height: '24px'}],
+      ['core/heading', {level: 4, placeholder: __('Enter title', 'planet4-blocks-backend'), content: title}],
+      ['core/columns', {
+        isStackedOnMobile: false,
+        className: 'is-style-mobile-carousel'
+      },
+      [...Array(5).keys()].map(() => category)]
+    ]]
+  ]]
+]);
+
+export default template;

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -1,5 +1,7 @@
 import * as sideImgTextCta from './side-image-with-text-and-cta';
+import * as quickLinks from './quick-links';
 
 export default [
   sideImgTextCta,
+  quickLinks,
 ];

--- a/classes/patterns/class-action.php
+++ b/classes/patterns/class-action.php
@@ -60,8 +60,8 @@ class Action extends Block_Pattern {
 						<!-- /wp:separator -->
 						' . QuickLinks::get_config(
 							[
-								'background_color'  => 'white',
-								'title_placeholder' => __( 'Explore by topics', 'planet4-blocks' ),
+								'background_color' => 'white',
+								'title'            => __( 'Explore by topics', 'planet4-blocks' ),
 							]
 						)['content'] . '
 					</div>

--- a/classes/patterns/class-deepdivetopic.php
+++ b/classes/patterns/class-deepdivetopic.php
@@ -64,8 +64,8 @@ class DeepDiveTopic extends Block_Pattern {
 					)['content'] . '
 					' . QuickLinks::get_config(
 						[
-							'title_placeholder' => __( 'Explore other topics', 'planet4-blocks' ),
-							'background_color'  => 'white',
+							'title'            => __( 'Explore other topics', 'planet4-blocks' ),
+							'background_color' => 'white',
 						]
 					)['content'] . '
 					</div>

--- a/classes/patterns/class-getinformed.php
+++ b/classes/patterns/class-getinformed.php
@@ -38,7 +38,7 @@ class GetInformed extends Block_Pattern {
 			'content'    => '
 				<!-- wp:group {"className":"block ' . $classname . '"} -->
 					<div class="wp-block-group block ' . $classname . '">
-						' . QuickLinks::get_config( [ 'title_placeholder' => __( 'Explore by topic', 'planet4-blocks' ) ] )['content'] . '
+						' . QuickLinks::get_config( [ 'title' => __( 'Explore by topic', 'planet4-blocks' ) ] )['content'] . '
 						' . SideImageWithTextAndCta::get_config(
 							[ 'title' => __( 'Topic 1', 'planet4-blocks' ) ]
 						)['content'] . '

--- a/classes/patterns/class-highleveltopic.php
+++ b/classes/patterns/class-highleveltopic.php
@@ -84,8 +84,8 @@ class HighLevelTopic extends Block_Pattern {
 						' . GravityFormWithText::get_content() . '
 						' . QuickLinks::get_config(
 							[
-								'title_placeholder' => __( 'Explore by topics', 'planet4-blocks' ),
-								'background_color'  => 'white',
+								'title'            => __( 'Explore by topics', 'planet4-blocks' ),
+								'background_color' => 'white',
 							]
 						)['content'] . '
 					</div>

--- a/classes/patterns/class-quicklinks.php
+++ b/classes/patterns/class-quicklinks.php
@@ -23,78 +23,16 @@ class QuickLinks extends Block_Pattern {
 	}
 
 	/**
-	 * Returns the template for one column.
-	 */
-	public static function get_column_template(): string {
-		return '
-			<!-- wp:column -->
-				<div class="wp-block-column">
-					<!-- wp:group {"className":"group-stretched-link"} -->
-						<div class="wp-block-group group-stretched-link">
-							<!-- wp:image {"align":"center","className":"is-style-rounded-90 force-no-lightbox force-no-caption mb-0"} -->
-								<div class="wp-block-image is-style-rounded-90 force-no-lightbox force-no-caption mb-0">
-									<figure class="aligncenter">
-										<img
-											src="' . esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-90x90.jpg"
-											alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '"
-										/>
-									</figure>
-								</div>
-							<!-- /wp:image -->
-							<!-- wp:spacer {"height":"16px"} -->
-								<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
-							<!-- /wp:spacer -->
-							<!-- wp:heading {
-								"level":5,
-								"style":{"typography":{"fontSize":"1rem"}},
-								"align":"center",
-								"className":"has-text-align-center",
-								"placeholder":"' . __( 'Category', 'planet4-blocks-backend' ) . '"
-							} -->
-								<h5 style="font-size:1rem;" class="has-text-align-center"></h5>
-							<!-- /wp:heading -->
-						</div>
-					<!-- /wp:group -->
-				</div>
-			<!-- /wp:column -->
-		';
-	}
-
-	/**
 	 * Returns the pattern config.
-	 * We start with 6 columns, but editors can easily remove and/or duplicate them.
-	 * This pattern should have grey 5% background by default.
 	 *
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
-		$classname         = self::get_classname();
-		$title_placeholder = $params['title_placeholder'] ?? '';
-		$background_color  = $params['background_color'] ?? 'grey-05';
-
 		return [
 			'title'      => 'Quick Links',
 			'categories' => [ 'planet4' ],
 			'content'    => '
-				<!-- wp:group {"className":"block ' . $classname . '","align":"full","backgroundColor":"' . $background_color . '"} -->
-					<div class="wp-block-group alignfull block ' . $classname . ' has-' . $background_color . '-background-color has-background">
-						<!-- wp:group {"className":"container"} -->
-							<div class="wp-block-group container">
-								<!-- wp:spacer {"height":"24px"} -->
-									<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
-								<!-- /wp:spacer -->
-								<!-- wp:heading {"level":4,"placeholder":"' . __( 'Enter title', 'planet4-blocks-backend' ) . '"} -->
-									<h4>' . $title_placeholder . '</h4>
-								<!-- /wp:heading -->
-								<!-- wp:columns {"isStackedOnMobile":false,"className":"is-style-mobile-carousel"} -->
-									<div class="wp-block-columns is-not-stacked-on-mobile is-style-mobile-carousel">
-											' . str_repeat( self::get_column_template(), 9 ) . '
-									</div>
-								<!-- /wp:columns -->
-							</div>
-						<!-- /wp:group -->
-					</div>
-				<!-- /wp:group -->
+				<!-- wp:planet4-block-templates/quick-links ' . wp_json_encode( $params, \JSON_FORCE_OBJECT ) . ' /-->
 			',
 		];
 	}

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -208,6 +208,7 @@ const BETA_ACTION_BLOCK_TYPES = [
 
 const BLOCK_TEMPLATES = [
 	'planet4-block-templates/side-image-with-text-and-cta',
+	'planet4-block-templates/quick-links',
 ];
 
 /**


### PR DESCRIPTION
### Description

See [PLANET-6939](https://jira.greenpeace.org/browse/PLANET-6939)

### Testing

You should be able to add a Quick Links pattern as before without any problems! And the layouts using it should also still work as expected.