### PR TITLE
PLANET-7130: Fix PageHeader content width

### DIFF
--- a/assets/src/styles/blocks/PageHeader.scss
+++ b/assets/src/styles/blocks/PageHeader.scss
@@ -24,7 +24,7 @@ $text-column-padding-in: 24px;
     grid-column: 1;
     grid-row: 2;
 
-    min-width: 312px;
+    width: fit-content;
     margin: -$sp-5x $sp-3 $sp-3;
     padding-inline-start: 0;
     padding-inline-end: 0;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7130

# Description

The content is broken on smaller screens less than ~550px. Here is the [demo page with the issue](https://www-dev.greenpeace.org/international/test-page-header/) 
This is the [demo page with the fix](https://www-dev.greenpeace.org/test-phoebe/test-page-header/)

![Screenshot 2023-04-11 at 14 02 25](https://user-images.githubusercontent.com/77975803/231237918-63004538-60a3-4f81-a714-a7cbe72e75a0.png)

![Screenshot 2023-04-11 at 14 02 37](https://user-images.githubusercontent.com/77975803/231237926-b0d72fff-8eed-4351-9d26-224a86f36143.png)



# Testing
1. Create a new page
2. Add two page header patterns with different content
3. Preview the page on a small screen
