### PR TITLE
PLANET-6981 Remove jQuery from addButtonLinkPasteWarning

### DIFF
--- a/assets/src/addButtonLinkPasteWarning.js
+++ b/assets/src/addButtonLinkPasteWarning.js
@@ -1,19 +1,19 @@
 export const addButtonLinkPasteWarning = () => {
-  document.addEventListener( 'DOMContentLoaded', () => {
-    document.onpaste = ( event ) => {
-      const target = event.target;
-      if ( !target.matches( '.wp-block-button__link, .wp-block-button__link *' ) ) {
+  document.addEventListener('DOMContentLoaded', () => {
+    document.onpaste = event => {
+      const { target } = event;
+      if (!target.matches('.wp-block-button__link, .wp-block-button__link *')) {
         return;
       }
 
-      const aTags = jQuery(target).closest( '.wp-block-button__link' ).find('a');
-      if ( aTags.length ) {
+      const aTags = target.querySelectorAll('a');
+      if (aTags.length) {
         const { __ } = wp.i18n;
-        alert( __(
+        alert(__(
           'You are pasting a link into the button text. Please ensure your clipboard only has text in it. Alternatively you can press control/command + SHIFT + V to paste only the text in your clipboard.',
-          'planet4-blocks-backend')
-        );
+          'planet4-blocks-backend'
+        ));
       }
     };
-  } );
+  });
 };


### PR DESCRIPTION
### Description

This is to eventually completely stop using jQuery

### Testing

The functionality should still work like before, so you should see the warning when adding a Button block and trying to paste a link into it.