### PR TITLE
Stabilize some e2e tests

### DIFF
--- a/tests/e2e/carousel-header.spec.js
+++ b/tests/e2e/carousel-header.spec.js
@@ -8,14 +8,12 @@ test('Create and check carousel header block', async ({page, context}) => {
   await page.goto('./wp-admin/post-new.php?post_type=page');
 
   // Using Editor to find Carousel Block
-  await page.getByRole('button', {name: 'Close'}).click();
-  const secondCloseBtn = page.getByRole('button', {name: 'Close'});
-  if (await secondCloseBtn.isVisible()) {
-    await secondCloseBtn.click();
-  }
+  await page.waitForSelector('.components-modal__header');
+  await page.locator('.components-modal__header button').click();
+  expect(page.locator('.components-modal__header')).toBeHidden();
 
   await page.locator('.block-editor-block-list__layout').click();
-  await page.locator('p.is-selected.wp-block-paragraph').fill('/carousel');
+  await page.locator('p.is-selected.wp-block-paragraph').type('/carousel');
   await page.getByRole('option', {name: 'Carousel Header'}).click();
 
   // Filling Carousel details

--- a/tests/e2e/editor-selector.spec.js
+++ b/tests/e2e/editor-selector.spec.js
@@ -8,7 +8,7 @@ test('Test Editor basic functionalities', async ({page, context}) => {
   await page.locator('.block-editor-block-list__layout').click();
   await page.locator('p.is-selected.wp-block-paragraph').fill('This is a test Post.');
   await page.keyboard.press('Enter');
-  await page.locator('p.is-selected.wp-block-paragraph').fill('/youtube');
+  await page.locator('p.is-selected.wp-block-paragraph').type('/youtube');
   await page.keyboard.press('Enter');
   await page.locator('[aria-label="YouTube URL"]').fill('https://youtu.be/3gPvDDHU41E');
   await page.getByRole('button', {name: 'Embed'}).click();

--- a/tests/e2e/take-action-boxout.spec.js
+++ b/tests/e2e/take-action-boxout.spec.js
@@ -8,7 +8,7 @@ test.describe('Test Take Action Boxout block', () => {
 
     // Add Take Action Boxout block.
     await page.locator('.block-editor-block-list__layout').click();
-    await page.locator('p.is-selected.wp-block-paragraph').fill('/take-action-boxout');
+    await page.locator('p.is-selected.wp-block-paragraph').type('/take-action-boxout');
     await page.keyboard.press('Enter');
   });
 

--- a/tests/e2e/tools/lib/columns.js
+++ b/tests/e2e/tools/lib/columns.js
@@ -5,7 +5,7 @@ const TEST_LINKS = ['/act', '/explore', '/'];
 async function addColumnsBlock(page, style) {
   // Add Columns block.
   await page.locator('.block-editor-block-list__layout').click();
-  await page.locator('p.is-selected.wp-block-paragraph').fill('/planet-4-columns');
+  await page.locator('p.is-selected.wp-block-paragraph').type('/planet-4-columns');
   await page.keyboard.press('Enter');
 
   // Select the style if needed.


### PR DESCRIPTION
- Replace `fill` with `type` when typing `/block name` to ensure a popover with blocks choices appears
- Replace template modal closing logic

This allows the `planet4-develop` tests to pass https://app.circleci.com/pipelines/github/greenpeace/planet4-develop/152/workflows/27553cb1-eaa5-4f72-aa3b-e8afcca3f496
- [theme report](https://output.circle-artifacts.com/output/job/9b669246-4329-4da9-93b2-bbfe014ace4b/artifacts/0/home/circleci/artifacts/playwright/themes/e2e-report/index.html)
- [plugin report](https://output.circle-artifacts.com/output/job/9b669246-4329-4da9-93b2-bbfe014ace4b/artifacts/0/home/circleci/artifacts/playwright/plugins/e2e-report/index.html)