### PR TITLE
PLANET-7153: Follow up Wordpress 6.2 deprecations

### DIFF
--- a/assets/src/ImageBlockExtension.js
+++ b/assets/src/ImageBlockExtension.js
@@ -106,8 +106,7 @@ const addExtraControls = function() {
                         });
                         updateCaptionAlignment(option.value);
                       }}
-                      isPrimary={captionAlignment === option.value}
-                      isSecondary={captionAlignment !== option.value}>
+                      variant={captionAlignment === option.value ? 'primary' : 'secondary'}>
                       { option.label }
                     </Button>;
                   })

--- a/assets/src/blocks/Accordion/AccordionEditor.js
+++ b/assets/src/blocks/Accordion/AccordionEditor.js
@@ -156,7 +156,7 @@ const renderEdit = ({tabs}, setAttributes, updateTabAttribute) => {
           {__('Add item', 'planet4-blocks-backend')}
         </Button>
         <Button
-          isSecondary
+          variant="secondary"
           disabled={tabs.length <= 1}
           onClick={removeTab}
         >

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -43,7 +43,7 @@ export const EditableBackground = ({
             className="carousel-header-editor-controls"
             renderToggle={({onToggle}) => (
               <Button
-                isPrimary
+                variant="primary"
                 icon="edit"
                 onClick={onToggle}
               >

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -39,7 +39,7 @@ export const EditableBackground = ({
             }
           </div>
           <Dropdown
-            position="bottom left"
+            placement="bottom left"
             className="carousel-header-editor-controls"
             renderToggle={({onToggle}) => (
               <Button

--- a/assets/src/blocks/Submenu/SubmenuEditor.js
+++ b/assets/src/blocks/Submenu/SubmenuEditor.js
@@ -71,7 +71,7 @@ const renderEdit = (attributes, setAttributes) => {
           {__('Add level', 'planet4-blocks-backend')}
         </Button>
         <Button
-          isSecondary
+          variant="secondary"
           onClick={removeLevel}
           disabled={attributes.levels.length <= 1}
         >

--- a/assets/src/functions/hydrateBlock.js
+++ b/assets/src/functions/hydrateBlock.js
@@ -13,7 +13,9 @@ export const hydrateBlock = (blockName, Component, csrAttributes = {}) => { // e
   blocks.forEach(
     blockNode => {
       const attributes = JSON.parse(blockNode.dataset.attributes);
-      hydrateRoot(blockNode, <Component {...attributes} {...csrAttributes} />);
+      if(blockNode.length) {
+        hydrateRoot(blockNode, <Component {...attributes} {...csrAttributes} />);
+      }
     }
   );
 };


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7153

## Description
Since we're about to upgrade to [WordPress 6.2 “Dolphy”](https://wordpress.org/news/2023/03/dolphy/) we would need to make sure our code is up to date with the new requirements. Some of them has been deprecated since [WordPress 6.1 “Misha”](https://wordpress.org/news/2022/11/misha/).

**The current PR should be merged after**
- https://github.com/greenpeace/planet4-base/pull/244

## Testing
Make sure to run `Wordpress 6.2` on your local.