### PR TITLE
PLANET-7013 Make sure Deep Dive images are always round

### DIFF
--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -2,20 +2,20 @@
   figure,
   img {
     border-radius: 50%;
-    height: $size;
-    width: $size;
+    max-height: $size;
   }
 
   img {
     object-fit: cover;
+    aspect-ratio: 1;
   }
 }
 
 @mixin square-image-size($size) {
   figure,
   img {
-    height: #{$size};
-    width: #{$size};
+    height: $size;
+    width: $size;
   }
 
   img {
@@ -30,12 +30,14 @@
   margin-top: $sp-1;
   margin-bottom: $sp-2;
 
-  &.is-style-rounded-180 {
-    @include rounded-image-size(180px);
-  }
+  &.is-style-rounded {
+    &-180 {
+      @include rounded-image-size(180px);
+    }
 
-  &.is-style-rounded-90 {
-    @include rounded-image-size(90px);
+    &-90 {
+      @include rounded-image-size(90px);
+    }
   }
 
   &:not(.force-no-lightbox) img {

--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -30,14 +30,12 @@
   margin-top: $sp-1;
   margin-bottom: $sp-2;
 
-  &.is-style-rounded {
-    &-180 {
-      @include rounded-image-size(180px);
-    }
+  &.is-style-rounded-180 {
+    @include rounded-image-size(180px);
+  }
 
-    &-90 {
-      @include rounded-image-size(90px);
-    }
+  &.is-style-rounded-90 {
+    @include rounded-image-size(90px);
   }
 
   &:not(.force-no-lightbox) img {
@@ -48,14 +46,12 @@
     display: none !important;
   }
 
-  &.square {
-    &-40 {
-      @include square-image-size(40px);
-    }
+  &.square-40 {
+    @include square-image-size(40px);
+  }
 
-    &-80 {
-      @include square-image-size(80px);
-    }
+  &.square-80 {
+    @include square-image-size(80px);
   }
 
   @include large-and-up {


### PR DESCRIPTION
### Description

See [PLANET-7013](https://jira.greenpeace.org/browse/PLANET-7013)
Before this fix, in certain screen sizes the images became more oval, especially when more items were added. This solution uses the `aspect-ratio` CSS property which is supported by [all major browsers except IE](https://caniuse.com/mdn-css_properties_aspect-ratio)

### Testing

You can compare the broken version [here](https://www.greenpeace.org/finland/metsat/) with the fixed one [here](https://www-dev.greenpeace.org/test-rhea/deep-dive-tests/) for example.