### PR TITLE
PLANET-7129: Change the import of the ServerSideRender function

### DIFF
--- a/assets/src/blocks/SocialMediaCards/SocialMediaCards.js
+++ b/assets/src/blocks/SocialMediaCards/SocialMediaCards.js
@@ -8,10 +8,10 @@ import {
 import {
   TextControl,
   TextareaControl,
-  ServerSideRender,
   Button,
   Tooltip,
 } from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
 
 export class SocialMediaCards extends Component {
   renderEdit() {

--- a/assets/src/blocks/SubPages/SubPages.js
+++ b/assets/src/blocks/SubPages/SubPages.js
@@ -1,7 +1,5 @@
 import {Fragment} from '@wordpress/element';
-import {
-  ServerSideRender,
-} from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
 import {Preview} from '../../components/Preview';
 
 export const SubPages = props => {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7129

## Description
After Wordpress 6.2, this function is exported as default in a separate module.

Taken from the [Wordpress's official document](https://make.wordpress.org/core/2023/03/06/add-new-prop-to-serversiderender-component/)
> The ServerSideRender component has moved to its own package/script in WordPress 5.3 and accessing it using wp.components.ServerSideRender has been deprecated since. Starting WordPress 6.2, you should be able to access it directly using wp.serverSideRender.

And here is their [changed code](https://github.com/WordPress/gutenberg/pull/46106/files#diff-77df04898762524cd09f00a391d4977694eeed141eba84bcde4ca8eb7473a40bL51-L56).

__Please make sure to test and merge this new functionality after the next PRs__
- https://github.com/greenpeace/planet4-base/pull/244
- https://github.com/greenpeace/planet4-develop/pull/11