### PR TITLE
PLANET-7083 Convert Homepage pattern layout to Block Templates

### DIFF
--- a/assets/src/block-templates/homepage/block.json
+++ b/assets/src/block-templates/homepage/block.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-block-templates/homepage",
+  "title": "Homepage",
+  "category": "planet4-block-templates",
+  "icon": "editor-table",
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/block-templates/homepage/index.js
+++ b/assets/src/block-templates/homepage/index.js
@@ -1,0 +1,4 @@
+import metadata from './block.json';
+import template from './template';
+
+export {metadata, template};

--- a/assets/src/block-templates/homepage/template.js
+++ b/assets/src/block-templates/homepage/template.js
@@ -1,0 +1,34 @@
+import gravityFormWithText from '../templates/gravity-form-with-text';
+const {__} = wp.i18n;
+const isNewIdentity = window.p4ge_vars.planet4_options.new_identity_styles ?? false;
+const backgroundColor = isNewIdentity ? 'beige-100' : 'grey-05';
+
+const template = () => (
+  [
+    ['core/group', {}, [
+      ['planet4-blocks/carousel-header'],
+      ['planet4-block-templates/issues', {
+        titlePlaceholder: __('The issues we work on', 'planet4-blocks'),
+      }],
+      ['core/spacer', {height: '88px'}],
+      ['planet4-blocks/articles', {
+        article_heading: __('Read our Stories', 'planet4-blocks'),
+      }],
+      ['core/spacer', {height: '56px'}],
+      ['planet4-block-templates/side-image-with-text-and-cta', {
+        title: __('Get to know us', 'planet4-blocks'),
+      }],
+      ['core/spacer', {height: '30px'}],
+      ['planet4-block-templates/side-image-with-text-and-cta', {
+        title: __('We win campaigns', 'planet4-blocks'),
+        mediaPosition: 'right',
+      }],
+      ['core/spacer', {height: '56px'}],
+      ['planet4-blocks/covers'],
+      ['core/spacer', {height: '72px'}],
+      gravityFormWithText({backgroundColor}),
+    ]],
+  ]
+);
+
+export default template;

--- a/assets/src/block-templates/issues/block.json
+++ b/assets/src/block-templates/issues/block.json
@@ -7,6 +7,7 @@
   "icon": "editor-table",
   "textdomain": "planet4-blocks-backend",
   "attributes": {
-    "backgroundColor": { "type": "string" }
+    "backgroundColor": { "type": "string" },
+    "titlePlaceholder": { "type": "string" }
   }
 }

--- a/assets/src/block-templates/issues/template.js
+++ b/assets/src/block-templates/issues/template.js
@@ -45,6 +45,7 @@ const item = ['core/group', {
 
 const template = ({
   backgroundColor = isNewIdentity ? 'beige-100' : 'grey-05',
+  titlePlaceholder = __('Enter title', 'planet4-blocks-backend'),
 }) => ([
   ['core/group', {
     align: 'full',
@@ -65,7 +66,7 @@ const template = ({
     }, [
       ['core/heading', {
         level: 2,
-        placeholder: __('Enter title', 'planet4-blocks-backend'),
+        placeholder: titlePlaceholder,
         style: {
           spacing: {
             margin: {

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -6,6 +6,7 @@ import * as issues from './issues';
 import * as pageHeader from './page-header';
 import * as highlightedCta from './highlighted-cta';
 import * as deepDiveTopic from './deep-dive-topic';
+import * as homepage from './homepage';
 
 export default [
   sideImgTextCta,
@@ -16,4 +17,5 @@ export default [
   pageHeader,
   highlightedCta,
   deepDiveTopic,
+  homepage,
 ];

--- a/assets/src/block-templates/templates/gravity-form-with-text.js
+++ b/assets/src/block-templates/templates/gravity-form-with-text.js
@@ -1,0 +1,36 @@
+const {__} = wp.i18n;
+
+const gravityFormWithText = ({backgroundColor}) => (
+  ['core/group', {
+    backgroundColor,
+    align: 'full',
+    style: {
+      spacing: {
+        padding: {
+          top:'80px',
+          bottom:'50px',
+        },
+      },
+    },
+  }, [
+    ['core/group', {className: 'container'}, [
+      ['core/columns', {}, [
+        ['core/column', {}, [
+          ['core/heading', {
+            level: 2,
+            style: {typography: {fontSize: '40px'}},
+            placeholder: __('Enter title', 'planet4-blocks-backend'),
+          }],
+          ['core/paragraph', {
+            placeholder: __('Enter description', 'planet4-blocks-backend'),
+          }],
+        ]],
+        ['core/column', {}, [
+          ['gravityforms/form', {title: false, description: false}],
+        ]],
+      ]],
+    ]],
+  ]]
+);
+
+export default gravityFormWithText;

--- a/classes/patterns/class-homepage.php
+++ b/classes/patterns/class-homepage.php
@@ -8,10 +8,6 @@
 
 namespace P4GBKS\Patterns;
 
-use P4GBKS\Patterns\Templates\CarouselHeader;
-use P4GBKS\Patterns\Templates\Covers;
-use P4GBKS\Patterns\Templates\GravityFormWithText;
-
 /**
  * This class is used for returning a homepage pattern layout template.
  *
@@ -37,55 +33,7 @@ class Homepage extends Block_Pattern {
 			'blockTypes' => [ 'core/post-content' ],
 			'categories' => [ 'layouts' ],
 			'content'    => '
-			<!-- wp:group -->
-			<div class="wp-block-group">
-
-				' . CarouselHeader::get_content() . '
-
-				' . Issues::get_config( [ 'title_placeholder' => __( 'The issues we work on', 'planet4-blocks-backend' ) ] )['content'] . '
-
-				<!-- wp:spacer {"height":"88px"} -->
-				<div style="height:88px" aria-hidden="true" class="wp-block-spacer"></div>
-				<!-- /wp:spacer -->
-
-				<!-- wp:planet4-blocks/articles {
-					"article_heading":"' . __( 'Read our Stories', 'planet4-blocks' ) . '"
-				} /-->
-
-				<!-- wp:spacer {"height":"56px"} -->
-				<div style="height:56px" aria-hidden="true" class="wp-block-spacer"></div>
-				<!-- /wp:spacer -->
-
-				' . SideImageWithTextAndCta::get_config(
-						[
-							'title' => __( 'Get to know us', 'planet4-blocks' ),
-						]
-					)['content'] . '
-
-				<!-- wp:spacer {"height":"30px"} -->
-				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
-				<!-- /wp:spacer -->
-				' . SideImageWithTextAndCta::get_config(
-						[
-							'title'         => __( 'We win campaigns', 'planet4-blocks' ),
-							'mediaPosition' => 'right',
-						]
-					)['content'] . '
-
-				<!-- wp:spacer {"height":"56px"} -->
-				<div style="height:56px" aria-hidden="true" class="wp-block-spacer"></div>
-				<!-- /wp:spacer -->
-
-				' . Covers::get_content() . '
-
-				<!-- wp:spacer {"height":"72px"} -->
-				<div style="height:72px" aria-hidden="true" class="wp-block-spacer"></div>
-				<!-- /wp:spacer -->
-
-				' . GravityFormWithText::get_content() . '
-
-			</div>
-			<!-- /wp:group -->
+				<!-- wp:planet4-block-templates/homepage ' . wp_json_encode( $params, \JSON_FORCE_OBJECT ) . ' /-->
 			',
 		];
 	}

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -212,6 +212,7 @@ const BLOCK_TEMPLATES = [
 	'planet4-block-templates/side-image-with-text-and-cta',
 	// layouts.
 	'planet4-block-templates/deep-dive-topic',
+	'planet4-block-templates/homepage',
 ];
 
 /**


### PR DESCRIPTION
**Description:** https://jira.greenpeace.org/browse/PLANET-7083

**Testing:** 

Open the editor on the assigned instance or on your local on this branch and the layout for the Homepage pattern should still look the same.

<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
