### PR TITLE
PLANET-7138: Remove text shadows on links

### DIFF
--- a/assets/src/styles/blocks/Covers/styles/CampaignCovers.scss
+++ b/assets/src/styles/blocks/Covers/styles/CampaignCovers.scss
@@ -82,7 +82,7 @@
 
         &:hover {
           &:before {
-            opacity: 0.1;
+            opacity: 0.3;
           }
         }
       }
@@ -97,7 +97,7 @@
         text-align: center;
         font-size: $font-size-md;
         font-family: var(--headings--font-family);
-        color: $yellow;
+        color: var(--p4-action-yellow-500, $yellow);
         font-weight: 500;
         position: absolute;
         left: 0;
@@ -105,7 +105,6 @@
         width: 100%;
         z-index: 2;
         margin-bottom: $sp-2;
-        text-shadow: 1px 1px $grey-80;
 
         @include medium-and-up {
           margin-bottom: 20px;

--- a/assets/src/styles/blocks/Covers/styles/CampaignCovers.scss
+++ b/assets/src/styles/blocks/Covers/styles/CampaignCovers.scss
@@ -94,10 +94,12 @@
       }
 
       .yellow-cta {
+        _-- {
+          color: $yellow;
+        }
         text-align: center;
         font-size: $font-size-md;
         font-family: var(--headings--font-family);
-        color: var(--p4-action-yellow-500, $yellow);
         font-weight: 500;
         position: absolute;
         left: 0;

--- a/assets/src/styles/blocks/SplitTwoColumns.scss
+++ b/assets/src/styles/blocks/SplitTwoColumns.scss
@@ -63,7 +63,6 @@
 
   a {
     color: $white;
-    text-shadow: 1px 1px 3px $grey-80;
   }
 
   @include small-and-up {
@@ -97,7 +96,6 @@
 
   &:hover {
     color: $yellow;
-    text-shadow: 1px 1px 3px $grey-80;
   }
 
   &:visited {
@@ -131,7 +129,6 @@
   @include medium-and-up {
     font-size: $font-size-xs;
     font-weight: 400;
-    text-shadow: 1px 1px 1px $grey-80;
     line-height: 1.6;
     margin-bottom: 18px;
   }

--- a/assets/src/styles/blocks/SplitTwoColumns.scss
+++ b/assets/src/styles/blocks/SplitTwoColumns.scss
@@ -84,10 +84,12 @@
 }
 
 .split-two-column-item-tag {
+  _-- {
+    color: $yellow;
+  }
   font-family: var(--headings--font-family);
   font-size: $font-size-xl;
   font-weight: 700;
-  color: $yellow;
   display: block;
   margin-bottom: .75em;
   white-space: nowrap;
@@ -99,7 +101,9 @@
   }
 
   &:visited {
-    color: $yellow;
+    _-- {
+      color: $yellow;
+    }
   }
 
   @include medium-and-up {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7138

## Description
The idea comes from [here](https://github.com/greenpeace/planet4-master-theme/pull/1996#discussion_r1174932194)

Demo page: https://www-dev.greenpeace.org/test-proteus/test-text-links-without-shadow/