### PR TITLE
PLANET-7170 Add help text to canonical link sidebar option

### DIFF
--- a/assets/src/components/Sidebar/SearchEngineOptimizationsSidebar.js
+++ b/assets/src/components/Sidebar/SearchEngineOptimizationsSidebar.js
@@ -17,7 +17,12 @@ export const SearchEngineOptimizationsSidebar = {
         name="planet4-search-engine-optimizations"
         title={__('Search Engine Optimizations', 'planet4-blocks-backend')}
       >
-        <URLInput label={__('Canonical link', 'planet4-blocks-backend')} value={meta[CANONICAL_URL]} onChange={value => editPost({meta: {[CANONICAL_URL]: value}})} />
+        <URLInput
+          label={__('Canonical link', 'planet4-blocks-backend')}
+          value={meta[CANONICAL_URL]}
+          onChange={value => editPost({meta: {[CANONICAL_URL]: value}})}
+          help={__('If emtpy a self-reference canonical link will be used', 'planet4-blocks-backend')}
+        />
       </PluginDocumentSettingPanel>
     );
   },


### PR DESCRIPTION
### Description

See [PLANET-7170](https://jira.greenpeace.org/browse/PLANET-7170)
This is to clarify that the permalink will be used by default
