### PR TITLE
Fix warning on block templates category missing

### DIFF
--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -548,10 +548,13 @@ DEFERREDCSS;
 				'slug'  => 'planet4-blocks',
 				'title' => 'Planet 4 Blocks',
 			],
-
 			[
 				'slug'  => 'planet4-blocks-beta',
 				'title' => 'Planet 4 Blocks - BETA',
+			],
+			[
+				'slug'  => 'planet4-block-templates',
+				'title' => 'Planet 4 Block Templates',
 			],
 		];
 


### PR DESCRIPTION
Adding a new block template in the editor generates a Warning message in the browser console, saying that the block category is invalid.

`The block "planet4-block-templates/side-image-with-text-and-cta" is registered with an invalid category "planet4-block-templates".`

## Fix 

- Declare missing block templates category
