### PR TITLE
PLANET-6980 Make sure non-admins cannot create new tags in the sidebar

### DIFF
--- a/assets/src/components/TermSelector/TermSelector.js
+++ b/assets/src/components/TermSelector/TermSelector.js
@@ -134,13 +134,15 @@
      loading,
      availableTerms,
      taxonomy,
+     isUserAdmin,
    } = useSelect(
      ( select ) => {
        const { getCurrentPost, getEditedPostAttribute } = select( 'core/editor' );
-       const { getTaxonomy, getEntityRecords, isResolving } = select( coreStore );
+       const { getTaxonomy, getEntityRecords, isResolving, canUser } = select( coreStore );
        const _taxonomy = getTaxonomy( slug );
 
        return {
+        isUserAdmin: canUser( 'create', 'users' ) ?? false,
          hasCreateAction: _taxonomy
            ? get(
                getCurrentPost(),
@@ -359,7 +361,8 @@
            '' !== filterValue ? filteredTermsTree : availableTermsTree
          ) }
        </div>
-       { ! loading && hasCreateAction && (
+       {/* Only admins should be allowed to create new tags */}
+       { ! loading && hasCreateAction && (isUserAdmin || slug !== 'post_tag') && (
          <Button
            onClick={ onToggleForm }
            className="editor-post-taxonomies__hierarchical-terms-add"
@@ -369,6 +372,7 @@
            { newTermButtonLabel }
          </Button>
        ) }
+       {!isUserAdmin && slug === 'post_tag' && <p>{__( 'New tags can only be created by an administrator', 'planet4-blocks-backend' )}</p>}
        { showForm && (
          <form onSubmit={ onAddTerm }>
            <TextControl


### PR DESCRIPTION
### Description

See [PLANET-6980](https://jira.greenpeace.org/browse/PLANET-6980)
We forgot about this detail when implementing the new tags selector interface. Right now for non-admins, we add a restricted tags box which is no longer needed since we now handle the restriction here in the new tags selector. There is [another PR](https://github.com/greenpeace/planet4-master-theme/pull/1857) to remove the restricted box, especially because there was a bug in the removal of the "normal" tags box which caused 2 boxes to be shown 😬 

### Testing

On local or on the [umbriel test instance](https://www-dev.greenpeace.org/test-umbriel/), whether you login as an admin or as a non-admin you should see only one "Tags" section in the sidebar. The only difference between the two interfaces should be the "Add new tag" button available for admins, for other users instead they should see the explanation message.