### PR TITLE
PLANET-6917 Refactor Counter block to use hydration

### DIFF
--- a/assets/src/blocks/Counter/CounterBlock.js
+++ b/assets/src/blocks/Counter/CounterBlock.js
@@ -50,13 +50,13 @@ export const registerCounterBlock = () => {
     },
     // eslint-disable-next-line no-shadow
     edit: CounterEditor,
-    save: ({attributes: saveAttributes}) => {
+    save: props => {
       const markup = renderToString(
         <div
           data-hydrate={BLOCK_NAME}
-          data-attributes={JSON.stringify(saveAttributes)}
+          data-attributes={JSON.stringify(props.attributes)}
         >
-          <CounterFrontend {...saveAttributes} />
+          <CounterFrontend {...props.attributes} />
         </div>
       );
       return <RawHTML>{markup}</RawHTML>;

--- a/assets/src/blocks/Counter/CounterBlock.js
+++ b/assets/src/blocks/Counter/CounterBlock.js
@@ -50,14 +50,13 @@ export const registerCounterBlock = () => {
     },
     // eslint-disable-next-line no-shadow
     edit: CounterEditor,
-    save: props => {
-      const {attributes: saveAttributes} = props;
+    save: ({attributes: saveAttributes}) => {
       const markup = renderToString(
         <div
           data-hydrate={BLOCK_NAME}
           data-attributes={JSON.stringify(saveAttributes)}
         >
-          <CounterFrontend {...props} />
+          <CounterFrontend {...saveAttributes} />
         </div>
       );
       return <RawHTML>{markup}</RawHTML>;

--- a/assets/src/blocks/Counter/CounterEditor.js
+++ b/assets/src/blocks/Counter/CounterEditor.js
@@ -1,90 +1,71 @@
-import {Component, Fragment} from '@wordpress/element';
 import {InspectorControls, RichText} from '@wordpress/block-editor';
 import {
   TextControl,
   TextareaControl,
   PanelBody,
 } from '@wordpress/components';
-
 import {URLInput} from '../../components/URLInput/URLInput';
-
 import {CounterFrontend} from './CounterFrontend';
 
 const {__} = wp.i18n;
 
-export class CounterEditor extends Component {
-  constructor(props) {
-    super(props);
+export const CounterEditor = ({setAttributes, attributes, isSelected}) => {
 
-    this.toAttribute = this.toAttribute.bind(this);
-  }
+  const toAttribute = attributeName => value => setAttributes({[attributeName]: value});
 
-  toAttribute(attributeName) {
-    const {setAttributes} = this.props;
-    return value => {
-      setAttributes({[attributeName]: value});
-    };
-  }
+  const renderEdit = () => (
+    <>
+      <InspectorControls>
+        <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
+          <div>
+            <TextControl
+              label={__('Completed', 'planet4-blocks-backend')}
+              placeholder={__('e.g. number of signatures', 'planet4-blocks-backend')}
+              type="number"
+              value={attributes.completed}
+              onChange={value => toAttribute('completed')(Number(value))}
+              min={0}
+            />
+          </div>
 
-  renderEdit() {
-    const {attributes} = this.props;
+          <div>
+            <URLInput
+              label={__('Completed API URL', 'planet4-blocks-backend')}
+              placeholder={__('API URL of completed number. If filled in will override the \'Completed\' field', 'planet4-blocks-backend')}
+              value={attributes.completed_api}
+              onChange={toAttribute('completed_api')}
+            />
+          </div>
 
-    return (
-      <Fragment>
-        <InspectorControls>
-          <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
-            <div>
-              <TextControl
-                label={__('Completed', 'planet4-blocks-backend')}
-                placeholder={__('e.g. number of signatures', 'planet4-blocks-backend')}
-                type="number"
-                value={attributes.completed}
-                onChange={value => this.toAttribute('completed')(Number(value))}
-                min={0}
-              />
-            </div>
+          <div>
+            <TextControl
+              label={__('Target', 'planet4-blocks-backend')}
+              placeholder={__('e.g. target no. of signatures', 'planet4-blocks-backend')}
+              type="number"
+              value={attributes.target}
+              onChange={value => toAttribute('target')(Number(value))}
+              min={0}
+            />
+          </div>
 
-            <div>
-              <URLInput
-                label={__('Completed API URL', 'planet4-blocks-backend')}
-                placeholder={__('API URL of completed number. If filled in will override the \'Completed\' field', 'planet4-blocks-backend')}
-                value={attributes.completed_api}
-                onChange={this.toAttribute('completed_api')}
-              />
-            </div>
+          <div>
+            <TextareaControl
+              label={__('Text', 'planet4-blocks-backend')}
+              placeholder={__('e.g. "signatures collected of %target%"', 'planet4-blocks-backend')}
+              value={attributes.text}
+              onChange={toAttribute('text')}
+            />
+          </div>
+          <div className="sidebar-blocks-help">
+            {__('These placeholders can be used:', 'planet4-blocks-backend')}{' '}<code>%completed%</code>, <code>%target%</code>, <code>%remaining%</code>
+          </div>
+        </PanelBody>
+      </InspectorControls>
+    </>
+  );
 
-            <div>
-              <TextControl
-                label={__('Target', 'planet4-blocks-backend')}
-                placeholder={__('e.g. target no. of signatures', 'planet4-blocks-backend')}
-                type="number"
-                value={attributes.target}
-                onChange={value => this.toAttribute('target')(Number(value))}
-                min={0}
-              />
-            </div>
-
-            <div>
-              <TextareaControl
-                label={__('Text', 'planet4-blocks-backend')}
-                placeholder={__('e.g. "signatures collected of %target%"', 'planet4-blocks-backend')}
-                value={attributes.text}
-                onChange={this.toAttribute('text')}
-              />
-            </div>
-            <div className="sidebar-blocks-help">
-              {__('These placeholders can be used:', 'planet4-blocks-backend')}{' '}<code>%completed%</code>, <code>%target%</code>, <code>%remaining%</code>
-            </div>
-          </PanelBody>
-        </InspectorControls>
-      </Fragment>
-    );
-  }
-
-  renderView() {
-    const {attributes} = this.props;
-
-    return <Fragment>
+  const renderView = () => (
+    <>
       <div className="counter-block">
         <header>
           <RichText
@@ -92,7 +73,7 @@ export class CounterEditor extends Component {
             className="page-section-header"
             placeholder={__('Enter title', 'planet4-blocks-backend')}
             value={attributes.title}
-            onChange={this.toAttribute('title')}
+            onChange={toAttribute('title')}
             withoutInteractiveFormatting
             multiline="false"
             allowedFormats={[]}
@@ -103,25 +84,19 @@ export class CounterEditor extends Component {
           className="page-section-description"
           placeholder={__('Enter description', 'planet4-blocks-backend')}
           value={attributes.description}
-          onChange={this.toAttribute('description')}
+          onChange={toAttribute('description')}
           withoutInteractiveFormatting
           allowedFormats={['core/bold', 'core/italic']}
         />
       </div>
       <CounterFrontend isEditing {...attributes} />
-    </Fragment>;
-  }
+    </>
+  );
 
-  render() {
-    return (
-      <Fragment>
-        {
-          this.props.isSelected ?
-            this.renderEdit() :
-            null
-        }
-        {this.renderView()}
-      </Fragment>
-    );
-  }
-}
+  return (
+    <>
+      {isSelected ? renderEdit() : null}
+      {renderView()}
+    </>
+  );
+};

--- a/assets/src/blocks/Counter/CounterEditorScript.js
+++ b/assets/src/blocks/Counter/CounterEditorScript.js
@@ -1,0 +1,3 @@
+import {registerCounterBlock} from './CounterBlock';
+
+registerCounterBlock();

--- a/assets/src/blocks/Counter/CounterFrontend.js
+++ b/assets/src/blocks/Counter/CounterFrontend.js
@@ -1,4 +1,4 @@
-import {Component, Fragment} from '@wordpress/element';
+import {Component} from '@wordpress/element';
 import {getStyleFromClassName} from '../getStyleFromClassName';
 
 export class CounterFrontend extends Component {
@@ -118,7 +118,7 @@ export class CounterFrontend extends Component {
     }
 
     return (
-      <Fragment>
+      <>
         <section className={counterClassName}>
           {title && !isEditing &&
             <header>
@@ -151,7 +151,7 @@ export class CounterFrontend extends Component {
             }
           </div>
         </section>
-      </Fragment>
+      </>
     );
   }
 }

--- a/assets/src/blocks/Counter/CounterFrontend.js
+++ b/assets/src/blocks/Counter/CounterFrontend.js
@@ -118,40 +118,38 @@ export class CounterFrontend extends Component {
     }
 
     return (
-      <>
-        <section className={counterClassName}>
-          {title && !isEditing &&
-            <header>
-              <h2 className="page-section-header">{title}</h2>
-            </header>
+      <section className={counterClassName}>
+        {title && !isEditing &&
+          <header>
+            <h2 className="page-section-header">{title}</h2>
+          </header>
+        }
+        {description && !isEditing &&
+          <p className="page-section-description" dangerouslySetInnerHTML={{__html: description}} />
+        }
+        <div className="content-counter">
+          {(style === 'bar' || style === 'en-forms-bar') &&
+            <div className="progress-container">
+              <div className={`progress-bar ${style === 'en-forms-bar' ? 'enform-progress-bar' : ''}`} style={{width: `calc(${percent}% + 20px)`}} />
+            </div>
           }
-          {description && !isEditing &&
-            <p className="page-section-description" dangerouslySetInnerHTML={{__html: description}} />
+          {style === 'arc' &&
+            <svg className="progress-arc" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 24 14">
+              <path className="background" d="M 2 12 A 1 1 0 1 1 22 12" />
+              <path className="foreground" d="M 2 12 A 1 1 0 1 1 22 12"
+                strokeDasharray={arcLength}
+                strokeDashoffset={`${(1 - (percent / 100)) * arcLength}`} />
+            </svg>
           }
-          <div className="content-counter">
-            {(style === 'bar' || style === 'en-forms-bar') &&
-              <div className="progress-container">
-                <div className={`progress-bar ${style === 'en-forms-bar' ? 'enform-progress-bar' : ''}`} style={{width: `calc(${percent}% + 20px)`}} />
-              </div>
-            }
-            {style === 'arc' &&
-              <svg className="progress-arc" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 24 14">
-                <path className="background" d="M 2 12 A 1 1 0 1 1 22 12" />
-                <path className="foreground" d="M 2 12 A 1 1 0 1 1 22 12"
-                  strokeDasharray={arcLength}
-                  strokeDashoffset={`${(1 - (percent / 100)) * arcLength}`} />
-              </svg>
-            }
-            {text &&
-              <div
-                className={`counter-text ${100 <= percent ? 'counter-text-goal_reached' : ''}`}
-                role="presentation"
-                dangerouslySetInnerHTML={{__html: this.getCounterText()}}
-              />
-            }
-          </div>
-        </section>
-      </>
+          {text &&
+            <div
+              className={`counter-text ${100 <= percent ? 'counter-text-goal_reached' : ''}`}
+              role="presentation"
+              dangerouslySetInnerHTML={{__html: this.getCounterText()}}
+            />
+          }
+        </div>
+      </section>
     );
   }
 }

--- a/assets/src/blocks/Counter/CounterScript.js
+++ b/assets/src/blocks/Counter/CounterScript.js
@@ -1,0 +1,5 @@
+import {CounterFrontend} from './CounterFrontend';
+import {hydrateBlock} from '../../functions/hydrateBlock';
+import {BLOCK_NAME} from './CounterBlock';
+
+hydrateBlock(BLOCK_NAME, CounterFrontend);

--- a/assets/src/blocks/Counter/CounterScript.js
+++ b/assets/src/blocks/Counter/CounterScript.js
@@ -1,5 +1,15 @@
 import {CounterFrontend} from './CounterFrontend';
 import {hydrateBlock} from '../../functions/hydrateBlock';
 import {BLOCK_NAME} from './CounterBlock';
+import {createRoot} from 'react-dom/client';
 
 hydrateBlock(BLOCK_NAME, CounterFrontend);
+
+// Fallback for non migrated content. Remove after migration.
+document.querySelectorAll(`[data-render="${BLOCK_NAME}"]`).forEach(
+  blockNode => {
+    const attributes = JSON.parse(blockNode.dataset.attributes);
+    const rootElement = createRoot(blockNode);
+    rootElement.render(<CounterFrontend {...attributes.attributes} />);
+  }
+);

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -1,7 +1,6 @@
 import {ArticlesBlock} from './blocks/Articles/ArticlesBlock';
 import {registerColumnsBlock} from './blocks/Columns/ColumnsBlock';
 import {CookiesBlock} from './blocks/Cookies/CookiesBlock';
-import {CounterBlock} from './blocks/Counter/CounterBlock';
 import {HappypointBlock} from './blocks/Happypoint/HappypointBlock';
 import {registerMediaBlock} from './blocks/Media/MediaBlock';
 import {registerSocialMediaBlock} from './blocks/SocialMedia/SocialMediaBlock';
@@ -27,7 +26,6 @@ blockEditorValidation();
 new ArticlesBlock();
 registerColumnsBlock();
 new CookiesBlock();
-new CounterBlock();
 new HappypointBlock();
 registerMediaBlock();
 registerSocialMediaBlock();

--- a/assets/src/frontendIndex.js
+++ b/assets/src/frontendIndex.js
@@ -1,4 +1,3 @@
-import {CounterFrontend} from './blocks/Counter/CounterFrontend';
 import {ArticlesFrontend} from './blocks/Articles/ArticlesFrontend';
 import {CookiesFrontend} from './blocks/Cookies/CookiesFrontend';
 import {SplittwocolumnsFrontend} from './blocks/Splittwocolumns/SplittwocolumnsFrontend';
@@ -15,7 +14,6 @@ import {createRoot} from 'react-dom/client';
 
 // Render React components
 const COMPONENTS = {
-  'planet4-blocks/counter': CounterFrontend,
   'planet4-blocks/articles': ArticlesFrontend,
   'planet4-blocks/cookies': CookiesFrontend,
   'planet4-blocks/split-two-columns': SplittwocolumnsFrontend,

--- a/assets/src/styles/blocks.scss
+++ b/assets/src/styles/blocks.scss
@@ -1,7 +1,6 @@
 // P4 Blocks
 @import "blocks/Articles";
 @import "blocks/Columns";
-@import "blocks/Counter";
 @import "blocks/File";
 @import "blocks/Happypoint";
 @import "blocks/Media";

--- a/assets/src/styles/blocks/Counter/CounterStyle.scss
+++ b/assets/src/styles/blocks/Counter/CounterStyle.scss
@@ -1,3 +1,6 @@
+@import "../../master-theme/assets/src/scss/base/colors";
+@import "../../master-theme/assets/src/scss/base/variables";
+
 .counter-block {
   _-- {
     font-family: var(--headings--font-family);

--- a/classes/blocks/class-counter.php
+++ b/classes/blocks/class-counter.php
@@ -61,6 +61,9 @@ class Counter extends Base_Block {
 				],
 			]
 		);
+
+		add_action( 'enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ] );
+		add_action( 'wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ] );
 	}
 
 	/**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,8 @@
-const defaultConfig = require('./node_modules/@wordpress/scripts/config/webpack.config');    // Require default Webpack config
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const defaultConfig = require("./node_modules/@wordpress/scripts/config/webpack.config");    // Require default Webpack config
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const TerserJSPlugin = require('terser-webpack-plugin');
-const FixStyleOnlyEntriesPlugin = require('webpack-fix-style-only-entries');
+const FixStyleOnlyEntriesPlugin = require("webpack-fix-style-only-entries");
 const dashDash = require('@greenpeace/dashdash');
 
 const mediaQueryAliases = {
@@ -17,12 +17,12 @@ const jsConfig = {
   ...defaultConfig,
   output: {
     filename: '[name].js',
-    path: __dirname + '/assets/build',
+    path: __dirname + '/assets/build'
   },
   optimization: {
     minimizer: [
       new TerserJSPlugin({}),
-    ],
+    ]
   },
 };
 
@@ -33,7 +33,7 @@ const publicJsConfig = {
       '@hooks': 'preact/hooks',
       '@render': 'preact',
       '@compat': 'preact/compat',
-    },
+    }
   },
   entry: {
     frontendIndex: './assets/src/frontendIndex.js',
@@ -55,7 +55,7 @@ const adminJsConfig = {
       '@hooks': '@wordpress/element',
       '@render': '@wordpress/element',
       '@compat': '@wordpress/element',
-    },
+    }
   },
   entry: {
     editorIndex: './assets/src/editorIndex.js',
@@ -96,7 +96,7 @@ const cssConfig = {
   },
   output: {
     filename: '[name].js',
-    path: __dirname + '/assets/build',
+    path: __dirname + '/assets/build'
   },
   module: {
     rules: [
@@ -108,8 +108,8 @@ const cssConfig = {
             loader: 'css-loader',
             options: {
               url: false,
-              sourceMap: true,
-            },
+              sourceMap: true
+            }
           },
           {
             loader: 'postcss-loader',
@@ -119,16 +119,16 @@ const cssConfig = {
                 dashDash({mediaQueryAliases, mediaQueryAtStart: false}),
                 require('autoprefixer'),
               ],
-              sourceMap: true,
-            },
+              sourceMap: true
+            }
           },
           {
             loader: 'sass-loader',
             options: {
-              sourceMap: true,
-            },
-          },
-        ],
+              sourceMap: true
+            }
+          }
+        ]
       },
       {
         test: /\.(png|svg|jpg|jpeg|gif)$/,
@@ -137,12 +137,12 @@ const cssConfig = {
             {
               loader: 'file-loader',
               options: {
-                publicPath: __dirname + '/public',
-              },
-            },
-          ],
-      },
-    ],
+                publicPath: __dirname + '/public'
+              }
+            }
+          ]
+      }
+    ]
   },
   plugins: [
     ...defaultConfig.plugins,
@@ -151,7 +151,7 @@ const cssConfig = {
     new MiniCssExtractPlugin({
       chunkFilename: '[id].css',
       ignoreOrder: false, // Enable to remove warnings about conflicting order
-      filename: './[name].min.css',
+      filename: './[name].min.css'
     }),
   ],
   optimization: {
@@ -163,10 +163,10 @@ const cssConfig = {
           map: {
             inline: false,
             annotation: true,
-          },
-        },
-      }),
-    ],
+          }
+        }
+      })
+    ]
   },
 };
 module.exports = [publicJsConfig, adminJsConfig, cssConfig];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,8 @@
-const defaultConfig = require("./node_modules/@wordpress/scripts/config/webpack.config");    // Require default Webpack config
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
+const defaultConfig = require('./node_modules/@wordpress/scripts/config/webpack.config');    // Require default Webpack config
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const TerserJSPlugin = require('terser-webpack-plugin');
-const FixStyleOnlyEntriesPlugin = require("webpack-fix-style-only-entries");
+const FixStyleOnlyEntriesPlugin = require('webpack-fix-style-only-entries');
 const dashDash = require('@greenpeace/dashdash');
 
 const mediaQueryAliases = {
@@ -17,12 +17,12 @@ const jsConfig = {
   ...defaultConfig,
   output: {
     filename: '[name].js',
-    path: __dirname + '/assets/build'
+    path: __dirname + '/assets/build',
   },
   optimization: {
     minimizer: [
       new TerserJSPlugin({}),
-    ]
+    ],
   },
 };
 
@@ -33,7 +33,7 @@ const publicJsConfig = {
       '@hooks': 'preact/hooks',
       '@render': 'preact',
       '@compat': 'preact/compat',
-    }
+    },
   },
   entry: {
     frontendIndex: './assets/src/frontendIndex.js',
@@ -45,6 +45,7 @@ const publicJsConfig = {
     TimelineScript: './assets/src/blocks/Timeline/TimelineScript.js',
     GalleryScript: './assets/src/blocks/Gallery/GalleryScript.js',
     GuestBookScript: './assets/src/blocks/GuestBook/GuestBookScript.js',
+    CounterScript: './assets/src/blocks/Counter/CounterScript.js',
   },
 };
 const adminJsConfig = {
@@ -54,7 +55,7 @@ const adminJsConfig = {
       '@hooks': '@wordpress/element',
       '@render': '@wordpress/element',
       '@compat': '@wordpress/element',
-    }
+    },
   },
   entry: {
     editorIndex: './assets/src/editorIndex.js',
@@ -67,6 +68,7 @@ const adminJsConfig = {
     SocialMediaEditorScript: './assets/src/blocks/SocialMedia/SocialMediaEditorScript.js',
     GalleryEditorScript: './assets/src/blocks/Gallery/GalleryEditorScript.js',
     GuestBookEditorScript: './assets/src/blocks/GuestBook/GuestBookEditorScript.js',
+    CounterEditorScript: './assets/src/blocks/Counter/CounterEditorScript.js',
   },
 };
 const cssConfig = {
@@ -90,10 +92,11 @@ const cssConfig = {
     CoversEditorStyle: './assets/src/styles/blocks/Covers/CoversEditorStyle.scss',
     GalleryStyle: './assets/src/styles/blocks/Gallery/GalleryStyle.scss',
     GalleryEditorStyle: './assets/src/styles/blocks/Gallery/GalleryEditorStyle.scss',
+    CounterStyle: './assets/src/styles/blocks/Counter/CounterStyle.scss',
   },
   output: {
     filename: '[name].js',
-    path: __dirname + '/assets/build'
+    path: __dirname + '/assets/build',
   },
   module: {
     rules: [
@@ -105,8 +108,8 @@ const cssConfig = {
             loader: 'css-loader',
             options: {
               url: false,
-              sourceMap: true
-            }
+              sourceMap: true,
+            },
           },
           {
             loader: 'postcss-loader',
@@ -116,16 +119,16 @@ const cssConfig = {
                 dashDash({mediaQueryAliases, mediaQueryAtStart: false}),
                 require('autoprefixer'),
               ],
-              sourceMap: true
-            }
+              sourceMap: true,
+            },
           },
           {
             loader: 'sass-loader',
             options: {
-              sourceMap: true
-            }
-          }
-        ]
+              sourceMap: true,
+            },
+          },
+        ],
       },
       {
         test: /\.(png|svg|jpg|jpeg|gif)$/,
@@ -134,12 +137,12 @@ const cssConfig = {
             {
               loader: 'file-loader',
               options: {
-                publicPath: __dirname + '/public'
-              }
-            }
-          ]
-      }
-    ]
+                publicPath: __dirname + '/public',
+              },
+            },
+          ],
+      },
+    ],
   },
   plugins: [
     ...defaultConfig.plugins,
@@ -148,7 +151,7 @@ const cssConfig = {
     new MiniCssExtractPlugin({
       chunkFilename: '[id].css',
       ignoreOrder: false, // Enable to remove warnings about conflicting order
-      filename: './[name].min.css'
+      filename: './[name].min.css',
     }),
   ],
   optimization: {
@@ -160,10 +163,10 @@ const cssConfig = {
           map: {
             inline: false,
             annotation: true,
-          }
-        }
-      })
-    ]
+          },
+        },
+      }),
+    ],
   },
 };
 module.exports = [publicJsConfig, adminJsConfig, cssConfig];


### PR DESCRIPTION
### Description

See [PLANET-6917](https://jira.greenpeace.org/browse/PLANET-6917)
This is to stop using the deprecated `frontendRendered` function. This PR also includes splitting the files for the Counter block.

### Testing

You can check out different styles of the block now using hydration on local or on [this page](https://www-dev.greenpeace.org/test-janus/counter-tests/) for example.
