### PR TITLE
Improve Playwright tests 

### DIFF
--- a/tests/e2e/carousel-header.spec.js
+++ b/tests/e2e/carousel-header.spec.js
@@ -10,7 +10,7 @@ test('Create and check carousel header block', async ({page, context}) => {
   // Using Editor to find Carousel Block
   await page.waitForSelector('.components-modal__header');
   await page.locator('.components-modal__header button').click();
-  expect(page.locator('.components-modal__header')).toBeHidden();
+  await expect(page.locator('.components-modal__header')).toBeHidden();
 
   await page.locator('.block-editor-block-list__layout').click();
   await page.locator('p.is-selected.wp-block-paragraph').type('/carousel');
@@ -84,7 +84,7 @@ test('Create and check carousel header block', async ({page, context}) => {
 
   expect(h2Title1).toBe('My test Header 1');
   expect(paragraphDescription1).toBe('Testing carousel description 1');
-  expect(ctaButton1).toBeVisible();
+  await expect(ctaButton1).toBeVisible();
 
   await page.locator('button.carousel-control-next').click();
 
@@ -94,6 +94,6 @@ test('Create and check carousel header block', async ({page, context}) => {
 
   expect(h2Title2).toBe('My test Header 2');
   expect(paragraphDescription2).toBe('Testing carousel description 2');
-  expect(ctaButton2).toBeVisible();
+  await expect(ctaButton2).toBeVisible();
 
 });

--- a/tests/e2e/editor-selector.spec.js
+++ b/tests/e2e/editor-selector.spec.js
@@ -22,5 +22,5 @@ test('Test Editor basic functionalities', async ({page, context}) => {
   const video = page.locator('figure.is-provider-youtube');
   expect(h1).toBe('Test Post');
   expect(paragraph).toBe('This is a test Post.');
-  expect(video).toBeVisible();
+  await expect(video).toBeVisible();
 });

--- a/tests/e2e/split-two-columns.spec.js
+++ b/tests/e2e/split-two-columns.spec.js
@@ -9,7 +9,7 @@ test('Create and check check split two column block', async ({page, context}) =>
 
   await page.waitForSelector('.components-modal__header');
   await page.locator('.components-modal__header button').click();
-  expect(page.locator('.components-modal__header')).toBeHidden();
+  await expect(page.locator('.components-modal__header')).toBeHidden();
 
   // Adding Split Two Column Block
   await page.locator('.block-editor-block-list__layout').click();
@@ -52,9 +52,9 @@ test('Create and check check split two column block', async ({page, context}) =>
   const tag = page.locator('a.split-two-column-item-tag');
   const button = page.locator('a.split-two-column-item-button');
 
-  expect(h2Title).toBeVisible();
-  expect(desc).toBeVisible();
+  await expect(h2Title).toBeVisible();
+  await expect(desc).toBeVisible();
   expect(link).toBe('Learn more about this issue');
-  expect(tag).toBeVisible();
-  expect(button).toBeVisible();
+  await expect(tag).toBeVisible();
+  await expect(button).toBeVisible();
 });

--- a/tests/e2e/tools/lib/columns.js
+++ b/tests/e2e/tools/lib/columns.js
@@ -45,19 +45,19 @@ async function checkColumnsBlock(page, style) {
   const frontendColums = await page.locator('.column-wrap').all();
   for (const [index, column] of frontendColums.entries()) {
     if (style === 'Tasks') {
-      expect(column.locator('.step-number')).toBeVisible();
+      await expect(column.locator('.step-number')).toBeVisible();
     }
-    expect(await column.locator(style === 'Tasks' ? 'h5' : 'h3').innerText()).toBe(`Column ${index + 1}`);
-    expect(await column.locator('p').innerText ()).toBe(`Description ${index + 1}`);
+    await expect(column.locator(style === 'Tasks' ? 'h5' : 'h3')).toHaveText(`Column ${index + 1}`);
+    await expect(column.locator('p')).toHaveText(`Description ${index + 1}`);
     if (style === 'Images' || style === 'Icons') {
-      expect(column.locator('.attachment-container > a > img')).toBeVisible();
+      await expect(column.locator('.attachment-container > a > img')).toBeVisible();
       const link = column.locator('a.standalone-link');
-      expect(link).toHaveText(`Link ${index + 1}`);
-      expect(await link.getAttribute('href')).toBe(TEST_LINKS[index]);
+      await expect(link).toHaveText(`Link ${index + 1}`);
+      await expect(link).toHaveAttribute('href', TEST_LINKS[index]);
     } else {
       const button = column.locator('a.btn-secondary');
-      expect(button).toHaveText(`Button ${index + 1}`);
-      expect(button.getAttribute('href')).toBe(TEST_LINKS[index]);
+      await expect(button).toHaveText(`Button ${index + 1}`);
+      await expect(button).toHaveAttribute('href', TEST_LINKS[index]);
     }
   }
 }

--- a/tests/e2e/tools/lib/columns.js
+++ b/tests/e2e/tools/lib/columns.js
@@ -28,7 +28,7 @@ async function addColumnsBlock(page, style) {
       `div[aria-label="Enter column ${['Images','Icons'].includes(style) ? 'link' : 'button'} text"]`
     ).fill(`${['Images','Icons'].includes(style) ? 'Link' : 'Button'} ${index + 1}`);
 
-    if (style === 'Icons') {
+    if (style === 'Images' || style === 'Icons') {
       await column.locator('.columns-image-placeholder').hover({noWaitAfter: true});
       await column.locator('.dashicons-plus-alt2').click();
       // Select image from media library modal.

--- a/tests/e2e/tools/lib/covers.js
+++ b/tests/e2e/tools/lib/covers.js
@@ -54,31 +54,31 @@ async function checkCoversBlock(page, style) {
     await expect(page.locator('.content-covers-block')).toBeVisible();
     const frontendCovers = await page.locator('.post-column.cover').all();
     for (const [, cover] of frontendCovers.entries()) {
-      expect(cover.locator('.content-covers-block-image > a > img')).toBeVisible();
-      expect(cover.locator('.content-covers-block-information > h5 > a')).toBeVisible();
-      expect(cover.locator('.content-covers-block-information > .publication-date')).toBeVisible();
-      expect(cover.locator('.content-covers-block-information > .post-excerpt')).toBeVisible();
+      await expect(cover.locator('.content-covers-block-image > a > img')).toBeVisible();
+      await expect(cover.locator('.content-covers-block-information > h5 > a')).toBeVisible();
+      await expect(cover.locator('.content-covers-block-information > .publication-date')).toBeVisible();
+      await expect(cover.locator('.content-covers-block-information > .post-excerpt')).toBeVisible();
     }
   } else if (style === 'Campaign') {
     await expect(page.locator('.campaign-covers-block')).toBeVisible();
     const frontendCovers = await page.locator('.campaign-card-column').all();
     for (const [, cover] of frontendCovers.entries()) {
-      expect(cover.locator('a > div.thumbnail-large >img')).toBeVisible();
-      expect(cover.locator('.yellow-cta')).toBeVisible();
+      await expect(cover.locator('a > div.thumbnail-large >img')).toBeVisible();
+      await expect(cover.locator('.yellow-cta')).toBeVisible();
       let tagName = await cover.locator('.yellow-cta').innerText();
       tagName = tagName.replace(/#/g, '');
-      expect(TAG_NAMES.includes(tagName)).toBe(true);
+      expect(TAG_NAMES.includes(tagName)).toBeTruthy();
     }
   } else if (style === 'Take Action') {
     await expect(page.locator('.take-action-covers-block')).toBeVisible();
     const frontendCovers = await page.locator('.cover-card').all();
     for (const [, cover] of frontendCovers.entries()) {
-      expect(cover.locator('a > img')).toBeVisible();
-      let coverName = await cover.locator('a.cover-card-heading').innerText();
+      await expect(cover.locator('a > img')).toBeVisible();
+      const coverName = await cover.locator('a.cover-card-heading').innerText();
       expect(PAGE_NAMES.includes(coverName)).toBe(true);
-      expect(cover.locator('.cover-card-tag')).toBeVisible();
-      expect(cover.locator('.cover-card-excerpt')).toBeVisible();
-      expect(cover.locator('a.cover-card-btn')).toHaveText('Get Involved');
+      await expect(cover.locator('.cover-card-tag')).toBeVisible();
+      await expect(cover.locator('.cover-card-excerpt')).toBeVisible();
+      await expect(cover.locator('a.cover-card-btn')).toHaveText('Get Involved');
     }
   }
 

--- a/tests/e2e/tools/lib/covers.js
+++ b/tests/e2e/tools/lib/covers.js
@@ -19,33 +19,36 @@ async function addCoversBlock(page, style = '') {
 
   if (style === 'Take Action') {
     // Fill in the Posts.
-    await page.locator('input[placeholder="Select pages"]').type(PAGE_NAMES[0]);
+    const postsInput = await page.getByLabel('Select pages');
+    await postsInput.type(PAGE_NAMES[0]);
     await page.locator('li.components-form-token-field__suggestion').click();
-    await page.locator('input.components-form-token-field__input').type(PAGE_NAMES[1]);
+    await postsInput.type(PAGE_NAMES[1]);
     await page.locator('li.components-form-token-field__suggestion').click();
-    await page.locator('input.components-form-token-field__input').type(PAGE_NAMES[2]);
+    await postsInput.type(PAGE_NAMES[2]);
     await page.locator('li.components-form-token-field__suggestion').click();
   } else {
     // Fill in the tags.
-    await page.locator('input[placeholder="Select Tags"]').type(TAG_NAMES[0]);
+    const tagsInput = await page.getByLabel('Select Tags');
+    await tagsInput.type(TAG_NAMES[0]);
     await page.locator('li.components-form-token-field__suggestion').click();
-    await page.locator('input.components-form-token-field__input').nth(0).type(TAG_NAMES[1]);
+    await tagsInput.type(TAG_NAMES[1]);
     await page.locator('li.components-form-token-field__suggestion').click();
-    await page.locator('input.components-form-token-field__input').nth(0).type(TAG_NAMES[2]);
+    await tagsInput.type(TAG_NAMES[2]);
     await page.locator('li.components-form-token-field__suggestion').click();
-    await page.locator('input.components-form-token-field__input').nth(0).type(TAG_NAMES[3]);
+    await tagsInput.type(TAG_NAMES[3]);
     await page.locator('li.components-form-token-field__suggestion').click();
   }
 
   // Default style, i.e 'Content cover'.
   if (style === 'Default') {
     // Fill in the Post types.
-    await page.locator('input[placeholder="Select Post Types"]').type(POST_TYPES[0]);
+    const postTypesInput = await page.getByLabel('Select Post Types');
+    await postTypesInput.type(POST_TYPES[0]);
     await page.locator('li.components-form-token-field__suggestion').click();
-    await page.locator('input.components-form-token-field__input').nth(1).type(POST_TYPES[1]);
+    await postTypesInput.type(POST_TYPES[1]);
     await page.locator('li.components-form-token-field__suggestion').click();
   }
-  await page.locator('input[placeholder="Override button text"]').fill('Read more');
+  await page.getByLabel('Button Text').fill('Read more');
 }
 
 async function checkCoversBlock(page, style) {

--- a/tests/e2e/tools/lib/login.js
+++ b/tests/e2e/tools/lib/login.js
@@ -3,11 +3,11 @@ import {nonce} from './nonce';
 async function login(context) {
   // Login to admin using request context.
   const response = await context.request.post('./wp-login.php', {
-      failOnStatusCode: true,
-      form: {
-          log: process.env.WP_TEST_USERNAME || 'admin',
-          pwd: process.env.WP_TEST_PASSWORD || 'admin',
-      },
+    failOnStatusCode: true,
+    form: {
+      log: process.env.WP_TEST_USERNAME || 'admin',
+      pwd: process.env.WP_TEST_PASSWORD || 'admin',
+    },
   });
   await response.dispose();
 

--- a/tests/e2e/tools/lib/new-page.js
+++ b/tests/e2e/tools/lib/new-page.js
@@ -12,7 +12,7 @@ async function newPage(page, context, opts = {}) {
   // Need to close modal so test can continue.
   await page.waitForSelector('.components-modal__header');
   await page.locator('.components-modal__header button').click();
-  expect(page.locator('.components-modal__header')).toBeHidden();
+  await expect(page.locator('.components-modal__header')).toBeHidden();
 
   // Fill in page title.
   await page.locator('.editor-post-title__input').click();
@@ -20,9 +20,9 @@ async function newPage(page, context, opts = {}) {
 }
 
 async function publishPage(page) {
-  await page.getByRole('button', { name: 'Publish', exact: true }).click();
-  await page.getByRole('region', { name: 'Editor publish' }).getByRole('button', { name: 'Publish', exact: true }).click();
-  await page.getByRole('link', { name: 'View Page', exact: true }).first().click();
+  await page.getByRole('button', {name: 'Publish', exact: true}).click();
+  await page.getByRole('region', {name: 'Editor publish'}).getByRole('button', {name: 'Publish', exact: true}).click();
+  await page.getByRole('link', {name: 'View Page', exact: true}).first().click();
 }
 
 export {newPage, publishPage};

--- a/tests/e2e/tools/lib/new-post.js
+++ b/tests/e2e/tools/lib/new-post.js
@@ -1,3 +1,4 @@
+const {expect} = require('@playwright/test');
 import {login} from './login';
 
 async function newPost(page, context) {
@@ -12,6 +13,7 @@ async function newPost(page, context) {
   const closeButton = page.locator('.components-modal__header button');
   if (await closeButton.isVisible()) {
     await closeButton.click();
+    await expect(closeButton).toBeHidden();
   }
 
   // Fill in post title.
@@ -20,9 +22,9 @@ async function newPost(page, context) {
 }
 
 async function publishPost(page) {
-  await page.getByRole('button', { name: 'Publish', exact: true }).click();
-  await page.getByRole('region', { name: 'Editor publish' }).getByRole('button', { name: 'Publish', exact: true }).click();
-  await page.getByRole('link', { name: 'View Post', exact: true }).first().click();
+  await page.getByRole('button', {name: 'Publish', exact: true}).click();
+  await page.getByRole('region', {name: 'Editor publish'}).getByRole('button', {name: 'Publish', exact: true}).click();
+  await page.getByRole('link', {name: 'View Post', exact: true}).first().click();
 }
 
 export {newPost, publishPost};

--- a/tests/e2e/tools/lib/nonce.js
+++ b/tests/e2e/tools/lib/nonce.js
@@ -2,7 +2,7 @@
 async function nonce(context) {
   const response = await context.request.get(
     './wp-admin/admin-ajax.php?action=rest-nonce',
-    {failOnStatusCode: true,}
+    {failOnStatusCode: true}
   );
 
   const adminNonce = await response.text();


### PR DESCRIPTION
### Description

This PR includes several things:
- removing/adding some `await` statements
- linting fixes
- adding image selection to the Columns Images test so that the attachments are always there in the frontend
- rewriting parts of the Covers tests, making them easier to read and hopefully less flaky 🤞 

### Testing

All tests should still pass, but the Covers one with `Take Action` style has an issue where sometimes the block crashes when trying to manually select pages, I'm still looking into that 👀 
