### PR TITLE
Change style to render line breaks in table cells

### DIFF
--- a/assets/src/styles/blocks/Spreadsheet/SpreadsheetStyle.scss
+++ b/assets/src/styles/blocks/Spreadsheet/SpreadsheetStyle.scss
@@ -91,6 +91,8 @@ table.spreadsheet-table {
       padding: 5px 20px;
       font-size: $font-size-xs;
 
+      white-space: pre-wrap;
+
       @include x-large-and-up {
         font-size: $font-size-xs;
       }


### PR DESCRIPTION
Fixes greenpeace/planet4#183

Added style `white-space: pre-wrap;` to table cells. That way, line breaks from the source sheet will be rendered in the frontend.

Here's a Google sheet for testing:

- Edit URL: https://docs.google.com/spreadsheets/d/1-IcRk5UXDqg9Mxi-A8hzkJqJNbx-V1O5_IGtfSNa-Mw/edit?usp=sharing
- Published URL (use this one in the block): https://docs.google.com/spreadsheets/d/e/2PACX-1vRtQznqXzrUZzrE1KvzI9lQ1O4sTZhNHNdIg87b_BsyQ2qzqHfQcn8mJ7Jd29maqNk9Zsp24dohCFZi/pubhtml?gid=0&single=true


