### PR TITLE
PLANET-7022 Apply new identity colors to Highlighted CTA pattern

### DIFF
--- a/assets/src/block-templates/highlighted-cta/template.js
+++ b/assets/src/block-templates/highlighted-cta/template.js
@@ -2,6 +2,8 @@ import mainThemeUrl from '../main-theme-url';
 
 const {__} = wp.i18n;
 
+const isNewIdentity = window.p4ge_vars.planet4_options.new_identity_styles ?? false;
+
 const template = ({
   titlePlaceholder = __('Enter text', 'planet4-blocks-backend'),
 }) => [
@@ -10,7 +12,7 @@ const template = ({
     {
       className: 'block',
       textColor: 'white',
-      backgroundColor: 'dark-blue',
+      backgroundColor: isNewIdentity ? 'dark-green-800' : 'dark-blue',
     },
     [
       ['core/column', {}, [


### PR DESCRIPTION
### Description

See [PLANET-7022](https://jira.greenpeace.org/browse/PLANET-7022)
This is just about changing the background color that is applied by default, if the new identity styles are enabled. I know it's a bit different from what's required in the ticket, but as far as I know we can't change the color palette per pattern, only per block 😕 So this is why we only change the default background color, and anyway now when the new identity styles are enabled we only have access to the new color palette. For the text color, I don't think that we can change it automatically depending on what background editors select, but WordPress does show a warning if the color combination is hard to read so hopefully this is enough (in addition to the examples in the design system).

**Related PR:** https://github.com/greenpeace/planet4-master-theme/pull/1971

### Testing

Either on local (make sure the new identity styles are enabled!) or on the janus test instance, you can check the new available colors for the pattern. You can also use [this page](https://www-dev.greenpeace.org/test-janus/highlighted-ctas/) that I made for UAT.