### PR TITLE
Hotfix: ENForm fields select validation when no P4 EN Networks Form

### DIFF
--- a/assets/src/blocks/ENForm/ENFormFrontend.js
+++ b/assets/src/blocks/ENForm/ENFormFrontend.js
@@ -1,6 +1,6 @@
 import {ShareButtons} from '../../components/ShareButtons/ShareButtons';
 import {FormGenerator} from './FormGenerator';
-import {useSelect} from '@wordpress/data';
+import * as wpData from '@wordpress/data';
 import {useState} from '@wordpress/element';
 import {unescape} from '../../functions/unescape';
 
@@ -44,8 +44,8 @@ export const ENFormFrontend = attributes => {
   const is_side_style = en_form_style === 'side-style';
 
   let fields = en_form_fields ?? [];
-  if (fields.length <= 0) {
-    const form_post = useSelect(select => {
+  if (!fields.length && wpData?.useSelect !== undefined ) {
+    const form_post = wpData.useSelect(select => {
       return en_form_id ?
         select('core').getEntityRecord('postType', 'p4en_form', en_form_id) :
         [];


### PR DESCRIPTION
There is an issue with the `useSelect` hook, which seems to be `undefined`. That's why I've implemented an extra validation on that. It occurs when no Planet 4 Engaging Networks form has been added. 

**No ticket needed.**

## Before (without the fix):

![Screenshot 2023-04-11 at 07 34 48](https://user-images.githubusercontent.com/77975803/231137671-1b8a960e-4095-4e63-bb4a-ab7609d7269d.png)

![Screenshot 2023-04-11 at 07 47 44](https://user-images.githubusercontent.com/77975803/231138126-0612fa54-b6fb-4562-9297-b3cf07d93788.png)

## After (with the fix):
![Screenshot 2023-04-11 at 07 35 03](https://user-images.githubusercontent.com/77975803/231137697-dcaed0f2-dc41-4b29-b0f1-1afa8f94132f.png)

# Testing 
1. Just create a new ENForm and don't set any P4 EN Networks Form in any test instance.
2. Preview the page
3. Open the console and you'll see the error

Here is a [demo page](https://www-dev.greenpeace.org/test-neptune/empty-enform-demo-page/) to confirm the fixed issue.