### PR TITLE
PLANET-7081 Convert Get Informed pattern layout to block template

### DIFF
--- a/assets/src/block-templates/get-informed/block.json
+++ b/assets/src/block-templates/get-informed/block.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-block-templates/get-informed",
+  "title": "Get Informed",
+  "category": "planet4-block-templates",
+  "icon": "editor-table",
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/block-templates/get-informed/index.js
+++ b/assets/src/block-templates/get-informed/index.js
@@ -1,0 +1,4 @@
+import metadata from './block.json';
+import template from './template';
+
+export {metadata, template};

--- a/assets/src/block-templates/get-informed/template.js
+++ b/assets/src/block-templates/get-informed/template.js
@@ -1,0 +1,37 @@
+import gravityFormWithText from '../templates/gravity-form-with-text';
+
+const {__} = wp.i18n;
+
+const template = () => ([
+  ['core/group', {className: 'block'}, [
+    ['planet4-block-templates/quick-links', {
+      title: __('Explore by topics', 'planet4-blocks'),
+    }],
+    ['planet4-block-templates/side-image-with-text-and-cta', {
+      title: __('Topic 1', 'planet4-blocks'),
+    }],
+    ['planet4-block-templates/side-image-with-text-and-cta', {
+      title: __('Topic 2', 'planet4-blocks'),
+      mediaPosition: 'right',
+    }],
+    ['planet4-block-templates/side-image-with-text-and-cta', {
+      title: __('Topic 3', 'planet4-blocks'),
+    }],
+    ['planet4-block-templates/issues', {
+      title: __('The issues we work on', 'planet4-blocks'),
+    }],
+    ['planet4-blocks/articles', {
+      article_heading: __('Our recent victories', 'planet4-blocks'),
+    }],
+    ['planet4-blocks/gallery', {
+      className: 'is-style-grid',
+      gallery_block_title: __('Our latest actions around the world', 'planet4-blocks'),
+    }],
+    ['planet4-blocks/articles', {
+      article_heading: __('Latest news & stories', 'planet4-blocks'),
+    }],
+    gravityFormWithText(),
+  ]],
+]);
+
+export default template;

--- a/assets/src/block-templates/homepage/template.js
+++ b/assets/src/block-templates/homepage/template.js
@@ -7,7 +7,7 @@ const template = () => (
     ['core/group', {}, [
       ['planet4-blocks/carousel-header'],
       ['planet4-block-templates/issues', {
-        titlePlaceholder: __('The issues we work on', 'planet4-blocks'),
+        title: __('The issues we work on', 'planet4-blocks'),
       }],
       ['core/spacer', {height: '88px'}],
       ['planet4-blocks/articles', {

--- a/assets/src/block-templates/issues/block.json
+++ b/assets/src/block-templates/issues/block.json
@@ -8,6 +8,6 @@
   "textdomain": "planet4-blocks-backend",
   "attributes": {
     "backgroundColor": { "type": "string" },
-    "titlePlaceholder": { "type": "string" }
+    "title": { "type": "string" }
   }
 }

--- a/assets/src/block-templates/issues/template.js
+++ b/assets/src/block-templates/issues/template.js
@@ -45,7 +45,7 @@ const item = ['core/group', {
 
 const template = ({
   backgroundColor = isNewIdentity ? 'beige-100' : 'grey-05',
-  titlePlaceholder = __('Enter title', 'planet4-blocks-backend'),
+  title = '',
 }) => ([
   ['core/group', {
     align: 'full',
@@ -66,7 +66,8 @@ const template = ({
     }, [
       ['core/heading', {
         level: 2,
-        placeholder: titlePlaceholder,
+        content: title,
+        placeholder: __('Enter title', 'planet4-blocks-backend'),
         style: {
           spacing: {
             margin: {

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -10,6 +10,7 @@ import * as homepage from './homepage';
 import * as campaign from './campaign';
 import * as takeAction from './take-action';
 import * as action from './action';
+import * as getInformed from './get-informed';
 
 export default [
   sideImgTextCta,
@@ -26,4 +27,5 @@ export default [
   campaign,
   takeAction,
   action,
+  getInformed,
 ];

--- a/classes/patterns/class-getinformed.php
+++ b/classes/patterns/class-getinformed.php
@@ -8,8 +8,6 @@
 
 namespace P4GBKS\Patterns;
 
-use P4GBKS\Patterns\Templates\GravityFormWithText;
-
 /**
  * Class Get Informed.
  *
@@ -30,37 +28,12 @@ class GetInformed extends Block_Pattern {
 	 * @param array $params Optional array of parameters for the config.
 	 */
 	public static function get_config( $params = [] ): array {
-		$classname = self::get_classname();
 		return [
 			'title'      => 'Get Informed',
 			'blockTypes' => [ 'core/post-content' ],
 			'categories' => [ 'layouts' ],
 			'content'    => '
-				<!-- wp:group {"className":"block ' . $classname . '"} -->
-					<div class="wp-block-group block ' . $classname . '">
-						' . QuickLinks::get_config( [ 'title' => __( 'Explore by topic', 'planet4-blocks' ) ] )['content'] . '
-						' . SideImageWithTextAndCta::get_config(
-							[ 'title' => __( 'Topic 1', 'planet4-blocks' ) ]
-						)['content'] . '
-						' . SideImageWithTextAndCta::get_config(
-							[
-								'title'         => __( 'Topic 2', 'planet4-blocks' ),
-								'mediaPosition' => 'right',
-							]
-						)['content'] . '
-						' . SideImageWithTextAndCta::get_config(
-							[ 'title' => __( 'Topic 3', 'planet4-blocks' ) ]
-						)['content'] . '
-						' . Issues::get_config( [ 'title_placeholder' => __( 'Issues we work on', 'planet4-blocks' ) ] )['content'] . '
-						<!-- wp:planet4-blocks/articles {"article_heading":"' . __( 'Our recent victories', 'planet4-blocks' ) . '"} /-->
-						<!-- wp:planet4-blocks/gallery {
-							"className":"is-style-grid",
-							"gallery_block_title":"' . __( 'Our latest actions around the world', 'planet4-blocks' ) . '"
-						} /-->
-						<!-- wp:planet4-blocks/articles {"article_heading":"' . __( 'Latest news & stories', 'planet4-blocks' ) . '"} /-->
-						' . GravityFormWithText::get_content() . '
-					</div>
-				<!-- /wp:group -->
+				<!-- wp:planet4-block-templates/get-informed ' . wp_json_encode( $params, \JSON_FORCE_OBJECT ) . ' /-->
 			',
 		];
 	}

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -217,6 +217,7 @@ const BLOCK_TEMPLATES = [
 	'planet4-block-templates/campaign',
 	'planet4-block-templates/take-action',
 	'planet4-block-templates/action',
+	'planet4-block-templates/get-informed',
 ];
 
 /**


### PR DESCRIPTION
### Description

See [PLANET-7081](https://jira.greenpeace.org/browse/PLANET-7081)
This is easier to write and maintain

### Testing

Either on local or on the test instance, you should still be able to add the `Get Informed` pattern layout, and it should look the same as before.