### PR TITLE
PLANET-7082 Convert Campaign pattern layout into a Block Template

### DIFF
--- a/assets/src/block-templates/campaign/block.json
+++ b/assets/src/block-templates/campaign/block.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-block-templates/campaign",
+  "title": "Campaign",
+  "category": "planet4-block-templates",
+  "icon": "editor-table",
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/block-templates/campaign/index.js
+++ b/assets/src/block-templates/campaign/index.js
@@ -1,0 +1,4 @@
+import metadata from './block.json';
+import template from './template';
+
+export {metadata, template};

--- a/assets/src/block-templates/campaign/template.js
+++ b/assets/src/block-templates/campaign/template.js
@@ -1,3 +1,5 @@
+import gravityFormWithText from '../templates/gravity-form-with-text';
+
 const {__} = wp.i18n;
 
 const template = () => ([
@@ -19,7 +21,7 @@ const template = () => ([
       title: __('How you can help', 'planet4-blocks'),
     }],
     ['core/spacer', {height: '48px'}],
-    ['gravityforms/form'],
+    gravityFormWithText(),
   ]],
 ]);
 

--- a/assets/src/block-templates/campaign/template.js
+++ b/assets/src/block-templates/campaign/template.js
@@ -1,0 +1,26 @@
+const {__} = wp.i18n;
+
+const template = () => ([
+  ['core/group', {className: 'block'}, [
+    ['planet4-block-templates/page-header', {
+      titlePlaceholder: __('Page header title', 'planet4-blocks-backend'),
+    }],
+    ['core/spacer', {height: '64px'}],
+    ['planet4-block-templates/side-image-with-text-and-cta', {
+      title: __('The problem', 'planet4-blocks'),
+    }],
+    ['core/spacer', {height: '32px'}],
+    ['planet4-block-templates/side-image-with-text-and-cta', {
+      title: __('The solution', 'planet4-blocks'),
+      mediaPosition: 'right',
+    }],
+    ['core/spacer', {height: '32px'}],
+    ['planet4-blocks/covers', {
+      title: __('How you can help', 'planet4-blocks'),
+    }],
+    ['core/spacer', {height: '48px'}],
+    ['gravityforms/form'],
+  ]],
+]);
+
+export default template;

--- a/assets/src/block-templates/homepage/template.js
+++ b/assets/src/block-templates/homepage/template.js
@@ -1,7 +1,6 @@
 import gravityFormWithText from '../templates/gravity-form-with-text';
+
 const {__} = wp.i18n;
-const isNewIdentity = window.p4ge_vars.planet4_options.new_identity_styles ?? false;
-const backgroundColor = isNewIdentity ? 'beige-100' : 'grey-05';
 
 const template = () => (
   [
@@ -26,7 +25,7 @@ const template = () => (
       ['core/spacer', {height: '56px'}],
       ['planet4-blocks/covers'],
       ['core/spacer', {height: '72px'}],
-      gravityFormWithText({backgroundColor}),
+      gravityFormWithText(),
     ]],
   ]
 );

--- a/assets/src/block-templates/page-header/block.json
+++ b/assets/src/block-templates/page-header/block.json
@@ -6,9 +6,8 @@
   "category": "planet4-block-templates",
   "textdomain": "planet4-blocks-backend",
   "attributes": {
-    "titlePlaceholder": { "type": "string" },
-    "backgroundColor": { "type": "string" },
     "imageFill": { "type": "boolean" },
-    "mediaPosition": { "type": "string" }
+    "mediaPosition": { "type": "string" },
+    "titlePlaceholder": { "type": "string" }
   }
 }

--- a/assets/src/block-templates/page-header/template.js
+++ b/assets/src/block-templates/page-header/template.js
@@ -3,10 +3,9 @@ import mainThemeUrl from '../main-theme-url';
 const {__} = wp.i18n;
 
 const template = ({
-  titlePlaceholder = __('Enter title', 'planet4-blocks-backend'),
-  backgroundColor = 'grey-05',
   mediaPosition = '',
   imageFill = false,
+  titlePlaceholder = __('Enter title', 'planet4-blocks-backend'),
 }) => ([
   ['core/group',
     {
@@ -34,7 +33,7 @@ const template = ({
           ['core/group', {}, [
             ['core/heading', {
               level: 1,
-              backgroundColor,
+              backgroundColor: 'white',
               placeholder: titlePlaceholder,
             }],
           ]],

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -7,6 +7,7 @@ import * as pageHeader from './page-header';
 import * as highlightedCta from './highlighted-cta';
 import * as deepDiveTopic from './deep-dive-topic';
 import * as homepage from './homepage';
+import * as campaign from './campaign';
 
 export default [
   sideImgTextCta,
@@ -16,6 +17,9 @@ export default [
   issues,
   pageHeader,
   highlightedCta,
+
+  // layouts.
   deepDiveTopic,
   homepage,
+  campaign,
 ];

--- a/assets/src/block-templates/templates/gravity-form-with-text.js
+++ b/assets/src/block-templates/templates/gravity-form-with-text.js
@@ -1,6 +1,9 @@
 const {__} = wp.i18n;
 
-const gravityFormWithText = ({backgroundColor}) => (
+const isNewIdentity = window.p4ge_vars.planet4_options.new_identity_styles ?? false;
+const backgroundColor = isNewIdentity ? 'beige-100' : 'grey-05';
+
+const gravityFormWithText = () => (
   ['core/group', {
     backgroundColor,
     align: 'full',

--- a/classes/patterns/class-campaign.php
+++ b/classes/patterns/class-campaign.php
@@ -8,9 +8,6 @@
 
 namespace P4GBKS\Patterns;
 
-use P4GBKS\Patterns\Templates\Covers;
-use P4GBKS\Patterns\Templates\GravityFormWithText;
-
 /**
  * Class Campaign.
  *
@@ -31,42 +28,12 @@ class Campaign extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
-		$classname       = self::get_classname();
-		$is_new_identity = get_theme_mod( 'new_identity_styles' );
-
 		return [
 			'title'      => 'Campaign',
 			'blockTypes' => [ 'core/post-content' ],
 			'categories' => [ 'layouts' ],
 			'content'    => '
-				<!-- wp:group {"className":"block ' . $classname . '"} -->
-					<div class="wp-block-group block ' . $classname . '">
-						' . PageHeader::get_config( [ 'title_placeholder' => __( 'Page header title', 'planet4-blocks' ) ] )['content'] . '
-						<!-- wp:spacer {"height":"64px"} -->
-							<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
-						<!-- /wp:spacer -->
-						' . SideImageWithTextAndCta::get_config(
-							[ 'title' => __( 'The problem', 'planet4-blocks' ) ]
-						)['content'] . '
-						<!-- wp:spacer {"height":"32px"} -->
-							<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
-						<!-- /wp:spacer -->
-						' . SideImageWithTextAndCta::get_config(
-							[
-								'title'         => __( 'The solution', 'planet4-blocks' ),
-								'mediaPosition' => 'right',
-							]
-						)['content'] . '
-						<!-- wp:spacer {"height":"32px"} -->
-							<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
-						<!-- /wp:spacer -->
-						' . Covers::get_content( [ 'title_placeholder' => __( 'How you can help', 'planet4-blocks' ) ] ) . '
-						<!-- wp:spacer {"height":"48px"} -->
-							<div style="height:48px" aria-hidden="true" class="wp-block-spacer"></div>
-						<!-- /wp:spacer -->
-						' . GravityFormWithText::get_content() . '
-					</div>
-				<!-- /wp:group -->
+				<!-- wp:planet4-block-templates/campaign ' . wp_json_encode( $params, \JSON_FORCE_OBJECT ) . ' /-->
 			',
 		];
 	}

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -210,9 +210,11 @@ const BLOCK_TEMPLATES = [
 	'planet4-block-templates/issues',
 	'planet4-block-templates/page-header',
 	'planet4-block-templates/side-image-with-text-and-cta',
+
 	// layouts.
 	'planet4-block-templates/deep-dive-topic',
 	'planet4-block-templates/homepage',
+	'planet4-block-templates/campaign',
 ];
 
 /**


### PR DESCRIPTION
### Description

See [PLANET-7082](https://jira.greenpeace.org/browse/PLANET-7082)

### Testing

You should still be able to add the Campaign pattern layout from the `Layouts` category, and it should look just like before.