### PR TITLE
PLANET-6944 Convert Page Header Pattern into a Block Template

### DIFF
--- a/assets/src/block-templates/page-header/block.json
+++ b/assets/src/block-templates/page-header/block.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-block-templates/page-header",
+  "title": "Page Header",
+  "category": "planet4-block-templates",
+  "textdomain": "planet4-blocks-backend",
+  "attributes": {
+    "backgroundColor": { "type": "string" },
+    "imageFill": { "type": "boolean" },
+    "mediaPosition": { "type": "string" }
+  }
+}

--- a/assets/src/block-templates/page-header/index.js
+++ b/assets/src/block-templates/page-header/index.js
@@ -1,0 +1,4 @@
+import metadata from './block.json';
+import template from './template';
+
+export { metadata, template };

--- a/assets/src/block-templates/page-header/template.js
+++ b/assets/src/block-templates/page-header/template.js
@@ -1,0 +1,54 @@
+import mainThemeUrl from '../main-theme-url';
+
+const { __ } = wp.i18n;
+
+const template = ({
+  backgroundColor = 'grey-05',
+  mediaPosition = '',
+  imageFill = false,
+}) => ([
+  ['core/group',
+    {
+      align: 'full',
+      backgroundColor,
+      style: {
+        spacing: {
+          padding: {
+            top:'56px',
+            bottom:'56px',
+          }
+        },
+      }
+    },
+    [
+      ['core/group', {className: 'container'}, [
+        ['core/media-text', {
+          mediaType: 'image',
+          mediaPosition,
+          imageFill,
+          className: 'is-pattern-p4-page-header is-style-parallax',
+          mediaUrl: `${mainThemeUrl}/images/placeholders/placeholder-546x415.jpg`,
+          isStackedOnMobile: true,
+          align: 'full'
+        },[
+          ['core/group', {}, [
+            ['core/heading', {
+              level: 1,
+              backgroundColor,
+              placeholder: __('Enter title', 'planet4-blocks-backend')
+            }]
+          ]],
+          ['core/paragraph', {
+            placeholder: __('Enter description', 'planet4-blocks-backend'),
+            style: { typography: { fontSize: '1.25rem'} }
+          }],
+          ['core/buttons', {}, [
+            ['core/button', { className: 'is-style-cta' }]
+          ]],
+        ]],
+      ]]
+    ]
+  ]
+]);
+
+export default template;

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -3,6 +3,7 @@ import * as quickLinks from './quick-links';
 import * as deepDive from './deep-dive';
 import * as realityCheck from './reality-check';
 import * as issues from './issues';
+import * as pageHeader from './page-header';
 
 export default [
   sideImgTextCta,
@@ -10,4 +11,5 @@ export default [
   deepDive,
   realityCheck,
   issues,
+  pageHeader,
 ];

--- a/classes/patterns/class-pageheader.php
+++ b/classes/patterns/class-pageheader.php
@@ -38,53 +38,15 @@ class PageHeader extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
-		$classname         = 'is-pattern-p4-page-header';
-		$media_link        = esc_url( get_template_directory_uri() ) . '/images/placeholders/placeholder-546x415.jpg';
-		$pos_class         = 'left' === static::$media_position ? ''
-			: 'has-media-on-the-' . static::$media_position;
-		$title_placeholder = $params['title_placeholder'] ?? '';
-		$background_color  = $params['background_color'] ?? 'grey-05';
+		if ( empty( $params['mediaPosition'] ) ) {
+			$params['mediaPosition'] = static::$media_position;
+		}
 
 		return [
 			'title'      => __( static::$title, 'planet4-blocks-backend' ), // phpcs:ignore
 			'categories' => [ 'page-headers' ],
 			'content'    => '
-				<!-- wp:group {"backgroundColor":"' . $background_color . '","align":"full","style":{"spacing":{"padding":{"top":"56px","bottom":"56px"}}}} -->
-					<div class="wp-block-group alignfull has-' . $background_color . '-background-color has-background" style="padding-top:56px;padding-bottom:56px;">
-						<!-- wp:group {"className":"container"} -->
-							<div class="wp-block-group container">
-								<!-- wp:media-text {"align":"full","mediaPosition":"' . static::$media_position . '","mediaType":"image","imageFill":false,"className":"' . $classname . ' is-style-parallax"} -->
-								<div class="wp-block-media-text alignfull ' . $pos_class . ' is-stacked-on-mobile ' . $classname . ' is-style-parallax">
-
-									<figure class="wp-block-media-text__media">
-										<img src="' . $media_link . '" alt=""/>
-									</figure>
-
-									<div class="wp-block-media-text__content">
-										<!-- wp:group -->
-										<div class="wp-block-group">
-											<!-- wp:heading {"level":1,"placeholder":"' . __( 'Enter title', 'planet4-blocks-backend' ) . '","backgroundColor":"' . $background_color . '"} -->
-											<h1 class="has-' . $background_color . '-background-color has-background">' . $title_placeholder . '</h1>
-											<!-- /wp:heading -->
-										</div>
-										<!-- /wp:group -->
-
-										<!-- wp:paragraph {"placeholder":"' . __( 'Enter description', 'planet4-blocks-backend' ) . '","style":{"typography":{"fontSize":"1.25rem"}}} -->
-										<p style="font-size:1.25rem"></p>
-										<!-- /wp:paragraph -->
-
-										<!-- wp:buttons -->
-										<div class="wp-block-buttons">
-											<!-- wp:button {"className":"is-style-cta"} /-->
-										</div>
-										<!-- /wp:buttons -->
-									</div>
-								</div>
-								<!-- /wp:media-text -->
-							</div>
-						<!-- /wp:group -->
-					</div>
-				<!-- /wp:group -->
+				<!-- wp:planet4-block-templates/page-header ' . wp_json_encode( $params, \JSON_FORCE_OBJECT ) . ' /-->
 			',
 		];
 	}

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -209,6 +209,7 @@ const BLOCK_TEMPLATES = [
 	'planet4-block-templates/deep-dive',
 	'planet4-block-templates/reality-check',
 	'planet4-block-templates/issues',
+	'planet4-block-templates/page-header',
 ];
 
 /**


### PR DESCRIPTION
### Ref: [PLANET-6944](https://jira.greenpeace.org/browse/PLANET-6944)

**Description**

- Converted the Page Header pattern to a block template.
- Used the same code to handle both left and right page headers, added a condition in the `PageHeader` class to handle side image position based on the `media_position` variable.

<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
