### PR TITLE
Use CSS variables wherever possible for links and colors

### DIFF
--- a/assets/src/styles/blocks/Accordion/AccordionEditorStyle.scss
+++ b/assets/src/styles/blocks/Accordion/AccordionEditorStyle.scss
@@ -1,5 +1,5 @@
-@import "../../master-theme/assets/src/scss/base/variables";
 @import "../../master-theme/assets/src/scss/base/colors";
+@import "../../master-theme/assets/src/scss/base/variables";
 @import "../../master-theme/assets/src/scss/base/mixins";
 @import "../../master-theme/assets/src/scss/base/fonts";
 

--- a/assets/src/styles/blocks/Accordion/AccordionStyle.scss
+++ b/assets/src/styles/blocks/Accordion/AccordionStyle.scss
@@ -1,5 +1,5 @@
-@import "../../master-theme/assets/src/scss/base/variables";
 @import "../../master-theme/assets/src/scss/base/colors";
+@import "../../master-theme/assets/src/scss/base/variables";
 @import "../../master-theme/assets/src/scss/base/mixins";
 @import "../../master-theme/assets/src/scss/base/fonts";
 

--- a/assets/src/styles/blocks/Accordion/AccordionStyle.scss
+++ b/assets/src/styles/blocks/Accordion/AccordionStyle.scss
@@ -78,7 +78,6 @@
     .panel {
       padding: 0 16px 24px 16px;
       background-color: white;
-      color: $grey-80;
       overflow: hidden;
       transition: display 1s, opacity 1s, height 1s ease-in-out;
 

--- a/assets/src/styles/blocks/Articles.scss
+++ b/assets/src/styles/blocks/Articles.scss
@@ -74,7 +74,7 @@
 .article-list-item-headline {
   --block-articles--article--headline-- {
     font-weight: 500;
-    color: $grey-80;
+    color: var(--body--color);
   }
 
   @include mobile-only {

--- a/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
+++ b/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
@@ -408,7 +408,7 @@ $medium-image-height: 600px;
 
     h2 {
       width: 100%;
-      color: $grey-80;
+      color: var(--body--color);
       transition: unset;
       transform: translateX($text-slide-offset);
       font-size: 1.62rem;
@@ -447,7 +447,7 @@ $medium-image-height: 600px;
 
     p {
       display: block;
-      color: $grey-80;
+      color: var(--body--color);
       font-family: var(--headings--font-family);
       font-size: .875rem;
       font-weight: 500;

--- a/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
+++ b/assets/src/styles/blocks/CarouselHeader/CarouselHeaderStyle.scss
@@ -1,6 +1,6 @@
 @import "../../master-theme/assets/src/scss/base/mixins";
-@import "../../master-theme/assets/src/scss/base/variables";
 @import "../../master-theme/assets/src/scss/base/colors";
+@import "../../master-theme/assets/src/scss/base/variables";
 @import "../../master-theme/assets/src/scss/base/fonts";
 
 // $slide-transition-speed should match SLIDE_TRANSITION_SPEED in carousel-header.js

--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -16,7 +16,7 @@
       font-size: $font-size-lg;
       font-family: var(--headings--font-family);
       font-weight: 700;
-      color: $grey-80;
+      color: var(--body--color);
       margin-bottom: .5rem;
       text-transform: none;
 
@@ -215,7 +215,7 @@
 
       .step-info {
         h5 > a _-- {
-          color: $grey-80;
+          color: var(--body--color);
         }
 
         p {
@@ -309,7 +309,7 @@
           border-bottom: none;
 
           p {
-            color: $grey-80;
+            color: var(--body--color);
             font-size: $font-size-xxs;
             line-height: 22px;
             margin-left: 0;

--- a/assets/src/styles/blocks/Cookies.scss
+++ b/assets/src/styles/blocks/Cookies.scss
@@ -10,7 +10,7 @@
   }
 
   .always-enabled {
-    background: $grey-80;
+    background: var(--body--color);
     color: white;
     font-weight: 700;
     border-radius: 4px;

--- a/assets/src/styles/blocks/CookiesEditor.scss
+++ b/assets/src/styles/blocks/CookiesEditor.scss
@@ -5,7 +5,7 @@
 
   .field-reset-button {
     display: inline-block;
-    color: $link-color;
+    color: var(--link--color);
     margin-inline-start: 16px;
     font-family: var(--headings--font-family);
     font-size: 14px;
@@ -27,7 +27,7 @@
       height: 18px;
       display: inline-block;
       text-align: center;
-      border: solid 1px $link-color;
+      border: solid 1px var(--link--color);
     }
   }
 }

--- a/assets/src/styles/blocks/Covers/CoversStyle.scss
+++ b/assets/src/styles/blocks/Covers/CoversStyle.scss
@@ -1,5 +1,5 @@
-@import "../../master-theme/assets/src/scss/base/variables";
 @import "../../master-theme/assets/src/scss/base/colors";
+@import "../../master-theme/assets/src/scss/base/variables";
 @import "../../master-theme/assets/src/scss/base/mixins";
 @import "../../master-theme/assets/src/scss/base/fonts";
 

--- a/assets/src/styles/blocks/Covers/styles/ContentCovers.scss
+++ b/assets/src/styles/blocks/Covers/styles/ContentCovers.scss
@@ -46,10 +46,6 @@
         /*! autoprefixer: on */
         /* stylelint-enable property-no-vendor-prefix */
         overflow: hidden;
-
-        > a {
-          color: $grey-80;
-        }
       }
 
       .post-excerpt {

--- a/assets/src/styles/blocks/ENForm/ENFormStyle.scss
+++ b/assets/src/styles/blocks/ENForm/ENFormStyle.scss
@@ -1,5 +1,5 @@
-@import "../../master-theme/assets/src/scss/base/variables";
 @import "../../master-theme/assets/src/scss/base/colors";
+@import "../../master-theme/assets/src/scss/base/variables";
 @import "../../master-theme/assets/src/scss/base/mixins";
 @import "../../master-theme/assets/src/scss/base/fonts";
 

--- a/assets/src/styles/blocks/ENForm/components/_enform-side-style.scss
+++ b/assets/src/styles/blocks/ENForm/components/_enform-side-style.scss
@@ -111,7 +111,6 @@
   }
 
   .title-and-description {
-    color: $grey-80;
     padding: $sp-2;
 
     @include large-and-up {

--- a/assets/src/styles/blocks/Gallery/styles/GalleryCarousel.scss
+++ b/assets/src/styles/blocks/Gallery/styles/GalleryCarousel.scss
@@ -3,7 +3,6 @@
 
   h1 {
     font-size: $font-size-lg;
-    color: $grey-80;
     margin-bottom: 22px;
     margin-left: 0;
 

--- a/assets/src/styles/blocks/Happypoint.scss
+++ b/assets/src/styles/blocks/Happypoint.scss
@@ -84,7 +84,6 @@
       font-size: $font-size-xl;
       line-height: 34px;
       margin-bottom: 20px;
-      color: $grey-80;
     }
 
     @include large-and-up {

--- a/assets/src/styles/blocks/OldENForm/components/_enform-side-style.scss
+++ b/assets/src/styles/blocks/OldENForm/components/_enform-side-style.scss
@@ -107,7 +107,6 @@
   }
 
   .title-and-description {
-    color: $grey-80;
     padding: $sp-2;
 
     @include large-and-up {

--- a/assets/src/styles/blocks/SocialMedia/SocialMediaStyle.scss
+++ b/assets/src/styles/blocks/SocialMedia/SocialMediaStyle.scss
@@ -1,3 +1,4 @@
+@import "../../master-theme/assets/src/scss/base/colors";
 @import "../../master-theme/assets/src/scss/base/variables";
 @import "../../master-theme/assets/src/scss/base/mixins";
 

--- a/assets/src/styles/blocks/SplitTwoColumns.scss
+++ b/assets/src/styles/blocks/SplitTwoColumns.scss
@@ -159,7 +159,7 @@
   }
 
   &:visited {
-    color: var(--link--color, $link-color);
+    color: var(--link--color);
   }
 
   &:after {

--- a/assets/src/styles/blocks/Spreadsheet/SpreadsheetStyle.scss
+++ b/assets/src/styles/blocks/Spreadsheet/SpreadsheetStyle.scss
@@ -1,5 +1,5 @@
-@import "../../master-theme/assets/src/scss/base/variables";
 @import "../../master-theme/assets/src/scss/base/colors";
+@import "../../master-theme/assets/src/scss/base/variables";
 @import "../../master-theme/assets/src/scss/base/mixins";
 @import "../../master-theme/assets/src/scss/base/fonts";
 

--- a/assets/src/styles/blocks/Submenu.scss
+++ b/assets/src/styles/blocks/Submenu.scss
@@ -27,7 +27,7 @@ div[data-render="planet4-blocks/submenu"] {
     }
 
     a {
-      color: $grey-80;
+      color: var(--body--color);
       font-family: var(--headings--font-family);
     }
 

--- a/assets/src/styles/blocks/TakeActionBoxout/style.scss
+++ b/assets/src/styles/blocks/TakeActionBoxout/style.scss
@@ -53,7 +53,7 @@
 
   .boxout-heading {
     font-family: var(--headings--font-family);
-    color: $grey-80;
+    color: inherit;
     font-size: 16px;
     font-weight: 700;
     line-height: 1.25;

--- a/assets/src/styles/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/styles/blocks/Timeline/TimelineStyle.scss
@@ -1,5 +1,5 @@
-@import "../../master-theme/assets/src/scss/base/variables";
 @import "../../master-theme/assets/src/scss/base/colors";
+@import "../../master-theme/assets/src/scss/base/variables";
 @import "../../master-theme/assets/src/scss/base/mixins";
 
 .timeline-block {

--- a/assets/src/styles/editorStyle.scss
+++ b/assets/src/styles/editorStyle.scss
@@ -1,3 +1,4 @@
+@import "master-theme/assets/src/scss/base/colors";
 @import "master-theme/assets/src/scss/base/variables";
 @import "master-theme/assets/src/scss/base/colors";
 @import "master-theme/assets/src/scss/base/functions";

--- a/assets/src/styles/style.scss
+++ b/assets/src/styles/style.scss
@@ -1,6 +1,6 @@
 // Global
-@import "master-theme/assets/src/scss/base/variables";
 @import "master-theme/assets/src/scss/base/colors";
+@import "master-theme/assets/src/scss/base/variables";
 @import "master-theme/assets/src/scss/base/functions";
 @import "master-theme/assets/src/scss/base/mixins";
 @import "master-theme/assets/src/scss/base/fonts";


### PR DESCRIPTION
### Description

This makes our code easier to customise, in preparation of [PLANET-6984](https://jira.greenpeace.org/browse/PLANET-6984) and other tickets related to the new identity. In some cases I was able to completely remove the usage of `$grey-80` since it was applied from somewhere else anyway.

**Related PR:** https://github.com/greenpeace/planet4-master-theme/pull/1920

### Testing

Everything should still look the same.