### PR TITLE
PLANET-7055 Setup Playwright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ assets/build/*
 
 # Playwright
 /e2e-results/
-/playwright-report/
+/e2e-report/
 /playwright/.cache/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ node_modules/
 
 # Built css and js assets
 assets/build/*
+
+# Playwright
+/e2e-results/
+/playwright-report/
+/playwright/.cache/

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -454,6 +454,9 @@ final class Loader {
 			'enable_analytical_cookies'  => $option_values['enable_analytical_cookies'] ?? '',
 			'enable_google_consent_mode' => $option_values['enable_google_consent_mode'] ?? '',
 			'cookies_default_copy'       => self::get_cookies_default_copy(),
+			'cookies_field'              => $option_values['cookies_field'],
+			'page_text_404'              => $option_values['404_page_text'],
+			'page_bg_image_404'          => $option_values['404_page_bg_image'],
 		];
 		wp_localize_script( 'planet4-blocks-script', 'p4bk_vars', $reflection_vars );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2269,6 +2269,24 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
+    "@playwright/test": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.30.0.tgz",
+      "integrity": "sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "playwright-core": "1.30.0"
+      },
+      "dependencies": {
+        "playwright-core": {
+          "version": "1.30.0",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.30.0.tgz",
+          "integrity": "sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==",
+          "dev": true
+        }
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/plugin-proposal-optional-chaining": "*",
     "@commitlint/cli": "^12.1.4",
     "@greenpeace/dashdash": "^1.1.2",
+    "@playwright/test": "^1.30.0",
     "@wordpress/components": "^8.3.2",
     "@wordpress/data": "^4.9.2",
     "@wordpress/e2e-test-utils": "^4.5.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -23,7 +23,7 @@ const config = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [['html', { outputFolder: 'e2e-report' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,100 @@
+const { devices } = require('@playwright/test');
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+const config = {
+  testDir: './tests/e2e',
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://www.planet4.test',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+      },
+    },
+
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari'],
+      },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: {
+    //     ...devices['Pixel 5'],
+    //   },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: {
+    //     ...devices['iPhone 12'],
+    //   },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: {
+    //     channel: 'msedge',
+    //   },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: {
+    //     channel: 'chrome',
+    //   },
+    // },
+  ],
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  outputDir: 'e2e-results/',
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   port: 3000,
+  // },
+};
+
+module.exports = config;

--- a/tests/e2e/404.spec.js
+++ b/tests/e2e/404.spec.js
@@ -1,0 +1,9 @@
+const { test, expect } = require('@playwright/test');
+
+test('check the 404 page', async ({ page }) => {
+  const response = await page.goto('/thispagereallywillnotexist');
+
+  expect(response.status()).toEqual(404);
+
+  await expect(page.locator('input[aria-label="Search"]')).toBeVisible();
+});


### PR DESCRIPTION
### Description

See [PLANET-7055](https://jira.greenpeace.org/browse/PLANET-7055)

**Related PR:** https://github.com/greenpeace/planet4-master-theme/pull/1908

### Testing

On local, run `npm install` to install Playwright and its needed dependencies, and then to run the tests you can use the following commands:

- `npx playwright test` for all tests
- `npx playwright test tests/e2e/404.spec.js` for individual tests (added this very simple one for now just to test the setup)