### PR TITLE
PLANET-6960 Add sidebar option to define canonical link

### DIFF
--- a/assets/src/components/Sidebar/SearchEngineOptimizationsSidebar.js
+++ b/assets/src/components/Sidebar/SearchEngineOptimizationsSidebar.js
@@ -1,0 +1,22 @@
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { TextSidebarField } from '../SidebarFields/TextSidebarField';
+import { getSidebarFunctions } from './getSidebarFunctions';
+const CANONICAL_URL = 'p4_seo_canonical_url';
+
+const { __ } = wp.i18n;
+
+ export const SearchEngineOptimizationsSidebar = {
+  getId: () => 'planet4-seo-sidebar',
+  render: () => {
+    const { getParams } = getSidebarFunctions();
+
+    return (
+      <PluginDocumentSettingPanel
+        name='planet4-search-engine-optimizations'
+        title={ __( 'Search Engine Optimizations', 'planet4-blocks-backend' ) }
+      >
+        <TextSidebarField label={__( 'Canonical link', 'planet4-blocks-backend' )} type="url" {...getParams(CANONICAL_URL)} />
+      </PluginDocumentSettingPanel>
+    );
+  }
+}

--- a/assets/src/components/Sidebar/SearchEngineOptimizationsSidebar.js
+++ b/assets/src/components/Sidebar/SearchEngineOptimizationsSidebar.js
@@ -1,6 +1,7 @@
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
-import { TextSidebarField } from '../SidebarFields/TextSidebarField';
-import { getSidebarFunctions } from './getSidebarFunctions';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { URLInput } from '../URLInput/URLInput';
+
 const CANONICAL_URL = 'p4_seo_canonical_url';
 
 const { __ } = wp.i18n;
@@ -8,14 +9,15 @@ const { __ } = wp.i18n;
  export const SearchEngineOptimizationsSidebar = {
   getId: () => 'planet4-seo-sidebar',
   render: () => {
-    const { getParams } = getSidebarFunctions();
+    const meta = useSelect(select => select('core/editor').getEditedPostAttribute('meta'),[]);
+    const { editPost } = useDispatch('core/editor', [meta[CANONICAL_URL]]);
 
     return (
       <PluginDocumentSettingPanel
         name='planet4-search-engine-optimizations'
         title={ __( 'Search Engine Optimizations', 'planet4-blocks-backend' ) }
       >
-        <TextSidebarField label={__( 'Canonical link', 'planet4-blocks-backend' )} type="url" {...getParams(CANONICAL_URL)} />
+        <URLInput label={__( 'Canonical link', 'planet4-blocks-backend' )} value={meta[CANONICAL_URL]}  onChange={value => editPost({ meta: {[CANONICAL_URL]: value} })} />
       </PluginDocumentSettingPanel>
     );
   }

--- a/assets/src/components/SidebarFields/TextSidebarField.js
+++ b/assets/src/components/SidebarFields/TextSidebarField.js
@@ -1,9 +1,10 @@
 import { TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export const TextSidebarField = ({ value, setValue, label }) => (
+export const TextSidebarField = ({ value, setValue, label, type }) => (
   <TextControl
     label={label}
+    type={type}
     value={value}
     onChange={setValue}
   />

--- a/assets/src/components/SidebarFields/TextSidebarField.js
+++ b/assets/src/components/SidebarFields/TextSidebarField.js
@@ -1,10 +1,9 @@
 import { TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export const TextSidebarField = ({ value, setValue, label, type }) => (
+export const TextSidebarField = ({ value, setValue, label }) => (
   <TextControl
     label={label}
-    type={type}
     value={value}
     onChange={setValue}
   />

--- a/assets/src/setupCustomSidebar.js
+++ b/assets/src/setupCustomSidebar.js
@@ -3,6 +3,7 @@ import { PageHeaderSidebar } from './components/Sidebar/PageHeaderSidebar';
 import { CampaignThemeSidebar } from './components/Sidebar/CampaignThemeSidebar';
 import { ActionSidebar } from './components/Sidebar/ActionSidebar';
 import { OpenGraphSidebar } from './components/Sidebar/OpenGraphSidebar';
+import { SearchEngineOptimizationsSidebar } from './components/Sidebar/SearchEngineOptimizationsSidebar';
 
 const sidebarsForPostType = postType => {
   switch (postType) {
@@ -15,20 +16,24 @@ const sidebarsForPostType = postType => {
         render: CampaignThemeSidebar,
       },
       OpenGraphSidebar,
+      SearchEngineOptimizationsSidebar,
     ];
   case 'p4_action':
     return [
       ActionSidebar,
       OpenGraphSidebar,
+      SearchEngineOptimizationsSidebar,
     ];
   case 'page':
     return [
       PageHeaderSidebar,
       OpenGraphSidebar,
+      SearchEngineOptimizationsSidebar,
     ];
   case 'post':
     return [
       OpenGraphSidebar,
+      SearchEngineOptimizationsSidebar,
     ];
   default:
     return null;


### PR DESCRIPTION
Description

See [PLANET-6960](https://jira.greenpeace.org/browse/PLANET-6960)

Associated [PR](https://github.com/greenpeace/planet4-master-theme/pull/1866)

Testing
On your local or [Umbriel Test Instance](https://www-dev.greenpeace.org/test-umbriel/), you can add the Canonical link from the sidebar (Search Engine Optimizations section), to any post type and update the page. On reload in the editor you should still see the data that you entered, and when inspecting the page in the frontend you should see the correct link tag added to the head.

<img width="1512" alt="Screenshot 2022-12-14 at 03 36 45" src="https://user-images.githubusercontent.com/38656549/207549876-6e83db9f-48ef-4ba3-acf0-a37b73fc15b5.png">

<img width="1512" alt="Screenshot 2022-12-14 at 03 41 30" src="https://user-images.githubusercontent.com/38656549/207550099-722dbfb8-ddfd-47bd-9e2b-489750b2cf12.png">



<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
