### PR TITLE
Create new square css class

### DIFF
--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -50,6 +50,10 @@
     &-40 {
       @include square-image-size(40px);
     }
+
+    &-80 {
+      @include square-image-size(80px);
+    }
   }
 
   @include large-and-up {


### PR DESCRIPTION
## Description

As a request of the [Design Team on Slack](https://greenpeace-gpi.slack.com/archives/G015K63081W/p1675260135442279?thread_ts=1675258419.842729&cid=G015K63081W)

We are going to still using `square-40` until we'll find a better solution for these kind of classes.