### PR TITLE
Standarize the import/destructure of the WP's block editor package

### DIFF
--- a/assets/src/block-templates/edit.js
+++ b/assets/src/block-templates/edit.js
@@ -1,11 +1,11 @@
-import {useBlockProps} from '@wordpress/block-editor';
+import {useBlockProps, InnerBlocks} from '@wordpress/block-editor';
 
 export default function(template, templateLock = false) {
   return props => {
     return (
       <div {...useBlockProps()}>
         {
-          wp.element.createElement(wp.blockEditor.InnerBlocks, {
+          wp.element.createElement(InnerBlocks, {
             template: template(props.attributes ?? {}),
             templateLock,
           })

--- a/assets/src/blocks/Accordion/AccordionEditor.js
+++ b/assets/src/blocks/Accordion/AccordionEditor.js
@@ -1,5 +1,5 @@
 import {Fragment, useState} from '@wordpress/element';
-import {InspectorControls} from '@wordpress/block-editor';
+import {InspectorControls, RichText} from '@wordpress/block-editor';
 import {URLInput} from '../../components/URLInput/URLInput';
 import {
   PanelBody,
@@ -9,7 +9,6 @@ import {
 
 import {debounce} from 'lodash';
 
-const {RichText} = wp.blockEditor;
 const {__} = wp.i18n;
 
 // Renders the editor view

--- a/assets/src/blocks/Articles/ArticlesEditor.js
+++ b/assets/src/blocks/Articles/ArticlesEditor.js
@@ -5,7 +5,7 @@ import {
   PanelBody,
   Tooltip,
 } from '@wordpress/components';
-import {InspectorControls} from '@wordpress/block-editor';
+import {InspectorControls, RichText} from '@wordpress/block-editor';
 import withCharacterCounter from '../../components/withCharacterCounter/withCharacterCounter';
 import TagSelector from '../../components/TagSelector/TagSelector';
 import {PostSelector} from '../../components/PostSelector/PostSelector';
@@ -15,7 +15,6 @@ import {ArticlesList} from './ArticlesList';
 import {useArticlesFetch} from './useArticlesFetch';
 import {useSelect} from '@wordpress/data';
 
-const {RichText} = wp.blockEditor;
 const {__} = wp.i18n;
 
 const TextControl = withCharacterCounter(BaseTextControl);

--- a/assets/src/blocks/CarouselHeader/Caption.js
+++ b/assets/src/blocks/CarouselHeader/Caption.js
@@ -1,4 +1,4 @@
-const {RichText} = wp.blockEditor;
+import {RichText} from '@wordpress/block-editor';
 const {__} = wp.i18n;
 
 export const Caption = ({slide, index, changeSlideAttribute}) => (

--- a/assets/src/blocks/Columns/ColumnsEditor.js
+++ b/assets/src/blocks/Columns/ColumnsEditor.js
@@ -5,7 +5,7 @@ import {
 } from '@wordpress/components';
 import {useSelect} from '@wordpress/data';
 import {useEffect} from '@wordpress/element';
-import {InspectorControls} from '@wordpress/block-editor';
+import {InspectorControls, RichText} from '@wordpress/block-editor';
 
 import {URLInput} from '../../components/URLInput/URLInput';
 import {EditableColumns} from './EditableColumns';
@@ -14,7 +14,6 @@ import {MAX_COLUMNS_AMOUNT, MIN_COLUMNS_AMOUNT} from './ColumnConstants';
 import {getStyleFromClassName} from '../getStyleFromClassName';
 
 const {__} = wp.i18n;
-const {RichText} = wp.blockEditor;
 
 const renderEdit = (attributes, toAttribute, setAttributes, isSelected) => {
   const {columns} = attributes;

--- a/assets/src/blocks/Columns/EditableColumns.js
+++ b/assets/src/blocks/Columns/EditableColumns.js
@@ -1,11 +1,10 @@
 import {LAYOUT_NO_IMAGE, LAYOUT_ICONS, LAYOUT_TASKS, LAYOUT_IMAGES} from './ColumnConstants';
-import {MediaUpload, MediaUploadCheck} from '@wordpress/block-editor';
+import {MediaUpload, MediaUploadCheck, RichText} from '@wordpress/block-editor';
 import {Button} from '@wordpress/components';
 import {ColumnsImagePlaceholder} from './ColumnsImagePlaceholder';
 import {ImageHoverControls} from '../../components/ImageHoverControls';
 
 const {__} = wp.i18n;
-const {RichText} = wp.blockEditor;
 
 export const EditableColumns = ({
   columns_block_style,

--- a/assets/src/blocks/Counter/CounterEditor.js
+++ b/assets/src/blocks/Counter/CounterEditor.js
@@ -1,5 +1,5 @@
 import {Component, Fragment} from '@wordpress/element';
-import {InspectorControls} from '@wordpress/block-editor';
+import {InspectorControls, RichText} from '@wordpress/block-editor';
 import {
   TextControl,
   TextareaControl,
@@ -10,7 +10,6 @@ import {URLInput} from '../../components/URLInput/URLInput';
 
 import {CounterFrontend} from './CounterFrontend';
 
-const {RichText} = wp.blockEditor;
 const {__} = wp.i18n;
 
 export class CounterEditor extends Component {

--- a/assets/src/blocks/Covers/CoversEditor.js
+++ b/assets/src/blocks/Covers/CoversEditor.js
@@ -7,7 +7,7 @@ import {
 } from '@wordpress/components';
 import {useEffect} from '@wordpress/element';
 
-import {InspectorControls} from '@wordpress/block-editor';
+import {InspectorControls, RichText} from '@wordpress/block-editor';
 import TagSelector from '../../components/TagSelector/TagSelector';
 import {PostSelector} from '../../components/PostSelector/PostSelector';
 import PostTypeSelector from '../../components/PostTypeSelector/PostTypeSelector';
@@ -17,7 +17,6 @@ import {useCovers} from './useCovers';
 import {getStyleFromClassName} from '../getStyleFromClassName';
 import {CoversCarouselLayout} from './CoversCarouselLayout';
 
-const {RichText} = wp.blockEditor;
 const {__} = wp.i18n;
 
 const renderEdit = (attributes, toAttribute, setAttributes) => {

--- a/assets/src/blocks/Gallery/GalleryEditor.js
+++ b/assets/src/blocks/Gallery/GalleryEditor.js
@@ -6,11 +6,8 @@ import {GalleryCarousel} from './GalleryCarousel';
 import {GalleryThreeColumns} from './GalleryThreeColumns';
 import {GalleryGrid} from './GalleryGrid';
 import {useGalleryImages} from './useGalleryImages';
-import {InspectorControls} from '@wordpress/block-editor';
+import {InspectorControls, MediaPlaceholder, MediaUploadCheck, RichText} from '@wordpress/block-editor';
 
-import {MediaPlaceholder, MediaUploadCheck} from '@wordpress/blockEditor';
-
-const {RichText} = wp.blockEditor;
 const {__} = wp.i18n;
 
 const renderEdit = (attributes, setAttributes, isSelected) => {

--- a/assets/src/blocks/Happypoint/HappypointEditor.js
+++ b/assets/src/blocks/Happypoint/HappypointEditor.js
@@ -6,12 +6,12 @@ import {USE_NONE, USE_IFRAME_URL, USE_EMBED_CODE} from './HappyPointConstants';
 
 import {debounce} from 'lodash';
 
-const {
+import {
   InspectorControls,
   BlockControls,
   MediaUpload,
   MediaUploadCheck,
-} = wp.blockEditor;
+} from '@wordpress/block-editor';
 
 const {__} = wp.i18n;
 

--- a/assets/src/blocks/Media/MediaEditor.js
+++ b/assets/src/blocks/Media/MediaEditor.js
@@ -1,6 +1,6 @@
 import {Fragment, useCallback} from '@wordpress/element';
 import {PanelBody, TextControl} from '@wordpress/components';
-import {MediaPlaceholder, InspectorControls} from '@wordpress/block-editor';
+import {MediaPlaceholder, InspectorControls, RichText} from '@wordpress/block-editor';
 import {debounce} from 'lodash';
 
 import {MediaElementVideo} from './MediaElementVideo';
@@ -10,7 +10,6 @@ import {lacksAttributes} from './MediaBlock';
 const {__} = wp.i18n;
 const {apiFetch} = wp;
 const {addQueryArgs} = wp.url;
-const {RichText} = wp.blockEditor;
 
 const MediaInspectorOptions = ({attributes, setAttributes}) => {
   const {media_url} = attributes;

--- a/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
@@ -4,6 +4,7 @@ import {
   RadioControl,
   SelectControl,
   PanelBody,
+  RichText,
 } from '@wordpress/components';
 import {SocialMediaEmbed} from './SocialMediaEmbed';
 import {URLInput} from '../../components/URLInput/URLInput';
@@ -17,7 +18,6 @@ import {
   ALLOWED_OEMBED_PROVIDERS,
 } from './SocialMediaConstants.js';
 
-const {RichText} = wp.blockEditor;
 const {__} = wp.i18n;
 const {apiFetch} = wp;
 const {addQueryArgs} = wp.url;

--- a/assets/src/blocks/SocialMediaCards/SocialMediaCards.js
+++ b/assets/src/blocks/SocialMediaCards/SocialMediaCards.js
@@ -1,9 +1,6 @@
 import {Component, Fragment} from '@wordpress/element';
 import {Preview} from '../../components/Preview';
-import {
-  MediaUpload,
-  MediaUploadCheck,
-} from '@wordpress/editor';
+import {MediaUpload, MediaUploadCheck} from '@wordpress/block-editor';
 
 import {
   TextControl,

--- a/assets/src/blocks/Submenu/SubmenuEditor.js
+++ b/assets/src/blocks/Submenu/SubmenuEditor.js
@@ -2,7 +2,7 @@ import {Fragment} from '@wordpress/element';
 import {Button, PanelBody} from '@wordpress/components';
 import {SubmenuLevel} from './SubmenuLevel';
 import {SubmenuItems} from './SubmenuItems';
-import {InspectorControls} from '@wordpress/block-editor';
+import {InspectorControls, RichText} from '@wordpress/block-editor';
 import {getSubmenuStyle} from './getSubmenuStyle';
 import {makeHierarchical} from './makeHierarchical';
 import {getHeadingsFromBlocks} from './getHeadingsFromBlocks';
@@ -10,7 +10,6 @@ import {useSelect} from '@wordpress/data';
 import {deepClone} from '../../functions/deepClone';
 
 const {__} = wp.i18n;
-const {RichText} = wp.blockEditor;
 
 const renderEdit = (attributes, setAttributes) => {
   function addLevel() {

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -1,6 +1,5 @@
 import {Fragment} from '@wordpress/element';
 import {useSelect} from '@wordpress/data';
-import {InspectorControls} from '@wordpress/block-editor';
 import {
   SelectControl,
   PanelBody,
@@ -10,6 +9,13 @@ import {
   Button,
   ToggleControl,
 } from '@wordpress/components';
+import {
+  RichText,
+  BlockControls,
+  MediaUpload,
+  MediaUploadCheck,
+  InspectorControls,
+} from '@wordpress/block-editor';
 import {URLInput} from '../../components/URLInput/URLInput';
 import {TakeActionBoxoutFrontend} from './TakeActionBoxoutFrontend';
 import {ImagePlaceholder} from './ImagePlaceholder';
@@ -19,13 +25,6 @@ const {__} = wp.i18n;
 
 // Planet 4 settings (Planet 4 >> Defaults content >> Take Action Covers default button text).
 const DEFAULT_BUTTON_TEXT = window.p4bk_vars.take_action_covers_button_text || __('Take action', 'planet4-blocks');
-
-const {
-  RichText,
-  BlockControls,
-  MediaUpload,
-  MediaUploadCheck,
-} = wp.blockEditor;
 
 export const TakeActionBoxoutEditor = ({
   attributes,

--- a/assets/src/blocks/Timeline/TimelineEditorScript.js
+++ b/assets/src/blocks/Timeline/TimelineEditorScript.js
@@ -5,7 +5,7 @@ import {
   CheckboxControl,
   Tooltip,
 } from '@wordpress/components';
-import {InspectorControls} from '@wordpress/block-editor';
+import {InspectorControls, RichText} from '@wordpress/block-editor';
 
 import {URLInput} from '../../components/URLInput/URLInput';
 import {useScript} from '../../components/useScript/useScript';
@@ -15,7 +15,6 @@ import {languages} from './TimelineLanguages';
 import {URLDescriptionHelp} from './URLDescriptionHelp';
 import {debounce, noConflict} from 'lodash';
 
-const {RichText} = wp.blockEditor;
 const {__} = wp.i18n;
 const TIMELINE_JS_VERSION = '3.8.12';
 


### PR DESCRIPTION
## Description
We have implemented different ways to get stuffs from the [WP's Block Editor package](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-editor). 

1. `import {...} from @wordpress/block-editor`
2. `import {...} from @wordpress/blockEditor`
3. `const {...} = wp.blockEditor;`

And I'd prefer to go with `import {...} from @wordpress/block-editor` since is the most used within our codebase.

This pull request is related to this [comment](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1039#issuecomment-1519551415) from #1039 