### PR TITLE
PLANET-7217 Fix carousel header flicker issue

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -1,9 +1,9 @@
 const {__} = wp.i18n;
 
 export const CarouselControls = ({
-  goToPrevSlide = null,
-  goToNextSlide = null,
-  goToSlide = null,
+  goToPrevSlide = () => {},
+  goToNextSlide = () => {},
+  goToSlide = () => {},
   currentSlide = null,
   slides = null,
 }) => slides.length > 1 && (

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
@@ -102,7 +102,7 @@ export const CarouselHeaderEditor = ({setAttributes, attributes}) => {
           {slides?.map((slide, index) => (
             <Slide
               key={index}
-              ref={element => slidesRef.current[index] = element}
+              ref={element => slidesRef ? slidesRef.current[index] = element : null}
               active={currentSlide === index}
             >
               <EditableBackground
@@ -124,8 +124,8 @@ export const CarouselHeaderEditor = ({setAttributes, attributes}) => {
             </Slide>
           ))}
           <CarouselControls
-            goToPrevSlide={goToPrevSlide}
-            goToNextSlide={goToNextSlide}
+            goToPrevSlide={() => goToPrevSlide(carousel_autoplay)}
+            goToNextSlide={() => goToNextSlide(carousel_autoplay)}
             goToSlide={goToSlide}
             slides={slides}
             currentSlide={currentSlide}

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
@@ -53,7 +53,7 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className}) =
       hammer.off('swipeleft', isRTL ? goToPrevSlide : goToNextSlide);
       hammer.off('swiperight', isRTL ? goToNextSlide : goToPrevSlide);
     };
-  }, [currentSlide]);
+  }, [currentSlide, goToNextSlide, goToPrevSlide]);
 
   useEffect(() => {
     if (!containerRef.current) {
@@ -68,7 +68,7 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className}) =
     }
 
     return () => window.removeEventListener('resize', () => setCarouselHeight(currentSlideRef));
-  }, []);
+  }, [currentSlide, setCarouselHeight]);
 
   // Set up the autoplay for the slides
   const timerRef = useRef(null);
@@ -85,7 +85,7 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className}) =
     } else if (timerRef.current) {
       clearTimeout(timerRef.current);
     }
-  }, [currentSlide, slides, carousel_autoplay, autoplayPaused, autoplayCancelled, pageLoaded]);
+  }, [currentSlide, goToNextSlide, slides, carousel_autoplay, autoplayPaused, autoplayCancelled, pageLoaded]);
 
   return (
     <section
@@ -107,8 +107,8 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className}) =
             </Slide>
           ))}
           <CarouselControls
-            goToPrevSlide={goToPrevSlide}
-            goToNextSlide={goToNextSlide}
+            goToPrevSlide={() => goToPrevSlide(carousel_autoplay)}
+            goToNextSlide={() => goToNextSlide(carousel_autoplay)}
             goToSlide={goToSlide}
             slides={slides}
             currentSlide={currentSlide}

--- a/assets/src/blocks/CarouselHeader/Sidebar.js
+++ b/assets/src/blocks/CarouselHeader/Sidebar.js
@@ -148,7 +148,7 @@ export const Sidebar = ({
         slidesRef.current.insertBefore(draggedSlide, dragTarget);
       }
     }
-  }, [dragTarget]);
+  }, [dragTarget, draggedSlide]);
 
   return <InspectorControls>
     <PanelBody title={__('Settings', 'planet4-blocks-backend')}>

--- a/assets/src/blocks/CarouselHeader/SidebarSlide.js
+++ b/assets/src/blocks/CarouselHeader/SidebarSlide.js
@@ -43,7 +43,7 @@ export const SidebarSlide = ({
     if (isOpened) {
       goToSlideHandler(index);
     }
-  }, [isOpened]);
+  }, [isOpened, goToSlideHandler, index]);
 
   return (
     <div

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -1,4 +1,6 @@
-import {useState} from '@wordpress/element';
+import {useEffect, useState} from '@wordpress/element';
+
+const activeClass = 'active';
 
 /**
  * Takes an array of refs to the slides
@@ -39,9 +41,11 @@ export const useSlides = (slidesRef, lastSlide, containerRef, options = {
     }
   };
 
-  const goToPrevSlide = () => {
+  const goToPrevSlide = (autoplay = false) => {
     goToSlide(currentSlide === 0 ? lastSlide : currentSlide - 1);
-    setAutoplayCancelled(true);
+    if (!autoplay) {
+      setAutoplayCancelled(true);
+    }
   };
 
   // eslint-disable-next-line no-shadow
@@ -97,10 +101,13 @@ export const useSlides = (slidesRef, lastSlide, containerRef, options = {
       nextElement.classList.add(enterTransitionClass);
 
       const unsetTransitionClasses = () => {
-        activeElement.classList.remove(exitTransitionClass);
-        nextElement.classList.remove(enterTransitionClass);
         activeElement.removeEventListener('transitionend', unsetTransitionClasses);
-        setSliding(false);
+        activeElement.classList.remove(exitTransitionClass);
+        // Force to manually remove the `active` class to avoid the flicker issue
+        activeElement.classList.remove(activeClass);
+        nextElement.classList.remove(enterTransitionClass);
+        nextElement.classList.add(activeClass);
+
         setCurrentSlide(newSlide);
       };
 
@@ -114,6 +121,11 @@ export const useSlides = (slidesRef, lastSlide, containerRef, options = {
       }
     }
   };
+
+  useEffect(() => {
+    // Update the sliding flag only when the current slide is being changed
+    setSliding(false);
+  }, [currentSlide]);
 
   return {
     currentSlide,


### PR DESCRIPTION
Revert some change from [PLANET-7189](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/commit/7e6724d44c39abc4b734e879e6dd6f4a75de54e0#) PR

**Testing:**
- You can test fix at - https://www-dev.greenpeace.org/test-telesto/test-carousel-header-block-fliker-image-issue/

[Demo page](https://www-dev.greenpeace.org/test-telesto/carousel-header-demo-page/) with the fix (editor and frontend), also tested on the [international dev site](https://github.com/greenpeace/planet4-international/blob/main/composer-local.json#L6).