### PR TITLE
PLANET-7017 Refactor Spreadsheet block for new identity implementation

### DIFF
--- a/assets/src/blocks/Spreadsheet/SpreadsheetBlock.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetBlock.js
@@ -4,24 +4,31 @@ import {frontendRendered} from '../frontendRendered';
 
 const BLOCK_NAME = 'planet4-blocks/spreadsheet';
 
-const attributes = {
-  url: {
-    type: 'string',
-    default: '',
-  },
-  css_variables: CSS_VARIABLES_ATTRIBUTE,
-};
-
 export const registerSpreadsheetBlock = () => {
   const {registerBlockType} = wp.blocks;
   registerBlockType(BLOCK_NAME, {
     title: 'Spreadsheet',
     icon: 'editor-table',
     category: 'planet4-blocks',
-    attributes,
+    attributes: {
+      url: {
+        type: 'string',
+        default: '',
+      },
+      color: {
+        type: 'string',
+        default: 'grey',
+      },
+    },
     deprecated: [
       {
-        attributes,
+        attributes: {
+          url: {
+            type: 'string',
+            default: '',
+          },
+          css_variables: CSS_VARIABLES_ATTRIBUTE,
+        },
         save() {
           return null;
         },

--- a/assets/src/blocks/Spreadsheet/SpreadsheetEditorScript.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetEditorScript.js
@@ -4,6 +4,8 @@ import ColorPaletteControl from '../../components/ColorPaletteControl/ColorPalet
 
 import {debounce} from 'lodash';
 
+const {__} = wp.i18n;
+
 import {
   TextControl,
   PanelBody,
@@ -16,27 +18,6 @@ const colors = [
   {name: 'green', color: '#d0fac9'},
   {name: 'grey', color: '#ececec'},
 ];
-
-const colors_variables_map = {
-  // Grey variables (default)
-  '#ececec': {
-    'block-spreadsheet--header--background-color': '#45494c',
-    'block-spreadsheet--even-row--background': '#f5f7f8',
-    'block-spreadsheet--odd-row--background': '#ececec',
-  },
-  // Green variables
-  '#d0fac9': {
-    'block-spreadsheet--header--background-color': '#073d14',
-    'block-spreadsheet--even-row--background': '#eafee7',
-    'block-spreadsheet--odd-row--background': '#d0fac9',
-  },
-  // Blue variables
-  '#c9e7fa': {
-    'block-spreadsheet--header--background-color': '#074365',
-    'block-spreadsheet--even-row--background': '#e7f5fe',
-    'block-spreadsheet--odd-row--background': '#c9e7fa',
-  },
-};
 
 export class SpreadsheetEditor extends Component {
   constructor(props) {
@@ -60,15 +41,11 @@ export class SpreadsheetEditor extends Component {
   }
 
   renderEdit() {
-    const {__} = wp.i18n;
-
     const {attributes, setAttributes} = this.props;
 
-    const toCssVariables = value => {
-      setAttributes({
-        css_variables: colors_variables_map[value] ?? {},
-      });
-    };
+    const toColorName = code => colors.find(color => color.color === code).name;
+
+    const toColorCode = name => colors.find(color => color.name === name).color;
 
     return (
       <Fragment>
@@ -76,8 +53,8 @@ export class SpreadsheetEditor extends Component {
           <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
             <ColorPaletteControl
               label={__('Table Color', 'planet4-blocks-backend')}
-              value={attributes.css_variables['block-spreadsheet--odd-row--background']}
-              onChange={toCssVariables}
+              value={toColorCode(attributes.color)}
+              onChange={value => setAttributes({color: toColorName(value)})}
               disableCustomColors
               clearable={false}
               options={colors}

--- a/assets/src/blocks/Spreadsheet/SpreadsheetEditorScript.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetEditorScript.js
@@ -4,6 +4,8 @@ import ColorPaletteControl from '../../components/ColorPaletteControl/ColorPalet
 
 import {debounce} from 'lodash';
 
+const isNewIdentity = window.p4ge_vars.planet4_options.new_identity_styles || false;
+
 const {__} = wp.i18n;
 
 import {
@@ -18,6 +20,13 @@ const colors = [
   {name: 'green', color: '#d0fac9'},
   {name: 'grey', color: '#ececec'},
 ];
+
+if (isNewIdentity) {
+  colors.push({
+    name: 'dark-green',
+    color: '#1f4912'
+  });
+}
 
 export class SpreadsheetEditor extends Component {
   constructor(props) {

--- a/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
@@ -165,7 +165,7 @@ export class SpreadsheetFrontend extends Component {
 
     return (
       <Fragment>
-        <section className={`block block-spreadsheet ${this.props.className ?? ''}`} style={{cssText: toDeclarations(this.props.css_variables)}}>
+        <section className={`block block-spreadsheet ${this.props.className ?? ''}`}>
           <input className="spreadsheet-search form-control"
             type="text"
             value={this.state.searchText}
@@ -173,7 +173,7 @@ export class SpreadsheetFrontend extends Component {
             placeholder={__('Search data', 'planet4-blocks')}
           />
           <div className="table-wrapper">
-            <table className="spreadsheet-table">
+            <table className={`spreadsheet-table is-color-${this.props.color ?? 'grey'}`}>
               <thead>
                 <tr>
                   {

--- a/assets/src/styles/blocks/Spreadsheet/SpreadsheetStyle.scss
+++ b/assets/src/styles/blocks/Spreadsheet/SpreadsheetStyle.scss
@@ -32,19 +32,81 @@
 
 table.spreadsheet-table {
   min-width: 100%;
-
   margin-bottom: 0;
 
   @include mobile-only {
     overflow: visible;
   }
 
-  th {
-    --block-spreadsheet--header-- {
-      background-color: $table-header-grey;
-      border-bottom-color: $table-header-grey;
+  // Grey is the default color.
+  th --block-spreadsheet-grey-header-- {
+    background: $table-header-grey;
+  }
+
+  tr {
+    td {
+      --block-spreadsheet-- {
+        color: $table-font-color;
+      }
+      padding: 5px 20px;
+      font-size: $font-size-xs;
+      white-space: pre-wrap;
+
+      @include x-large-and-up {
+        font-size: $font-size-xs;
+      }
+
+      .highlighted-text {
+        font-weight: bold;
+      }
     }
 
+    td --block-spreadsheet-grey-even-row-- {
+      background: $table-even-row-grey;
+    }
+
+    &:nth-child(odd) td --block-spreadsheet-grey-odd-row-- {
+      background: $table-odd-row-grey;
+    }
+  }
+
+  &.is-color-green {
+    th --block-spreadsheet-green-header-- {
+      background: $table-header-green;
+    }
+
+    tr {
+      td --block-spreadsheet-green-even-row-- {
+        background: $table-even-row-green;
+      }
+
+      &:nth-child(odd) {
+        td --block-spreadsheet-green-odd-row-- {
+          background: $table-odd-row-green;
+        }
+      }
+    }
+  }
+
+  &.is-color-blue {
+    th --block-spreadsheet-blue-header-- {
+      background: $table-header-blue;
+    }
+
+    tr {
+      td --block-spreadsheet-blue-even-row-- {
+        background: $table-even-row-blue;
+      }
+
+      &:nth-child(odd) {
+        td --block-spreadsheet-blue-odd-row-- {
+          background: $table-odd-row-blue;
+        }
+      }
+    }
+  }
+
+  th {
     button {
       background-color: inherit;
       color: inherit;
@@ -52,7 +114,6 @@ table.spreadsheet-table {
     }
 
     color: $white;
-    border-bottom: 1px solid;
     cursor: pointer;
     font-size: $font-size-sm;
     position: sticky;
@@ -76,36 +137,6 @@ table.spreadsheet-table {
       &.sort-desc {
         svg {
           transform: rotate(180deg);
-        }
-      }
-    }
-  }
-
-  tr {
-    color: $table-font-color;
-
-    td {
-      --block-spreadsheet--even-row-- {
-        background: $table-even-row-grey;
-      }
-      padding: 5px 20px;
-      font-size: $font-size-xs;
-
-      white-space: pre-wrap;
-
-      @include x-large-and-up {
-        font-size: $font-size-xs;
-      }
-
-      .highlighted-text {
-        font-weight: bold;
-      }
-    }
-
-    &:nth-child(odd) {
-      td {
-        --block-spreadsheet--odd-row-- {
-          background: $table-odd-row-grey;
         }
       }
     }

--- a/classes/blocks/class-spreadsheet.php
+++ b/classes/blocks/class-spreadsheet.php
@@ -37,11 +37,14 @@ class Spreadsheet extends Base_Block {
 			[
 				'editor_script' => 'planet4-blocks',
 				'attributes'    => [
-					'url'           => [
+					'url'   => [
 						'type'    => 'string',
 						'default' => '',
 					],
-					'css_variables' => self::CSS_VARIABLES_ATTRIBUTE,
+					'color' => [
+						'type'    => 'string',
+						'default' => 'grey',
+					],
 				],
 			]
 		);


### PR DESCRIPTION
### Description

This new version creates separate CSS variables for all colors of the block, that will be easier to override for the new identity ([PLANET-7017](https://jira.greenpeace.org/browse/PLANET-7017)). The actual color changes however are made in the master-theme repo, in [this PR](https://github.com/greenpeace/planet4-master-theme/pull/1967).

**Note:** we'll need to figure out how to deal with existing blocks, but [there are only 18 in production](https://docs.google.com/spreadsheets/d/1uAmZLIWYsxrBByqbhoF_vVtSM7WGebYWIc0xftPRPwE/edit?pli=1#gid=359432436) so we can probably manually update them. This new version should still work but they'll just show up as grey in the frontend regardless of the color previously selected, but it will show the `block recovery` message in the editor.

### Testing

Add a Spreadsheet block to a page, it should behave as expected both in the editor and in the frontend. Make sure the new dark green color option is present and works as expected when the new identity styles are toggled. You can also test the various styles on [this page](https://www-dev.greenpeace.org/test-saturn/all-the-spreadsheets/) that I made for UAT.