### PR TITLE
PLANET-7079: Convert Deep Dive Topic pattern layout into a Block Template

### DIFF
--- a/assets/src/block-templates/deep-dive-topic/block.json
+++ b/assets/src/block-templates/deep-dive-topic/block.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-block-templates/deep-dive-topic",
+  "title": "Deep Dive Topic",
+  "category": "planet4-block-templates",
+  "icon": "editor-table",
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/block-templates/deep-dive-topic/index.js
+++ b/assets/src/block-templates/deep-dive-topic/index.js
@@ -1,0 +1,4 @@
+import metadata from './block.json';
+import template from './template';
+
+export {metadata, template};

--- a/assets/src/block-templates/deep-dive-topic/template.js
+++ b/assets/src/block-templates/deep-dive-topic/template.js
@@ -1,0 +1,35 @@
+const {__} = wp.i18n;
+
+const template = () => ([
+  ['core/group', {}, [
+    ['planet4-block-templates/page-header', {
+      titlePlaceholder: __('Page header title', 'planet4-blocks'),
+      mediaPosition: 'right',
+    }],
+    ['core/spacer', {height: '64px'}],
+    ['planet4-block-templates/side-image-with-text-and-cta', {
+      title: __('The problem', 'planet4-blocks'),
+    }],
+    ['planet4-block-templates/side-image-with-text-and-cta', {
+      title: __('What can be done', 'planet4-blocks'),
+      mediaPosition: 'right',
+    }],
+    ['planet4-blocks/covers', {
+      title: __('How you can help', 'planet4-blocks'),
+      cover_type: 'take-action',
+      className: 'is-style-take-action',
+    }],
+    ['planet4-blocks/articles', {
+      article_heading: __('Latest news & stories', 'planet4-blocks'),
+    }],
+    ['planet4-block-templates/deep-dive', {
+      title: __('Keep learning about', 'planet4-blocks'),
+    }],
+    ['planet4-block-templates/quick-links', {
+      title: __('Explore other topics', 'planet4-blocks'),
+      backgroundColor: 'white',
+    }],
+  ]],
+]);
+
+export default template;

--- a/assets/src/block-templates/page-header/block.json
+++ b/assets/src/block-templates/page-header/block.json
@@ -6,6 +6,7 @@
   "category": "planet4-block-templates",
   "textdomain": "planet4-blocks-backend",
   "attributes": {
+    "titlePlaceholder": { "type": "string" },
     "backgroundColor": { "type": "string" },
     "imageFill": { "type": "boolean" },
     "mediaPosition": { "type": "string" }

--- a/assets/src/block-templates/page-header/template.js
+++ b/assets/src/block-templates/page-header/template.js
@@ -3,6 +3,8 @@ import mainThemeUrl from '../main-theme-url';
 const {__} = wp.i18n;
 
 const template = ({
+  titlePlaceholder = __('Enter title', 'planet4-blocks-backend'),
+  backgroundColor = 'grey-05',
   mediaPosition = '',
   imageFill = false,
 }) => ([
@@ -32,8 +34,8 @@ const template = ({
           ['core/group', {}, [
             ['core/heading', {
               level: 1,
-              backgroundColor: 'white',
-              placeholder: __('Enter title', 'planet4-blocks-backend'),
+              backgroundColor,
+              placeholder: titlePlaceholder,
             }],
           ]],
           ['core/paragraph', {

--- a/assets/src/block-templates/reality-check/template.js
+++ b/assets/src/block-templates/reality-check/template.js
@@ -26,7 +26,7 @@ const template = () => ([
   ['core/columns', {
     className: 'block',
   },
-    [...Array(3).keys()].map(() => column),
+  [...Array(3).keys()].map(() => column),
   ],
 ]);
 

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -5,6 +5,7 @@ import * as realityCheck from './reality-check';
 import * as issues from './issues';
 import * as pageHeader from './page-header';
 import * as highlightedCta from './highlighted-cta';
+import * as deepDiveTopic from './deep-dive-topic';
 
 export default [
   sideImgTextCta,
@@ -14,4 +15,5 @@ export default [
   issues,
   pageHeader,
   highlightedCta,
+  deepDiveTopic,
 ];

--- a/classes/patterns/class-deepdivetopic.php
+++ b/classes/patterns/class-deepdivetopic.php
@@ -36,38 +36,9 @@ class DeepDiveTopic extends Block_Pattern {
 			'categories' => [ 'layouts' ],
 			'blockTypes' => [ 'core/post-content' ],
 			'content'    => '
-				<!-- wp:group {"className":"block ' . $classname . '"} -->
-					<div class="wp-block-group ' . $classname . '">
-					' . PageHeader::get_config(
-						[ 'title_placeholder' => __( 'Page header title', 'planet4-blocks' ) ]
-					)['content'] . '
-					<!-- wp:spacer {"height":"64px"} -->
-						<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
-					<!-- /wp:spacer -->
-					' . SideImageWithTextAndCta::get_config(
-						[ 'title' => __( 'The problem', 'planet4-blocks' ) ]
-					)['content'] . '
-					' . SideImageWithTextAndCta::get_config(
-						[
-							'title'         => __( 'What can be done', 'planet4-blocks' ),
-							'mediaPosition' => 'right',
-						]
-					)['content'] . '
-					' . Covers::get_content(
-						[
-							'title_placeholder' => __( 'How you can help', 'planet4-blocks' ),
-						]
-					) . '
-					<!-- wp:planet4-blocks/articles {"article_heading":"' . __( 'Latest news & stories', 'planet4-blocks' ) . '"} /-->
-					' . DeepDive::get_config( [ 'title' => __( 'Keep learning about', 'planet4-blocks' ) ] )['content'] . '
-					' . QuickLinks::get_config(
-						[
-							'title'           => __( 'Explore other topics', 'planet4-blocks' ),
-							'backgroundColor' => 'white',
-						]
-					)['content'] . '
-					</div>
-				<!-- /wp:group -->
+				<!-- wp:planet4-block-templates/deep-dive-topic '
+					. wp_json_encode( $params, \JSON_FORCE_OBJECT )
+					. ' /-->
 			',
 		];
 	}

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -210,6 +210,8 @@ const BLOCK_TEMPLATES = [
 	'planet4-block-templates/issues',
 	'planet4-block-templates/page-header',
 	'planet4-block-templates/side-image-with-text-and-cta',
+	// layouts.
+	'planet4-block-templates/deep-dive-topic',
 ];
 
 /**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7079

Demo of the _Deep Dive Topic_ layout done as a Block template.
Same pros as other templates:
- easy to identify in editor and in block report
- easier to maintain

![Screenshot from 2023-02-14 16-10-05](https://user-images.githubusercontent.com/617346/218777892-8d05ba6d-8f75-45b2-a47c-eb1a5ad4c3fb.png)
