### PR TITLE
PLANET-7033: Allow list item in block list

### DIFF
--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -232,6 +232,7 @@ function set_allowed_block_types( $allowed_block_types, $context ) {
 		'core/heading',
 		'core/image',
 		'core/list',
+		'core/list-item',
 		'core/quote',
 		'core/file',
 		'core/html',


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7033

> When adding multiple items in either unordered or numeric lists in a page/article, simple hitting Enter does not add a new row with a new item.

It is not possible to add a new list item without allowing the core/list-item block.
Issue introduced by WordPress 6.1, cf. https://github.com/WordPress/gutenberg/issues/47185#issuecomment-1384637446

## Test
- Add a new page
- Add a List block
  - add text to the first item, and use `enter` to add a new item
  - a new list item line should appear