### PR TITLE
Remove stretched link edit styles from frontend

### DIFF
--- a/assets/src/styles/blocks.scss
+++ b/assets/src/styles/blocks.scss
@@ -51,4 +51,3 @@
 
 // Variations
 @import "../variations/stretched-link/index";
-@import "../variations/stretched-link/edit";


### PR DESCRIPTION
### Description

Reported by Quentin on [Slack](https://greenpeace-gpi.slack.com/archives/G015K63081W/p1680092872553299)
These should only be imported in the editor