### PR TITLE
PLANET-7094 Fix broken rounded images animation in Safari

### DIFF
--- a/assets/src/variations/stretched-link/index.scss
+++ b/assets/src/variations/stretched-link/index.scss
@@ -4,9 +4,10 @@
   [class*="is-style-rounded-"].force-no-caption {
     overflow: hidden;
     border-radius: 50%;
+    transform: translateZ(0); // This is needed for Safari, otherwise the animation looks off.
 
     img {
-      transition: all .2s ease-in-out;
+      transition: transform .2s ease-in-out;
     }
   }
 


### PR DESCRIPTION
### Description

See [PLANET-7094](https://jira.greenpeace.org/browse/PLANET-7094)
It seems it's not recommended to use `all` in CSS transitions, since browsers might interpret it in different ways. For Safari specifically, with a transition on the `transform` property, you need to add an additional `transformZ(0)` to the parent for some reason 😬 

### Testing

In Safari you can test the broken version with [this page](https://www.greenpeace.org/finland/metsat/) and the fixed version with [this page](https://www-dev.greenpeace.org/test-leda/52387-2/) for example. Make sure it also works as expected in other browsers.