### PR TITLE
Implement missing hover styles to the SplitTwoColumns block

### DIFF
--- a/assets/src/styles/blocks/SplitTwoColumns.scss
+++ b/assets/src/styles/blocks/SplitTwoColumns.scss
@@ -97,7 +97,9 @@
   text-overflow: ellipsis;
 
   &:hover {
-    color: $yellow;
+    _-- {
+      color: $yellow;
+    }
   }
 
   &:visited {


### PR DESCRIPTION
## Description
Following up #1044, we noticed that we forgot to add the `:hover` pseudo.

<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
