### PR TITLE
Refactor Articles block to use hydration

### DIFF
--- a/assets/src/blocks/Articles/ArticlesBlock.js
+++ b/assets/src/blocks/Articles/ArticlesBlock.js
@@ -5,7 +5,7 @@ import {ArticlesFrontend} from './ArticlesFrontend';
 
 const {__} = wp.i18n;
 
-export const BLOCK_NAME = 'planet4-blocks/articles';
+const BLOCK_NAME = 'planet4-blocks/articles';
 
 const attributes = {
   article_heading: {

--- a/assets/src/blocks/Articles/ArticlesBlock.js
+++ b/assets/src/blocks/Articles/ArticlesBlock.js
@@ -63,13 +63,13 @@ export const registerArticlesBlock = () => {
     },
     attributes,
     edit: ArticlesEditor,
-    save: ({attributes: saveAttributes}) => {
+    save: props => {
       const markup = renderToString(
         <div
           data-hydrate={BLOCK_NAME}
-          data-attributes={JSON.stringify(saveAttributes)}
+          data-attributes={JSON.stringify(props.attributes)}
         >
-          <ArticlesFrontend {...saveAttributes} />
+          <ArticlesFrontend {...props.attributes} />
         </div>
       );
       return <RawHTML>{markup}</RawHTML>;

--- a/assets/src/blocks/Articles/ArticlesBlock.js
+++ b/assets/src/blocks/Articles/ArticlesBlock.js
@@ -1,114 +1,91 @@
 import {ArticlesEditor} from './ArticlesEditor';
 import {frontendRendered} from '../frontendRendered';
+import {renderToString} from 'react-dom/server';
+import {ArticlesFrontend} from './ArticlesFrontend';
 
-const BLOCK_NAME = 'planet4-blocks/articles';
+const {__} = wp.i18n;
 
-export class ArticlesBlock {
-  constructor() {
-    const {registerBlockType} = wp.blocks;
-    const {__} = wp.i18n;
+export const BLOCK_NAME = 'planet4-blocks/articles';
 
-    registerBlockType(BLOCK_NAME, {
-      title: 'Articles',
-      icon: 'excerpt-view',
-      category: 'planet4-blocks',
-      supports: {
-        html: false, // Disable "Edit as HTMl" block option.
+const attributes = {
+  article_heading: {
+    type: 'string',
+    default: __('Related Articles', 'planet4-blocks'),
+  },
+  articles_description: {
+    type: 'string',
+    default: '',
+  },
+  article_count: {
+    type: 'integer',
+    default: 3,
+  },
+  tags: {
+    type: 'array',
+    default: [],
+  },
+  posts: {
+    type: 'array',
+    default: [],
+  },
+  post_types: {
+    type: 'array',
+    default: [],
+  },
+  read_more_text: {
+    type: 'string',
+    default: __('Load more', 'planet4-blocks'),
+  },
+  read_more_link: {
+    type: 'string',
+    default: '',
+  },
+  button_link_new_tab: {
+    type: 'boolean',
+    default: false,
+  },
+  ignore_categories: {
+    type: 'boolean',
+    default: false,
+  },
+};
+
+export const registerArticlesBlock = () => {
+  const {registerBlockType} = wp.blocks;
+  const {RawHTML} = wp.element;
+
+  registerBlockType(BLOCK_NAME, {
+    title: 'Articles',
+    icon: 'excerpt-view',
+    category: 'planet4-blocks',
+    supports: {
+      html: false, // Disable "Edit as HTMl" block option.
+    },
+    attributes,
+    edit: ArticlesEditor,
+    save: ({attributes: saveAttributes}) => {
+      const markup = renderToString(
+        <div
+          data-hydrate={BLOCK_NAME}
+          data-attributes={JSON.stringify(saveAttributes)}
+        >
+          <ArticlesFrontend {...saveAttributes} />
+        </div>
+      );
+      return <RawHTML>{markup}</RawHTML>;
+    },
+    deprecated: [
+      {
+        attributes,
+        save: frontendRendered(BLOCK_NAME),
       },
-      attributes: {
-        article_heading: {
-          type: 'string',
-          default: __('Related Articles', 'planet4-blocks'),
-        },
-        articles_description: {
-          type: 'string',
-          default: '',
-        },
-        article_count: {
-          type: 'integer',
-          default: 3,
-        },
-        tags: {
-          type: 'array',
-          default: [],
-        },
-        posts: {
-          type: 'array',
-          default: [],
-        },
-        post_types: {
-          type: 'array',
-          default: [],
-        },
-        read_more_text: {
-          type: 'string',
-          default: __('Load more', 'planet4-blocks'),
-        },
-        read_more_link: {
-          type: 'string',
-          default: '',
-        },
-        button_link_new_tab: {
-          type: 'boolean',
-          default: false,
-        },
-        ignore_categories: {
-          type: 'boolean',
-          default: false,
+      {
+        attributes,
+        save() {
+          return null;
         },
       },
-      edit: ArticlesEditor,
-      save: frontendRendered(BLOCK_NAME),
-      deprecated: [
-        {
-          attributes: {
-            article_heading: {
-              type: 'string',
-              default: __('Related Articles', 'planet4-blocks'),
-            },
-            articles_description: {
-              type: 'string',
-              default: '',
-            },
-            article_count: {
-              type: 'integer',
-              default: 3,
-            },
-            tags: {
-              type: 'array',
-              default: [],
-            },
-            posts: {
-              type: 'array',
-              default: [],
-            },
-            post_types: {
-              type: 'array',
-              default: [],
-            },
-            read_more_text: {
-              type: 'string',
-              default: __('Load more', 'planet4-blocks'),
-            },
-            read_more_link: {
-              type: 'string',
-              default: '',
-            },
-            button_link_new_tab: {
-              type: 'boolean',
-              default: false,
-            },
-            ignore_categories: {
-              type: 'boolean',
-              default: false,
-            },
-          },
-          save() {
-            return null;
-          },
-        },
-      ],
-    });
-  }
-}
+    ],
+  });
+};
 

--- a/assets/src/blocks/Articles/ArticlesEditor.js
+++ b/assets/src/blocks/Articles/ArticlesEditor.js
@@ -1,4 +1,3 @@
-import {Fragment} from '@wordpress/element';
 import {
   CheckboxControl,
   TextControl as BaseTextControl,
@@ -19,88 +18,86 @@ const {__} = wp.i18n;
 
 const TextControl = withCharacterCounter(BaseTextControl);
 
-const renderEdit = (attributes, toAttribute) => {
-  return (
-    <Fragment>
-      <InspectorControls>
-        <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
-          <TextControl
-            label={__('Button Text', 'planet4-blocks-backend')}
-            placeholder={__('Override button text', 'planet4-blocks-backend')}
-            help={__('Your default is set to [ Load more ]', 'planet4-blocks-backend')}
-            value={attributes.read_more_text}
-            onChange={toAttribute('read_more_text')}
-          />
-          <URLInput
-            label={__('Button Link', 'planet4-blocks-backend')}
-            value={attributes.read_more_link}
-            onChange={toAttribute('read_more_link')}
-          />
-          <CheckboxControl
-            label={__('Open in a new Tab', 'planet4-blocks-backend')}
-            help={__('Open button link in new tab', 'planet4-blocks-backend')}
-            value={attributes.button_link_new_tab}
-            checked={attributes.button_link_new_tab}
-            onChange={toAttribute('button_link_new_tab')}
-          />
-          <TextControl
-            label={__('Articles count', 'planet4-blocks-backend')}
-            help={__('Number of articles', 'planet4-blocks-backend')}
-            type="number"
-            min={1}
-            value={attributes.article_count}
-            onChange={value =>
-              toAttribute('article_count')(Number(value))}
-          />
-          {attributes.posts !== 'undefined' && attributes.posts.length === 0 &&
-            <Fragment>
-              <TagSelector
-                value={attributes.tags}
-                onChange={toAttribute('tags')}
-              />
-              <p className="FieldHelp">Associate this block with Actions that have specific Tags</p>
-              <PostTypeSelector
-                label={__('Post Types', 'planet4-blocks-backend')}
-                value={attributes.post_types}
-                onChange={toAttribute('post_types')}
-              />
-              <div className="ignore-categories-wrapper">
-                <CheckboxControl
-                  label={__('Ignore categories', 'planet4-blocks-backend')}
-                  help={__('Ignore categories when filtering posts to populate the content of this block', 'planet4-blocks-backend')}
-                  value={attributes.ignore_categories}
-                  checked={attributes.ignore_categories}
-                  onChange={toAttribute('ignore_categories')}
-                />
-              </div>
-            </Fragment>
-          }
-          {attributes.tags.length === 0 && attributes.post_types.length === 0 &&
-            <div>
-              <hr />
-              <p>{__('Manual override', 'planet4-blocks-backend')}</p>
-              <PostSelector
-                label={__('CAUTION: Adding articles individually will override the automatic functionality of this block. For good user experience, please include at least three articles so that spacing and alignment of the design remains intact.', 'planet4-blocks-backend')}
-                selected={attributes.posts || []}
-                onChange={toAttribute('posts')}
-                postType="post"
-                placeholder={__('Select articles', 'planet4-blocks-backend')}
-                maxLength={10}
-                maxSuggestions={20}
+const renderEdit = (attributes, toAttribute) => (
+  <>
+    <InspectorControls>
+      <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
+        <TextControl
+          label={__('Button Text', 'planet4-blocks-backend')}
+          placeholder={__('Override button text', 'planet4-blocks-backend')}
+          help={__('Your default is set to [ Load more ]', 'planet4-blocks-backend')}
+          value={attributes.read_more_text}
+          onChange={toAttribute('read_more_text')}
+        />
+        <URLInput
+          label={__('Button Link', 'planet4-blocks-backend')}
+          value={attributes.read_more_link}
+          onChange={toAttribute('read_more_link')}
+        />
+        <CheckboxControl
+          label={__('Open in a new Tab', 'planet4-blocks-backend')}
+          help={__('Open button link in new tab', 'planet4-blocks-backend')}
+          value={attributes.button_link_new_tab}
+          checked={attributes.button_link_new_tab}
+          onChange={toAttribute('button_link_new_tab')}
+        />
+        <TextControl
+          label={__('Articles count', 'planet4-blocks-backend')}
+          help={__('Number of articles', 'planet4-blocks-backend')}
+          type="number"
+          min={1}
+          value={attributes.article_count}
+          onChange={value =>
+            toAttribute('article_count')(Number(value))}
+        />
+        {attributes.posts !== 'undefined' && attributes.posts.length === 0 &&
+          <>
+            <TagSelector
+              value={attributes.tags}
+              onChange={toAttribute('tags')}
+            />
+            <p className="FieldHelp">Associate this block with Actions that have specific Tags</p>
+            <PostTypeSelector
+              label={__('Post Types', 'planet4-blocks-backend')}
+              value={attributes.post_types}
+              onChange={toAttribute('post_types')}
+            />
+            <div className="ignore-categories-wrapper">
+              <CheckboxControl
+                label={__('Ignore categories', 'planet4-blocks-backend')}
+                help={__('Ignore categories when filtering posts to populate the content of this block', 'planet4-blocks-backend')}
+                value={attributes.ignore_categories}
+                checked={attributes.ignore_categories}
+                onChange={toAttribute('ignore_categories')}
               />
             </div>
-          }
-        </PanelBody>
-      </InspectorControls>
-    </Fragment>
-  );
-};
+          </>
+        }
+        {attributes.tags.length === 0 && attributes.post_types.length === 0 &&
+          <div>
+            <hr />
+            <p>{__('Manual override', 'planet4-blocks-backend')}</p>
+            <PostSelector
+              label={__('CAUTION: Adding articles individually will override the automatic functionality of this block. For good user experience, please include at least three articles so that spacing and alignment of the design remains intact.', 'planet4-blocks-backend')}
+              selected={attributes.posts || []}
+              onChange={toAttribute('posts')}
+              postType="post"
+              placeholder={__('Select articles', 'planet4-blocks-backend')}
+              maxLength={10}
+              maxSuggestions={20}
+            />
+          </div>
+        }
+      </PanelBody>
+    </InspectorControls>
+  </>
+);
 
 const renderView = ({attributes, postType, posts, totalPosts}, toAttribute) => {
   const hasMultiplePages = totalPosts > attributes.article_count;
 
   return (
-    <Fragment>
+    <>
       <Tooltip text={__('Edit text', 'planet4-blocks-backend')}>
         <header className="articles-title-container">
           <RichText
@@ -141,13 +138,11 @@ const renderView = ({attributes, postType, posts, totalPosts}, toAttribute) => {
         </Tooltip>
       )
       }
-    </Fragment>
+    </>
   );
 };
 
-export const ArticlesEditor = props => {
-  const {isSelected, attributes, setAttributes} = props;
-
+export const ArticlesEditor = ({isSelected, attributes, setAttributes}) => {
   const {postType, postId} = useSelect(select => ({
     postType: select('core/editor').getCurrentPostType(),
     postId: select('core/editor').getCurrentPostId(),
@@ -160,9 +155,7 @@ export const ArticlesEditor = props => {
 
   return (
     <div>
-      {
-        isSelected && renderEdit(attributes, toAttribute)
-      }
+      {isSelected && renderEdit(attributes, toAttribute)}
       {renderView({attributes, postType, posts, totalPosts}, toAttribute)}
     </div>
   );

--- a/assets/src/blocks/Articles/ArticlesEditor.js
+++ b/assets/src/blocks/Articles/ArticlesEditor.js
@@ -19,78 +19,76 @@ const {__} = wp.i18n;
 const TextControl = withCharacterCounter(BaseTextControl);
 
 const renderEdit = (attributes, toAttribute) => (
-  <>
-    <InspectorControls>
-      <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
-        <TextControl
-          label={__('Button Text', 'planet4-blocks-backend')}
-          placeholder={__('Override button text', 'planet4-blocks-backend')}
-          help={__('Your default is set to [ Load more ]', 'planet4-blocks-backend')}
-          value={attributes.read_more_text}
-          onChange={toAttribute('read_more_text')}
-        />
-        <URLInput
-          label={__('Button Link', 'planet4-blocks-backend')}
-          value={attributes.read_more_link}
-          onChange={toAttribute('read_more_link')}
-        />
-        <CheckboxControl
-          label={__('Open in a new Tab', 'planet4-blocks-backend')}
-          help={__('Open button link in new tab', 'planet4-blocks-backend')}
-          value={attributes.button_link_new_tab}
-          checked={attributes.button_link_new_tab}
-          onChange={toAttribute('button_link_new_tab')}
-        />
-        <TextControl
-          label={__('Articles count', 'planet4-blocks-backend')}
-          help={__('Number of articles', 'planet4-blocks-backend')}
-          type="number"
-          min={1}
-          value={attributes.article_count}
-          onChange={value =>
-            toAttribute('article_count')(Number(value))}
-        />
-        {attributes.posts !== 'undefined' && attributes.posts.length === 0 &&
-          <>
-            <TagSelector
-              value={attributes.tags}
-              onChange={toAttribute('tags')}
-            />
-            <p className="FieldHelp">Associate this block with Actions that have specific Tags</p>
-            <PostTypeSelector
-              label={__('Post Types', 'planet4-blocks-backend')}
-              value={attributes.post_types}
-              onChange={toAttribute('post_types')}
-            />
-            <div className="ignore-categories-wrapper">
-              <CheckboxControl
-                label={__('Ignore categories', 'planet4-blocks-backend')}
-                help={__('Ignore categories when filtering posts to populate the content of this block', 'planet4-blocks-backend')}
-                value={attributes.ignore_categories}
-                checked={attributes.ignore_categories}
-                onChange={toAttribute('ignore_categories')}
-              />
-            </div>
-          </>
-        }
-        {attributes.tags.length === 0 && attributes.post_types.length === 0 &&
-          <div>
-            <hr />
-            <p>{__('Manual override', 'planet4-blocks-backend')}</p>
-            <PostSelector
-              label={__('CAUTION: Adding articles individually will override the automatic functionality of this block. For good user experience, please include at least three articles so that spacing and alignment of the design remains intact.', 'planet4-blocks-backend')}
-              selected={attributes.posts || []}
-              onChange={toAttribute('posts')}
-              postType="post"
-              placeholder={__('Select articles', 'planet4-blocks-backend')}
-              maxLength={10}
-              maxSuggestions={20}
+  <InspectorControls>
+    <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
+      <TextControl
+        label={__('Button Text', 'planet4-blocks-backend')}
+        placeholder={__('Override button text', 'planet4-blocks-backend')}
+        help={__('Your default is set to [ Load more ]', 'planet4-blocks-backend')}
+        value={attributes.read_more_text}
+        onChange={toAttribute('read_more_text')}
+      />
+      <URLInput
+        label={__('Button Link', 'planet4-blocks-backend')}
+        value={attributes.read_more_link}
+        onChange={toAttribute('read_more_link')}
+      />
+      <CheckboxControl
+        label={__('Open in a new Tab', 'planet4-blocks-backend')}
+        help={__('Open button link in new tab', 'planet4-blocks-backend')}
+        value={attributes.button_link_new_tab}
+        checked={attributes.button_link_new_tab}
+        onChange={toAttribute('button_link_new_tab')}
+      />
+      <TextControl
+        label={__('Articles count', 'planet4-blocks-backend')}
+        help={__('Number of articles', 'planet4-blocks-backend')}
+        type="number"
+        min={1}
+        value={attributes.article_count}
+        onChange={value =>
+          toAttribute('article_count')(Number(value))}
+      />
+      {attributes.posts !== 'undefined' && attributes.posts.length === 0 &&
+        <>
+          <TagSelector
+            value={attributes.tags}
+            onChange={toAttribute('tags')}
+          />
+          <p className="FieldHelp">Associate this block with Actions that have specific Tags</p>
+          <PostTypeSelector
+            label={__('Post Types', 'planet4-blocks-backend')}
+            value={attributes.post_types}
+            onChange={toAttribute('post_types')}
+          />
+          <div className="ignore-categories-wrapper">
+            <CheckboxControl
+              label={__('Ignore categories', 'planet4-blocks-backend')}
+              help={__('Ignore categories when filtering posts to populate the content of this block', 'planet4-blocks-backend')}
+              value={attributes.ignore_categories}
+              checked={attributes.ignore_categories}
+              onChange={toAttribute('ignore_categories')}
             />
           </div>
-        }
-      </PanelBody>
-    </InspectorControls>
-  </>
+        </>
+      }
+      {attributes.tags.length === 0 && attributes.post_types.length === 0 &&
+        <div>
+          <hr />
+          <p>{__('Manual override', 'planet4-blocks-backend')}</p>
+          <PostSelector
+            label={__('CAUTION: Adding articles individually will override the automatic functionality of this block. For good user experience, please include at least three articles so that spacing and alignment of the design remains intact.', 'planet4-blocks-backend')}
+            selected={attributes.posts || []}
+            onChange={toAttribute('posts')}
+            postType="post"
+            placeholder={__('Select articles', 'planet4-blocks-backend')}
+            maxLength={10}
+            maxSuggestions={20}
+          />
+        </div>
+      }
+    </PanelBody>
+  </InspectorControls>
 );
 
 const renderView = ({attributes, postType, posts, totalPosts}, toAttribute) => {
@@ -154,9 +152,9 @@ export const ArticlesEditor = ({isSelected, attributes, setAttributes}) => {
   const toAttribute = attributeName => value => setAttributes({[attributeName]: value});
 
   return (
-    <div>
+    <>
       {isSelected && renderEdit(attributes, toAttribute)}
       {renderView({attributes, postType, posts, totalPosts}, toAttribute)}
-    </div>
+    </>
   );
 };

--- a/assets/src/blocks/Articles/ArticlesEditorScript.js
+++ b/assets/src/blocks/Articles/ArticlesEditorScript.js
@@ -1,0 +1,3 @@
+import {registerArticlesBlock} from './ArticlesBlock';
+
+registerArticlesBlock();

--- a/assets/src/blocks/Articles/ArticlesFrontend.js
+++ b/assets/src/blocks/Articles/ArticlesFrontend.js
@@ -9,17 +9,15 @@ export const ArticlesFrontend = props => {
     read_more_link,
     button_link_new_tab,
     className,
+    post_categories = [],
   } = props;
-
   const postType = document.body.getAttribute('data-post-type');
 
   const postIdClass = [...document.body.classList].find(classNameFound => /^postid-\d+$/.test(classNameFound));
 
   const postId = !postIdClass ? null : postIdClass.split('-')[1];
 
-  const postCategories = props.post_categories || [];
-
-  const {posts, loadNextPage, hasMorePages, loading} = useArticlesFetch(props, postType, postId, document.body.dataset.nro, postCategories);
+  const {posts, loadNextPage, hasMorePages, loading} = useArticlesFetch(props, postType, postId, document.body.dataset.nro, post_categories);
 
   if (!posts.length) {
     return null;

--- a/assets/src/blocks/Articles/ArticlesScript.js
+++ b/assets/src/blocks/Articles/ArticlesScript.js
@@ -1,12 +1,11 @@
 import {ArticlesFrontend} from './ArticlesFrontend';
 import {hydrateBlock} from '../../functions/hydrateBlock';
-import {BLOCK_NAME} from './ArticlesBlock';
 import {createRoot} from 'react-dom/client';
 
-hydrateBlock(BLOCK_NAME, ArticlesFrontend);
+hydrateBlock('planet4-blocks/articles', ArticlesFrontend);
 
 // Fallback for non migrated content. Remove after migration.
-document.querySelectorAll(`[data-render="${BLOCK_NAME}"]`).forEach(
+document.querySelectorAll('[data-render="planet4-blocks/articles"]').forEach(
   blockNode => {
     const attributes = JSON.parse(blockNode.dataset.attributes);
     const rootElement = createRoot(blockNode);

--- a/assets/src/blocks/Articles/ArticlesScript.js
+++ b/assets/src/blocks/Articles/ArticlesScript.js
@@ -1,0 +1,15 @@
+import {ArticlesFrontend} from './ArticlesFrontend';
+import {hydrateBlock} from '../../functions/hydrateBlock';
+import {BLOCK_NAME} from './ArticlesBlock';
+import {createRoot} from 'react-dom/client';
+
+hydrateBlock(BLOCK_NAME, ArticlesFrontend);
+
+// Fallback for non migrated content. Remove after migration.
+document.querySelectorAll(`[data-render="${BLOCK_NAME}"]`).forEach(
+  blockNode => {
+    const attributes = JSON.parse(blockNode.dataset.attributes);
+    const rootElement = createRoot(blockNode);
+    rootElement.render(<ArticlesFrontend {...attributes.attributes} />);
+  }
+);

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderBlock.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderBlock.js
@@ -58,7 +58,7 @@ export const registerCarouselHeaderBlock = () =>
     edit: CarouselHeaderEditor,
     save: ({attributes: saveAttributes}) => {
       const markup = renderToString(<div
-        data-hydrate={'planet4-blocks/carousel-header'}
+        data-hydrate={BLOCK_NAME}
         data-attributes={JSON.stringify(saveAttributes)}
       >
         <CarouselHeaderFrontend {...saveAttributes} />

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -1,4 +1,3 @@
-import {ArticlesBlock} from './blocks/Articles/ArticlesBlock';
 import {registerColumnsBlock} from './blocks/Columns/ColumnsBlock';
 import {CookiesBlock} from './blocks/Cookies/CookiesBlock';
 import {HappypointBlock} from './blocks/Happypoint/HappypointBlock';
@@ -23,7 +22,6 @@ import {registerPageHeaderBlock} from './blocks/PageHeader/PageHeaderBlock';
 import {registerBlockTemplates} from './block-templates/register';
 
 blockEditorValidation();
-new ArticlesBlock();
 registerColumnsBlock();
 new CookiesBlock();
 new HappypointBlock();

--- a/assets/src/frontendIndex.js
+++ b/assets/src/frontendIndex.js
@@ -1,4 +1,3 @@
-import {ArticlesFrontend} from './blocks/Articles/ArticlesFrontend';
 import {CookiesFrontend} from './blocks/Cookies/CookiesFrontend';
 import {SplittwocolumnsFrontend} from './blocks/Splittwocolumns/SplittwocolumnsFrontend';
 import {HappypointFrontend} from './blocks/Happypoint/HappypointFrontend';
@@ -14,7 +13,6 @@ import {createRoot} from 'react-dom/client';
 
 // Render React components
 const COMPONENTS = {
-  'planet4-blocks/articles': ArticlesFrontend,
   'planet4-blocks/cookies': CookiesFrontend,
   'planet4-blocks/split-two-columns': SplittwocolumnsFrontend,
   'planet4-blocks/happypoint': HappypointFrontend,

--- a/assets/src/styles/blocks.scss
+++ b/assets/src/styles/blocks.scss
@@ -1,5 +1,4 @@
 // P4 Blocks
-@import "blocks/Articles";
 @import "blocks/Columns";
 @import "blocks/File";
 @import "blocks/Happypoint";

--- a/assets/src/styles/blocks/Articles/ArticlesEditorStyle.scss
+++ b/assets/src/styles/blocks/Articles/ArticlesEditorStyle.scss
@@ -1,3 +1,5 @@
+@import "../../master-theme/assets/src/scss/base/colors";
+
 .ignore-categories-wrapper {
   margin-top: 10px;
 }

--- a/assets/src/styles/blocks/Articles/ArticlesStyle.scss
+++ b/assets/src/styles/blocks/Articles/ArticlesStyle.scss
@@ -1,3 +1,7 @@
+@import "../../master-theme/assets/src/scss/base/colors";
+@import "../../master-theme/assets/src/scss/base/variables";
+@import "../../master-theme/assets/src/scss/base/mixins";
+
 .article-list-item {
   display: flex;
   flex-direction: column;

--- a/assets/src/styles/editorStyle.scss
+++ b/assets/src/styles/editorStyle.scss
@@ -7,7 +7,6 @@
 
 @import "blocks";
 
-@import "blocks/ArticlesEditor";
 @import "blocks/ColumnsEditor";
 @import "blocks/SplitTwoColumnsEditor";
 @import "blocks/SubmenuEditor";

--- a/classes/blocks/class-articles.php
+++ b/classes/blocks/class-articles.php
@@ -7,9 +7,6 @@
 
 namespace P4GBKS\Blocks;
 
-use P4_Post;
-use Timber\Timber;
-
 /**
  * Class Articles
  *
@@ -106,6 +103,9 @@ class Articles extends Base_Block {
 				],
 			]
 		);
+
+		add_action( 'enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ] );
+		add_action( 'wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ] );
 	}
 
 	/**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,7 @@ const publicJsConfig = {
     GalleryScript: './assets/src/blocks/Gallery/GalleryScript.js',
     GuestBookScript: './assets/src/blocks/GuestBook/GuestBookScript.js',
     CounterScript: './assets/src/blocks/Counter/CounterScript.js',
+    ArticlesScript: './assets/src/blocks/Articles/ArticlesScript.js',
   },
 };
 const adminJsConfig = {
@@ -69,6 +70,7 @@ const adminJsConfig = {
     GalleryEditorScript: './assets/src/blocks/Gallery/GalleryEditorScript.js',
     GuestBookEditorScript: './assets/src/blocks/GuestBook/GuestBookEditorScript.js',
     CounterEditorScript: './assets/src/blocks/Counter/CounterEditorScript.js',
+    ArticlesEditorScript: './assets/src/blocks/Articles/ArticlesEditorScript.js',
   },
 };
 const cssConfig = {
@@ -93,6 +95,8 @@ const cssConfig = {
     GalleryStyle: './assets/src/styles/blocks/Gallery/GalleryStyle.scss',
     GalleryEditorStyle: './assets/src/styles/blocks/Gallery/GalleryEditorStyle.scss',
     CounterStyle: './assets/src/styles/blocks/Counter/CounterStyle.scss',
+    ArticlesStyle: './assets/src/styles/blocks/Articles/ArticlesStyle.scss',
+    ArticlesEditorStyle: './assets/src/styles/blocks/Articles/ArticlesEditorStyle.scss',
   },
   output: {
     filename: '[name].js',


### PR DESCRIPTION
### Description

See [PLANET-6917](https://jira.greenpeace.org/browse/PLANET-6917)
This is to stop using the deprecated `frontendRendered` function

### Testing

You can make sure that the Articles block still works as expected, either on local or on the [deimos test instance](https://www-dev.greenpeace.org/test-deimos/)