### PR TITLE
PLANET-7025 Fix Covers block 'Load more' button translation issue

### DIFF
--- a/assets/src/blocks/Covers/CoversEditor.js
+++ b/assets/src/blocks/Covers/CoversEditor.js
@@ -2,6 +2,8 @@ import {
   SelectControl,
   PanelBody,
   RadioControl,
+  TextControl,
+  Tooltip
 } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 
@@ -13,7 +15,6 @@ import { Covers } from './Covers';
 import { COVERS_TYPES, COVERS_LAYOUTS, CAROUSEL_LAYOUT_COVERS_LIMIT } from './CoversConstants';
 import { useCovers } from './useCovers';
 import { getStyleFromClassName } from '../getStyleFromClassName';
-import { CoversGridLoadMoreButton } from './CoversGridLoadMoreButton';
 import { CoversCarouselLayout } from './CoversCarouselLayout';
 
 const { RichText } = wp.blockEditor;
@@ -91,6 +92,15 @@ const renderEdit = (attributes, toAttribute, setAttributes) => {
             />
           </div>
         }
+        {layout !== COVERS_LAYOUTS.carousel &&
+          <TextControl
+            label={__('Button Text', 'planet4-blocks-backend')}
+            placeholder={__('Override button text', 'planet4-blocks-backend')}
+            help={__('Your default is set to [ Load more ]', 'planet4-blocks-backend')}
+            value={readMoreText}
+            onChange={toAttribute('readMoreText')}
+          />
+        }
       </PanelBody>
     </InspectorControls>
   );
@@ -160,7 +170,22 @@ const renderView = (attributes, toAttribute) => {
         </div> :
         <>
           {isCarouselLayout && !isSmallWindow ? <CoversCarouselLayout {...coversProps} /> : <Covers {...coversProps} />}
-          {showLoadMoreButton && <CoversGridLoadMoreButton showMoreCovers={() => {}} readMoreText={readMoreText} />}
+          {showLoadMoreButton && (
+            <Tooltip text={__('Edit text', 'planet4-blocks-backend')}>
+              <button className="btn btn-block btn-secondary load-more-btn">
+                <RichText
+                  tagName="div"
+                  placeholder={__('Enter text', 'planet4-blocks-backend')}
+                  value={readMoreText}
+                  onChange={toAttribute('readMoreText')}
+                  withoutInteractiveFormatting
+                  multiline="false"
+                  allowedFormats={[]}
+                />
+              </button>
+              </Tooltip>
+            )
+          }
         </>
       }
     </section>


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-7025

The Covers block Grid view have a option to load more covers on click of "Load more" button.  The "Load more" string is saved in `readMoreText` block attribute as a plain text, also we don't have a backend option to update the 'readMoreText' value after covers block added on page. 

The covers block snippet -
```
<!-- wp:planet4-blocks/covers {"title":"new Cover block","description":"Content covers block","tags":[19,18,8],"className":"is-style-content"} -->
<div class="wp-block-planet4-blocks-covers is-style-content" data-render="planet4-blocks/covers" data-attributes="{&quot;attributes&quot;:{&quot;cover_type&quot;:&quot;content&quot;,&quot;initialRowsLimit&quot;:1,&quot;title&quot;:&quot;new Cover block&quot;,&quot;description&quot;:&quot;Content covers block&quot;,&quot;tags&quot;:[19,18,8],&quot;post_types&quot;:[],&quot;posts&quot;:[],&quot;version&quot;:2,&quot;layout&quot;:&quot;grid&quot;,&quot;isExample&quot;:false,&quot;readMoreText&quot;:&quot;Load more&quot;,&quot;className&quot;:&quot;is-style-content&quot;},&quot;innerBlocks&quot;:[]}"></div>
<!-- /wp:planet4-blocks/covers -->
```

~~The simple fix is just pass the `readMoreText` value to `__()` function, which do the job, but I personally discourage the use of variable inside the `__()` function. The reason for not use it like this way is, when we scan the plugin code in Loco translate it won't understand the variable value and it ignore such translatable strings.~~

After check-in  with design team, the covers block 'Load more' button text made editable(wysiwyg) -

eg. https://www-dev.greenpeace.org/test-saturn/test-covers-block-load-more-btn/


