### PR TITLE
PLANET-6958: Remove deprecated multiline prop

### DIFF
--- a/assets/src/blocks/Accordion/AccordionEditor.js
+++ b/assets/src/blocks/Accordion/AccordionEditor.js
@@ -43,7 +43,6 @@ const renderView = ({title, description, tabs, className}, setAttributes, isSele
           value={title}
           onChange={toAttribute('title')}
           withoutInteractiveFormatting
-          multiline="false"
           allowedFormats={[]}
         />
       </header>
@@ -65,7 +64,6 @@ const renderView = ({title, description, tabs, className}, setAttributes, isSele
             value={tab.headline}
             onChange={updateTabAttribute('headline', index)}
             withoutInteractiveFormatting
-            multiline="false"
             allowedFormats={[]}
           />
           <div className={`panel ${isSelected ? '' : 'panel-hidden'}`}>
@@ -86,7 +84,6 @@ const renderView = ({title, description, tabs, className}, setAttributes, isSele
                   value={tab.button.button_text}
                   onChange={updateTabAttribute('button_text', index)}
                   withoutInteractiveFormatting
-                  multiline="false"
                   allowedFormats={[]}
                 />
                 <Button

--- a/assets/src/blocks/Articles/ArticlesEditor.js
+++ b/assets/src/blocks/Articles/ArticlesEditor.js
@@ -110,7 +110,6 @@ const renderView = ({attributes, postType, posts, totalPosts}, toAttribute) => {
             value={attributes.article_heading}
             onChange={toAttribute('article_heading')}
             withoutInteractiveFormatting
-            multiline="false"
             allowedFormats={[]}
           />
         </header>
@@ -134,7 +133,6 @@ const renderView = ({attributes, postType, posts, totalPosts}, toAttribute) => {
               value={attributes.read_more_text}
               onChange={toAttribute('read_more_text')}
               withoutInteractiveFormatting
-              multiline="false"
               allowedFormats={[]}
             />
           </div>

--- a/assets/src/blocks/CarouselHeader/Caption.js
+++ b/assets/src/blocks/CarouselHeader/Caption.js
@@ -13,7 +13,6 @@ export const Caption = ({slide, index, changeSlideAttribute}) => (
           onChange={changeSlideAttribute('header', index)}
           withoutInteractiveFormatting
           allowedFormats={[]}
-          multiline="false"
         />
         <RichText
           tagName="p"

--- a/assets/src/blocks/Columns/ColumnsEditor.js
+++ b/assets/src/blocks/Columns/ColumnsEditor.js
@@ -156,7 +156,6 @@ export const ColumnsEditor = ({isSelected, attributes, setAttributes}) => {
             value={columns_title}
             onChange={toAttribute('columns_title')}
             withoutInteractiveFormatting
-            multiline="false"
             allowedFormats={[]}
           />
         </header>

--- a/assets/src/blocks/Columns/EditableColumns.js
+++ b/assets/src/blocks/Columns/EditableColumns.js
@@ -88,7 +88,6 @@ export const EditableColumns = ({
               onChange={toAttribute('title', index)}
               withoutInteractiveFormatting
               allowedFormats={[]}
-              multiline="false"
             />
             <RichText
               tagName="p"

--- a/assets/src/blocks/Cookies/CookiesFrontend.js
+++ b/assets/src/blocks/Cookies/CookiesFrontend.js
@@ -123,7 +123,6 @@ export const CookiesFrontend = props => {
             value={title}
             onChange={toAttribute('title')}
             withoutInteractiveFormatting
-            multiline="false"
             editable={isEditing}
             allowedFormats={[]}
           />
@@ -151,7 +150,6 @@ export const CookiesFrontend = props => {
                 value={getFieldValue('necessary_cookies_name')}
                 onChange={toAttribute('necessary_cookies_name')}
                 withoutInteractiveFormatting
-                multiline="false"
                 editable={isEditing}
                 allowedFormats={[]}
               />
@@ -219,7 +217,6 @@ export const CookiesFrontend = props => {
                   value={getFieldValue('analytical_cookies_name')}
                   onChange={toAttribute('analytical_cookies_name')}
                   withoutInteractiveFormatting
-                  multiline="false"
                   editable={isEditing}
                   allowedFormats={[]}
                 />
@@ -287,7 +284,6 @@ export const CookiesFrontend = props => {
                   value={getFieldValue('all_cookies_name')}
                   onChange={toAttribute('all_cookies_name')}
                   withoutInteractiveFormatting
-                  multiline="false"
                   editable={isEditing}
                   allowedFormats={[]}
                 />

--- a/assets/src/blocks/Counter/CounterEditor.js
+++ b/assets/src/blocks/Counter/CounterEditor.js
@@ -75,7 +75,6 @@ export const CounterEditor = ({setAttributes, attributes, isSelected}) => {
             value={attributes.title}
             onChange={toAttribute('title')}
             withoutInteractiveFormatting
-            multiline="false"
             allowedFormats={[]}
           />
         </header>

--- a/assets/src/blocks/Covers/CoversEditor.js
+++ b/assets/src/blocks/Covers/CoversEditor.js
@@ -148,7 +148,6 @@ const renderView = (attributes, toAttribute) => {
               value={title}
               onChange={toAttribute('title')}
               withoutInteractiveFormatting
-              multiline="false"
               allowedFormats={[]}
             />
           </header>
@@ -178,7 +177,6 @@ const renderView = (attributes, toAttribute) => {
                   value={readMoreText}
                   onChange={toAttribute('readMoreText')}
                   withoutInteractiveFormatting
-                  multiline="false"
                   allowedFormats={[]}
                 />
               </button>

--- a/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
+++ b/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
@@ -156,7 +156,6 @@ const SideContent = ({attributes, setAttributes}) => {
           placeholder={__('Enter title', 'planet4-blocks-backend')}
           withoutInteractiveFormatting
           allowedFormats={[]}
-          multiline="false"
         />
         <RichText
           tagName="div"
@@ -164,7 +163,6 @@ const SideContent = ({attributes, setAttributes}) => {
           onChange={desc => setAttributes({content_description: desc})}
           placeholder={__('Enter description', 'planet4-blocks-backend')}
           allowedFormats={['core/bold', 'core/italic']}
-          multiline
         />
       </div>
     </>
@@ -195,7 +193,6 @@ const Signup = ({attributes, setAttributes}) => {
             placeholder={__('Enter form title', 'planet4-blocks-backend')}
             withoutInteractiveFormatting
             allowedFormats={[]}
-            multiline="false"
           />
           <RichText
             tagName="div"
@@ -204,7 +201,6 @@ const Signup = ({attributes, setAttributes}) => {
             onChange={des => setAttributes({description: des})}
             placeholder={__('Enter form description', 'planet4-blocks-backend')}
             allowedFormats={['core/bold', 'core/italic']}
-            multiline
           />
         </div>
 
@@ -264,7 +260,6 @@ const ThankYou = ({attributes, setAttributes}) => {
             placeholder={__('Enter title', 'planet4-blocks-backend')}
             withoutInteractiveFormatting
             allowedFormats={[]}
-            multiline="false"
           />
         </header>
         <RichText
@@ -274,7 +269,6 @@ const ThankYou = ({attributes, setAttributes}) => {
           onChange={toAttribute('thankyou_subtitle')}
           placeholder={__('Enter description', 'planet4-blocks-backend')}
           allowedFormats={[]}
-          multiline
         />
 
         <div className="sub-section formblock-flex">
@@ -287,7 +281,6 @@ const ThankYou = ({attributes, setAttributes}) => {
               placeholder={__('Enter social media message', 'planet4-blocks-backend')}
               withoutInteractiveFormatting
               allowedFormats={[]}
-              multiline="false"
             />
           </div>
 
@@ -305,7 +298,6 @@ const ThankYou = ({attributes, setAttributes}) => {
                   onChange={toAttribute('thankyou_donate_message')}
                   placeholder={__('Enter donate message', 'planet4-blocks-backend')}
                   allowedFormats={['core/bold', 'core/italic', 'core/link']}
-                  multiline="false"
                 />
               </div>
 
@@ -319,7 +311,6 @@ const ThankYou = ({attributes, setAttributes}) => {
                   placeholder={__('Donate', 'planet4-blocks-backend')}
                   withoutInteractiveFormatting
                   allowedFormats={[]}
-                  multiline="false"
                 />
               </div>
             </>

--- a/assets/src/blocks/Gallery/GalleryEditor.js
+++ b/assets/src/blocks/Gallery/GalleryEditor.js
@@ -129,7 +129,6 @@ const renderView = (attributes, setAttributes) => {
           value={gallery_block_title}
           onChange={toAttribute('gallery_block_title')}
           withoutInteractiveFormatting
-          multiline="false"
           allowedFormats={[]}
         />
       </header>

--- a/assets/src/blocks/Media/MediaEditor.js
+++ b/assets/src/blocks/Media/MediaEditor.js
@@ -84,7 +84,6 @@ const renderView = (attributes, toAttribute) => {
           value={video_title}
           onChange={toAttribute('video_title')}
           withoutInteractiveFormatting
-          multiline="false"
           allowedFormats={[]}
         />
       </header>

--- a/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
@@ -166,7 +166,6 @@ export const SocialMediaEditor = ({
           value={title}
           onChange={toAttribute('title')}
           withoutInteractiveFormatting
-          multiline="false"
           allowedFormats={[]}
         />
       </header>

--- a/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsInPlaceEdit.js
+++ b/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsInPlaceEdit.js
@@ -55,7 +55,6 @@ export const SplittwocolumnsInPlaceEdit = ({attributes, setAttributes}) => {
             placeholder={__('Enter Title', 'planet4-blocks-backend')}
             value={title}
             onChange={onTextChange('title')}
-            multiline="false"
             withoutInteractiveFormatting
             allowedFormats={[]}
           />
@@ -65,7 +64,6 @@ export const SplittwocolumnsInPlaceEdit = ({attributes, setAttributes}) => {
             placeholder={__('Enter Description', 'planet4-blocks-backend')}
             value={issue_description}
             onChange={onTextChange('issue_description')}
-            multiline="false"
             allowedFormats={['core/bold', 'core/italic']}
           />
           {issue_link_path &&
@@ -75,7 +73,6 @@ export const SplittwocolumnsInPlaceEdit = ({attributes, setAttributes}) => {
               placeholder={__('Enter Link Text', 'planet4-blocks-backend')}
               value={issue_link_text}
               onChange={onTextChange('issue_link_text')}
-              multiline="false"
               withoutInteractiveFormatting
               allowedFormats={[]}
             />
@@ -105,7 +102,6 @@ export const SplittwocolumnsInPlaceEdit = ({attributes, setAttributes}) => {
             placeholder={__('Enter Description', 'planet4-blocks-backend')}
             value={tag_description}
             onChange={onTextChange('tag_description')}
-            multiline="false"
             allowedFormats={['core/bold', 'core/italic']}
           />
           <RichText
@@ -114,7 +110,6 @@ export const SplittwocolumnsInPlaceEdit = ({attributes, setAttributes}) => {
             placeholder={__('Enter button text', 'planet4-blocks-backend')}
             value={button_text}
             onChange={onTextChange('button_text')}
-            multiline="false"
             withoutInteractiveFormatting
             allowedFormats={[]}
           />

--- a/assets/src/blocks/Submenu/SubmenuEditor.js
+++ b/assets/src/blocks/Submenu/SubmenuEditor.js
@@ -107,7 +107,6 @@ const renderView = (attributes, setAttributes, className) => {
         value={title}
         onChange={titl => setAttributes({title: titl})}
         withoutInteractiveFormatting
-        multiline="false"
         allowedFormats={[]}
       />
       {menuItems.length > 0 ?

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -163,7 +163,6 @@ export const TakeActionBoxoutEditor = ({
           onChange={toAttribute('title')}
           disabled={true}
           withoutInteractiveFormatting
-          multiline="false"
           allowedFormats={[]}
         />
         <RichText
@@ -185,7 +184,6 @@ export const TakeActionBoxoutEditor = ({
         onChange={toAttribute('linkText')}
         disabled={takeActionPageSelected}
         withoutInteractiveFormatting
-        multiline="false"
         allowedFormats={[]}
       />
     </section>

--- a/assets/src/blocks/Timeline/TimelineEditorScript.js
+++ b/assets/src/blocks/Timeline/TimelineEditorScript.js
@@ -106,7 +106,6 @@ const renderView = (attributes, toAttribute, scriptLoaded, stylesLoaded) => {
             onChange={toAttribute('timeline_title')}
             withoutInteractiveFormatting
             maxLength={40}
-            multiline="false"
             allowedFormats={[]}
           />
         </header>


### PR DESCRIPTION
## Description
[PLANET-6958](https://jira.greenpeace.org/browse/PLANET-6958).

### Related PRs
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1042

### External Resources
- [Migrate to InnerBlocks](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/nested-blocks-inner-blocks/)


<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
