### PR TITLE
Fix broken page on gcloud 403

### DIFF
--- a/classes/blocks/class-carouselheader.php
+++ b/classes/blocks/class-carouselheader.php
@@ -151,15 +151,19 @@ class CarouselHeader extends Base_Block {
 	private static function get_slides_image_data( $slides ): array {
 		if ( ! empty( $slides ) ) {
 			foreach ( $slides as &$slide ) {
-				$image_id   = $slide['image'];
-				$temp_array = wp_get_attachment_image_src( $image_id, 'retina-large' );
-				if ( false !== $temp_array && ! empty( $temp_array ) ) {
-					$slide['image_url']    = $temp_array[0];
-					$slide['image_srcset'] = wp_get_attachment_image_srcset( $image_id, 'retina-large', wp_get_attachment_metadata( $image_id ) );
-				}
+				try {
+					$image_id   = $slide['image'];
+					$temp_array = wp_get_attachment_image_src( $image_id, 'retina-large' );
+					if ( false !== $temp_array && ! empty( $temp_array ) ) {
+						$slide['image_url']    = $temp_array[0];
+						$slide['image_srcset'] = wp_get_attachment_image_srcset( $image_id, 'retina-large', wp_get_attachment_metadata( $image_id ) );
+					}
 
-				$temp_image         = wp_prepare_attachment_for_js( $image_id );
-				$slide['image_alt'] = $temp_image['alt'] ?? '';
+					$temp_image         = wp_prepare_attachment_for_js( $image_id );
+					$slide['image_alt'] = $temp_image['alt'] ?? '';
+				} catch ( \Exception $e ) {
+					function_exists( '\Sentry\captureException' ) && \Sentry\captureException( $e );
+				}
 			}
 		}
 


### PR DESCRIPTION
Ref: https://sentry.greenpeace.org/organizations/greenpeace-org/issues/802/
```
Twig\Error\RuntimeError

An exception has been thrown during the rendering of a template ("{"error":{"code":403,"message":"testgpap@planet-4-151612.iam.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist).","errors":[{"message":"testgpap@planet-4-151612.iam.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist).","domain":"global","reason":"forbidden"}]}}").
```

Catch exception instead of crashing when gcloud returns 403 for images in Carousel.

- This was breaking homepage on https://www-dev.greenpeace.org/test-gpap/
- fix [deployed](https://github.com/greenpeace/planet4-test-gpap/commit/c020b931d556016dac4e6f6d683305abdd9e4244) on test-gpap, homepage is accessible again