### PR TITLE
Fix Gallery block image clicks in the editor

### DIFF
--- a/assets/src/blocks/Gallery/GalleryEditor.js
+++ b/assets/src/blocks/Gallery/GalleryEditor.js
@@ -124,6 +124,11 @@ const renderView = (attributes, setAttributes) => {
 
   const { images } = useGalleryImages({ multiple_image, gallery_block_focus_points }, layout);
 
+  const galleryProps = {
+    images: images || [],
+    onImageClick: () => {},
+  };
+
   return (
     <section className={`block ${GALLERY_BLOCK_CLASSES[layout]} ${className ?? ''}`}>
       <header className="articles-title-container">
@@ -147,9 +152,9 @@ const renderView = (attributes, setAttributes) => {
         withoutInteractiveFormatting
         allowedFormats={['core/bold', 'core/italic']}
       />
-      {layout === 'slider' && <GalleryCarousel images={images || []} isEditing />}
-      {layout === 'three-columns' && <GalleryThreeColumns images={images || []} postType={postType} />}
-      {layout === 'grid' && <GalleryGrid images={images || []} />}
+      {layout === 'slider' && <GalleryCarousel isEditing {...galleryProps} />}
+      {layout === 'three-columns' && <GalleryThreeColumns postType={postType} {...galleryProps} />}
+      {layout === 'grid' && <GalleryGrid {...galleryProps} />}
     </section>
   );
 }

--- a/assets/src/blocks/Gallery/GalleryFrontend.js
+++ b/assets/src/blocks/Gallery/GalleryFrontend.js
@@ -29,6 +29,11 @@ export const GalleryFrontend = ({
 
   const items = imagesToItems(images);
 
+  const galleryProps = {
+    images: images || [],
+    onImageClick: openLightbox
+  };
+
   return (
     <section className={`block ${GALLERY_BLOCK_CLASSES[layout]} ${className ?? ''}`}>
       {gallery_block_title &&
@@ -40,9 +45,9 @@ export const GalleryFrontend = ({
       {gallery_block_description &&
         <div className="page-section-description" dangerouslySetInnerHTML={{ __html: gallery_block_description }} />
       }
-      {layout === 'slider' && <GalleryCarousel onImageClick={openLightbox} images={images || []} />}
-      {layout === 'three-columns' && <GalleryThreeColumns onImageClick={openLightbox} images={images || []} postType={postType} />}
-      {layout === 'grid' && <GalleryGrid onImageClick={openLightbox} images={images || []} />}
+      {layout === 'slider' && <GalleryCarousel {...galleryProps} />}
+      {layout === 'three-columns' && <GalleryThreeColumns postType={postType} {...galleryProps} />}
+      {layout === 'grid' && <GalleryGrid {...galleryProps} />}
 
       <Lightbox isOpen={isOpen} index={index} items={items} onClose={closeLightbox} />
     </section>


### PR DESCRIPTION
### Description

Before this fix, since the `onImageClick` prop was undefined we would get an error in the console

### Testing

If you check a Gallery block in the editor and click on one of the images, on `main` branch you'll see an error message in the console but on this branch you won't.