### PR TITLE
Small improvements for Columns Tasks on mobile/tablet

### DIFF
--- a/assets/src/blocks/Columns/ColumnsTasks.js
+++ b/assets/src/blocks/Columns/ColumnsTasks.js
@@ -123,7 +123,6 @@ export const ColumnsTasks = ({ isCampaign, columns, no_of_columns }) => (
                   }
                   {cta_text && cta_link &&
                     <a
-                      className={`btn btn-small btn-${isCampaign ? 'primary' : 'secondary'}`}
                       href={cta_link}
                       data-ga-category='Columns Block'
                       data-ga-action='Call to Action'

--- a/assets/src/styles/blocks/Accordion/AccordionStyle.scss
+++ b/assets/src/styles/blocks/Accordion/AccordionStyle.scss
@@ -60,7 +60,7 @@
         height: 1rem;
         width: 0.5rem;
         display: inline-block;
-        transition: transform 0.8s ease;
+        transition: transform 300ms linear;
         transform: rotate(90deg);
         mask-image: url("../../public/images/icons/chevron.svg");
         mask-repeat: no-repeat;

--- a/assets/src/styles/blocks/Columns.scss
+++ b/assets/src/styles/blocks/Columns.scss
@@ -252,12 +252,13 @@
 
         .card-header {
           --block-columns--card-header-- {
-            font-weight: 400;
+            font-weight: 700;
             font-size: $font-size-xs;
             font-family: var(--headings--font-family);
             background: $dark-blue;
             color: $white;
           }
+          border-radius: 4px;
           display: block;
           cursor: pointer;
           text-decoration: none;
@@ -267,6 +268,34 @@
 
           &:hover {
             text-decoration: none;
+          }
+
+          &:not(.collapsed):after {
+            transform: rotate(-90deg);
+          }
+
+          &:after {
+            content: "";
+            position: absolute;
+            top: 14px;
+            right: 16px;
+            left: auto;
+            pointer-events: none;
+            height: 1rem;
+            width: 0.5rem;
+            display: inline-block;
+            transition: transform 300ms linear;
+            transform: rotate(90deg);
+            mask-image: url("../../public/images/icons/chevron.svg");
+            mask-repeat: no-repeat;
+            mask-size: contain;
+            background-repeat: no-repeat;
+            background-color: currentColor;
+
+            html[dir="rtl"] & {
+              right: auto;
+              left: 16px;
+            }
           }
         }
 
@@ -297,10 +326,9 @@
             }
           }
 
-          .btn-secondary {
-            margin-bottom: 0;
+          a {
             margin-top: $sp-4;
-            width: 100%;
+            display: inline-block;
           }
         }
 


### PR DESCRIPTION
### Testing

See [the designs](https://www.figma.com/file/9NtbY8n3at8uOEJTsLrETb/P4-Design-System?node-id=274-12607&t=aSmlq5qD1NFaw0rC-0)
These can be applied regardless of the new identity, the color changes though are part of the new identity so they are handled in a [separate master-theme PR](https://github.com/greenpeace/planet4-master-theme/pull/1952). Similarly, the new link styles will be added as part of [PLANET-6994](https://jira.greenpeace.org/browse/PLANET-6994).

### Testing

You can test the improved version of this block on mobile/tablet either by creating one on local, or by checking [this page](https://www-dev.greenpeace.org/test-phoebe/the-new-columns-tasks/) that I made for UAT. The desktop version should not be changed at all.