### PR TITLE
PLANET-7014 Apply new identity colors to Accordion block

### DIFF
--- a/assets/src/blocks/Accordion/AccordionEditorScript.js
+++ b/assets/src/blocks/Accordion/AccordionEditorScript.js
@@ -4,6 +4,8 @@ const {registerBlockType, registerBlockStyle} = wp.blocks;
 
 const BLOCK_NAME = 'planet4-blocks/accordion';
 
+const isNewIdentity = window.p4ge_vars.planet4_options.new_identity_styles ?? false;
+
 const attributes = {
   title: {
     type: 'string',
@@ -30,6 +32,13 @@ const styles = [
     label: 'Light',
   },
 ];
+
+if (isNewIdentity) {
+  styles.push({
+    name: 'outline',
+    label: 'Outline',
+  });
+}
 
 registerBlockType(BLOCK_NAME, {
   title: 'Accordion',

--- a/assets/src/styles/blocks/Accordion/AccordionStyle.scss
+++ b/assets/src/styles/blocks/Accordion/AccordionStyle.scss
@@ -7,16 +7,14 @@
   font-family: var(--headings--font-family);
 
   &.is-style-light .accordion-content .accordion-headline {
-    border-color: $grey-20;
-    background-color: white;
-    color: $grey-80;
+    --accordion-block-light-style-- {
+      border-color: $grey-20;
+      background: $white;
+      color: var(--body--color);
 
-    &:hover {
-      background-color: $grey-05;
-    }
-
-    &:after {
-      background-color: $grey-80;
+      &:hover {
+        background: $grey-05;
+      }
     }
   }
 
@@ -25,11 +23,18 @@
     flex-direction: column;
 
     .accordion-headline {
+      --accordion-block-dark-style-- {
+        border-color: transparent;
+        background: $dark-blue;
+        color: $white;
+
+        &:hover {
+          background: $active-blue;
+        }
+      }
       cursor: pointer;
       position: relative;
-      background-color: $dark-blue;
       display: block;
-      color: $white;
       padding-top: 16px;
       padding-bottom: 16px;
       padding-inline-start: 16px;
@@ -40,11 +45,8 @@
       line-height: 1;
       margin-top: 0;
       margin-bottom: 16px;
-      border: 1px solid $dark-blue;
-
-      &:hover {
-        background-color: $active-blue;
-      }
+      border-width: 1px;
+      border-style: solid;
 
       &.open:after {
         transform: rotate(-90deg);


### PR DESCRIPTION
### Description

See [PLANET-7014](https://jira.greenpeace.org/browse/PLANET-7014)

**Related PR:** https://github.com/greenpeace/planet4-master-theme/pull/1974

### Testing

You can add an Accordion block on local or on the janus test instance, making sure you enabled the new identity styles, and test out the various styles. You can also check [this page](https://www-dev.greenpeace.org/test-janus/all-the-accordions/) that I made for UAT. Make sure the block also still looks fine with the "old" styles, if the new identity is not enabled.