### PR TITLE
PLANET-7189 Remove our uses of ReactDOM.render

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselHeaderBlock.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderBlock.js
@@ -1,7 +1,7 @@
 import {CarouselHeaderEditor} from './CarouselHeaderEditor.js';
 import {carouselHeaderV1} from './deprecated/carouselHeaderV1.js';
 import {CarouselHeaderFrontend} from './CarouselHeaderFrontend';
-import ReactDOMServer from 'react-dom/server';
+import {renderToString} from 'react-dom/server';
 
 const {registerBlockType} = wp.blocks;
 const {__} = wp.i18n;
@@ -57,7 +57,7 @@ export const registerCarouselHeaderBlock = () =>
     ],
     edit: CarouselHeaderEditor,
     save: ({attributes: saveAttributes}) => {
-      const markup = ReactDOMServer.renderToString(<div
+      const markup = renderToString(<div
         data-hydrate={'planet4-blocks/carousel-header'}
         data-attributes={JSON.stringify(saveAttributes)}
       >

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderScript.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderScript.js
@@ -1,11 +1,13 @@
 import {CarouselHeaderFrontend} from './CarouselHeaderFrontend';
 import {hydrateBlock} from '../../functions/hydrateBlock';
+import {createRoot} from 'react-dom/client';
 
 hydrateBlock('planet4-blocks/carousel-header', CarouselHeaderFrontend);
 // Fallback for non migrated content. Remove after migration.
 document.querySelectorAll('[data-render=\'planet4-blocks/carousel-header\']').forEach(
   blockNode => {
     const attributes = JSON.parse(blockNode.dataset.attributes);
-    wp.element.render(<CarouselHeaderFrontend {...attributes.attributes} />, blockNode);
+    const rootElement = createRoot(blockNode);
+    rootElement.render(<CarouselHeaderFrontend {...attributes.attributes} />);
   }
 );

--- a/assets/src/blocks/Covers/CoversScript.js
+++ b/assets/src/blocks/Covers/CoversScript.js
@@ -1,8 +1,10 @@
 import {CoversFrontend} from './CoversFrontend';
+import {createRoot} from 'react-dom/client';
 
 document.querySelectorAll('[data-render="planet4-blocks/covers"]').forEach(
   blockNode => {
     const attributes = JSON.parse(blockNode.dataset.attributes);
-    wp.element.render(<CoversFrontend {...attributes.attributes} />, blockNode);
+    const rootElement = createRoot(blockNode);
+    rootElement.render(<CoversFrontend {...attributes.attributes} />);
   }
 );

--- a/assets/src/blocks/ENForm/ENFormScript.js
+++ b/assets/src/blocks/ENForm/ENFormScript.js
@@ -1,8 +1,10 @@
 import {ENFormFrontend} from './ENFormFrontend';
+import {createRoot} from 'react-dom/client';
 
 document.querySelectorAll('[data-render=\'planet4-blocks/enform\']').forEach(
   blockNode => {
     const attributes = JSON.parse(blockNode.dataset.attributes);
-    wp.element.render(<ENFormFrontend {...attributes.attributes} />, blockNode);
+    const rootElement = createRoot(blockNode);
+    rootElement.render(<ENFormFrontend {...attributes.attributes} />);
   }
 );

--- a/assets/src/blocks/Gallery/GalleryBlock.js
+++ b/assets/src/blocks/Gallery/GalleryBlock.js
@@ -1,4 +1,4 @@
-import ReactDOMServer from 'react-dom/server';
+import {renderToString} from 'react-dom/server';
 import {GalleryEditor} from './GalleryEditor';
 import {frontendRendered} from '../frontendRendered';
 import {getStyleLabel} from '../../functions/getStyleLabel';
@@ -55,7 +55,7 @@ export const registerGalleryBlock = () => {
     edit: GalleryEditor,
     save: props => {
       const {attributes: saveAttributes} = props;
-      const markup = ReactDOMServer.renderToString(
+      const markup = renderToString(
         <div
           data-hydrate={BLOCK_NAME}
           data-attributes={JSON.stringify(saveAttributes)}

--- a/assets/src/blocks/Spreadsheet/SpreadsheetScript.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetScript.js
@@ -1,10 +1,12 @@
 import {SpreadsheetFrontend} from './SpreadsheetFrontend';
+import {createRoot} from 'react-dom/client';
 
 document.addEventListener('DOMContentLoaded', () => {
   const spreadsheetBlocks = [...document.querySelectorAll('[data-render="planet4-blocks/spreadsheet"]')];
 
   spreadsheetBlocks.forEach(blockNode => {
     const attributes = JSON.parse(blockNode.dataset.attributes);
-    wp.element.render(<SpreadsheetFrontend {...attributes.attributes} />, blockNode);
+    const rootElement = createRoot(blockNode);
+    rootElement.render(<SpreadsheetFrontend {...attributes.attributes} />);
   });
 });

--- a/assets/src/components/Lightbox/setupLightboxForImages.js
+++ b/assets/src/components/Lightbox/setupLightboxForImages.js
@@ -1,4 +1,5 @@
 import {Lightbox} from './Lightbox';
+import {createRoot} from 'react-dom/client';
 
 const setupImageAndCaption = (lightBoxNode, imageSelector = 'img', captionSelector = null) => {
   // Returns the callback for `forEach`
@@ -19,12 +20,9 @@ const setupImageAndCaption = (lightBoxNode, imageSelector = 'img', captionSelect
     if (caption) {
       item.title = caption.innerHTML;
     }
+    const rootElement = createRoot(lightBoxNode);
 
-    imageBlock.querySelector('img').addEventListener('click', () => wp.element.render(
-      <Lightbox isOpen={true} index={index} items={[item]} />,
-      lightBoxNode
-    )
-    );
+    imageBlock.querySelector('img').addEventListener('click', () => rootElement.render(<Lightbox isOpen={true} index={index} items={[item]} />));
   };
 };
 

--- a/assets/src/frontendIndex.js
+++ b/assets/src/frontendIndex.js
@@ -12,6 +12,8 @@ import {setupLightboxForImages} from './components/Lightbox/setupLightboxForImag
 import {ENFormFrontend} from './blocks/ENForm/ENFormFrontend';
 import {setupParallax} from './components/Parallax/setupParallax';
 
+import {createRoot} from 'react-dom/client';
+
 // Render React components
 const COMPONENTS = {
   'planet4-blocks/counter': CounterFrontend,
@@ -39,7 +41,8 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
       const attributes = JSON.parse(blockNode.dataset.attributes);
-      wp.element.render(<BlockFrontend {...attributes.attributes} />, blockNode);
+      const rootElement = createRoot(blockNode);
+      rootElement.render(<BlockFrontend {...attributes.attributes} />);
     }
   );
 

--- a/assets/src/functions/hydrateBlock.js
+++ b/assets/src/functions/hydrateBlock.js
@@ -1,4 +1,4 @@
-import {hydrate} from 'react-dom';
+import {hydrateRoot} from 'react-dom/client';
 
 /**
  * This function hydrate a SSR Component
@@ -13,7 +13,7 @@ export const hydrateBlock = (blockName, Component, csrAttributes = {}) => { // e
   blocks.forEach(
     blockNode => {
       const attributes = JSON.parse(blockNode.dataset.attributes);
-      hydrate(<Component {...attributes} {...csrAttributes} />, blockNode);
+      hydrateRoot(blockNode, <Component {...attributes} {...csrAttributes} />);
     }
   );
 };


### PR DESCRIPTION
**Description: [PLANET-7189](https://jira.greenpeace.org/browse/PLANET-7189)**

**Testing:**

Nothing should change visually, only upgraded imports to match React 18 [recommendations](https://react.dev/blog/2022/03/08/react-18-upgrade-guide).


<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
