### PR TITLE
PLANET-6941: Convert Highlighted CTA Pattern into a Block Template

### DIFF
--- a/assets/src/block-templates/highlighted-cta/block.json
+++ b/assets/src/block-templates/highlighted-cta/block.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-block-templates/highlighted-cta",
+  "title": "Highlighted CTA",
+  "category": "planet4-block-templates",
+  "textdomain": "planet4-blocks-backend",
+  "attributes": {
+    "titlePlaceholder": { "type": "string" }
+  }
+}

--- a/assets/src/block-templates/highlighted-cta/index.js
+++ b/assets/src/block-templates/highlighted-cta/index.js
@@ -1,0 +1,4 @@
+import metadata from './block.json';
+import template from './template';
+
+export { metadata, template };

--- a/assets/src/block-templates/highlighted-cta/template.js
+++ b/assets/src/block-templates/highlighted-cta/template.js
@@ -1,0 +1,35 @@
+import mainThemeUrl from '../main-theme-url';
+
+const template = ({
+  titlePlaceholder = 'Enter text'
+}) => [
+  [
+    'core/columns',
+    {
+      className: `block`,
+      textColor: 'white',
+      backgroundColor: 'dark-blue',
+    },
+    [
+      ['core/column', {}, [
+        ['core/image', {
+          align: 'center',
+          className: 'force-no-lightbox force-no-caption',
+          url: `${mainThemeUrl}/images/placeholders/placeholder-80x80.jpg`,
+        }],
+        ['core/heading', {
+          textAlign: 'center',
+          level: 3,
+          placeholder: titlePlaceholder
+        }],
+        ['core/spacer', {height: '16px'}],
+        ['core/buttons', {layout: {type: 'flex', justifyContent: 'center'}}, [
+          ['core/button', {className: 'is-style-transparent'}]
+        ]],
+        ['core/spacer', {height: '16px'}],
+      ]]
+    ]
+  ]
+];
+
+export default template;

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -4,6 +4,7 @@ import * as deepDive from './deep-dive';
 import * as realityCheck from './reality-check';
 import * as issues from './issues';
 import * as pageHeader from './page-header';
+import * as highlightedCta from './highlighted-cta';
 
 export default [
   sideImgTextCta,
@@ -12,4 +13,5 @@ export default [
   realityCheck,
   issues,
   pageHeader,
+  highlightedCta,
 ];

--- a/assets/src/blocks/Covers/TakeActionCovers.js
+++ b/assets/src/blocks/Covers/TakeActionCovers.js
@@ -54,9 +54,9 @@ export const TakeActionCovers = ({
               <CoversImagePlaceholder height={220} /> :
               <img
                 loading='lazy'
-                alt={alt_text}
-                src={image}
-                srcSet={srcset}
+                alt={alt_text || undefined}
+                src={image || undefined}
+                srcSet={srcset || undefined}
                 sizes={IMAGE_SIZES.takeAction}
               />
             }

--- a/classes/patterns/class-highleveltopic.php
+++ b/classes/patterns/class-highleveltopic.php
@@ -67,7 +67,7 @@ class HighLevelTopic extends Block_Pattern {
 								'mediaPosition'   => 'right',
 							]
 						)['content'] . '
-						' . HighlightedCta::get_config( [ 'title_placeholder' => __( 'Featured action title', 'planet4-blocks' ) ] )['content'] . '
+						' . HighlightedCta::get_config( [ 'titlePlaceholder' => __( 'Featured action title', 'planet4-blocks' ) ] )['content'] . '
 						' . Covers::get_content(
 							[
 								'cover_type'        => 'take-action',

--- a/classes/patterns/class-highlightedcta.php
+++ b/classes/patterns/class-highlightedcta.php
@@ -28,42 +28,11 @@ class HighlightedCta extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
-		$classname         = self::get_classname();
-		$title_placeholder = $params['title_placeholder'] ?? '';
-
 		return [
 			'title'      => 'Highlighted CTA',
 			'categories' => [ 'planet4' ],
 			'content'    => '
-				<!-- wp:columns {"className":"block ' . $classname . '","textColor":"white","backgroundColor":"dark-blue"} -->
-					<div class="wp-block-columns block ' . $classname . ' has-dark-blue-background-color has-text-color has-background has-white-color">
-						<!-- wp:column -->
-							<div class="wp-block-column">
-								<!-- wp:image {"align":"center","className":"force-no-lightbox force-no-caption"} -->
-									<div class="wp-block-image force-no-lightbox force-no-caption">
-										<figure class="aligncenter">
-											<img src="' . esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-80x80.jpg" alt="' . __( 'Default image', 'planet4-blocks-backend' ) . '"/>
-										</figure>
-									</div>
-								<!-- /wp:image -->
-								<!-- wp:heading {"placeholder":"' . __( 'Enter text', 'planet4-blocks-backend' ) . '","align":"center","className":"has-text-align-center","level":3} -->
-									<h3 class="has-text-align-center">' . $title_placeholder . '</h3>
-								<!-- /wp:heading -->
-								<!-- wp:spacer {"height":"16px"} -->
-									<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
-								<!-- /wp:spacer -->
-								<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-									<div class="wp-block-buttons">
-										<!-- wp:button {"className":"is-style-transparent"} /-->
-									</div>
-								<!-- /wp:buttons -->
-								<!-- wp:spacer {"height":"16px"} -->
-									<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
-								<!-- /wp:spacer -->
-							</div>
-						<!-- /wp:column -->
-					</div>
-				<!-- /wp:columns -->
+				<!-- wp:planet4-block-templates/highlighted-cta ' . wp_json_encode( $params, \JSON_FORCE_OBJECT ) . ' /-->
 			',
 		];
 	}

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -204,12 +204,13 @@ const BETA_ACTION_BLOCK_TYPES = [
 ];
 
 const BLOCK_TEMPLATES = [
-	'planet4-block-templates/side-image-with-text-and-cta',
-	'planet4-block-templates/quick-links',
 	'planet4-block-templates/deep-dive',
+	'planet4-block-templates/highlighted-cta',
+	'planet4-block-templates/quick-links',
 	'planet4-block-templates/reality-check',
 	'planet4-block-templates/issues',
 	'planet4-block-templates/page-header',
+	'planet4-block-templates/side-image-with-text-and-cta',
 ];
 
 /**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6941

> Following [ADR-0019](https://docs.google.com/document/d/18pN7U4_v5BRjxeemGyQUGXvxZy-bjCr1XpIKKv5IQb0), this is about converting the Highlighted CTA pattern.
> Requirements
>    - Convert pattern to Block Template
>    - Update other patterns that may include this one
>    - Show pattern only on the Patterns selection list

## Additional fix

Tiny fix on _Take Action Covers_, variables set to `false` are throwing errors in the console when the Layout selector is loading.

## Test

- Create a new page
- Look for the _Highlighted CTA_ block in the block inserter
  - the block template should appear
- Insert a _Highlighted CTA_ block
  - it should work and look the same as the previous pattern
  - the source code in the Code Editor shows the tag `<!-- wp:planet4-block-templates/highlighted-cta`
- Insert a _High-level Topic_ layout
  - it includes the _Highlighted CTA_ block template, and should still be available and working