### PR TITLE
PLANET-6855: Add covers thumbnail size for large screen

### DIFF
--- a/assets/src/blocks/Columns/Columns.js
+++ b/assets/src/blocks/Columns/Columns.js
@@ -1,6 +1,7 @@
 import {ColumnsImagePlaceholder} from './ColumnsImagePlaceholder';
 import {LAYOUT_NO_IMAGE, LAYOUT_ICONS, LAYOUT_TASKS} from './ColumnConstants';
 import {ColumnsTasks} from './ColumnsTasks';
+import {IMAGE_SIZES} from './imageSizes';
 
 export const Columns = ({columns, columns_block_style, isCampaign, isExample = false}) => {
   if (!columns || !columns.length) {
@@ -18,6 +19,7 @@ export const Columns = ({columns, columns_block_style, isCampaign, isExample = f
           cta_link,
           cta_text,
           attachment,
+          attachment_srcset = '',
           link_new_tab,
           title,
           description,
@@ -52,9 +54,19 @@ export const Columns = ({columns, columns_block_style, isCampaign, isExample = f
                     data-ga-label={cta_link}
                     {...link_new_tab && {target: '_blank', rel: 'noreferrer'}}
                   >
-                    <img src={attachment} alt={title} title={title} loading="lazy" />
+                    <img src={attachment}
+                      srcSet={attachment_srcset}
+                      sizes={IMAGE_SIZES[`col-${columns.length}`] ?? ''}
+                      alt={title}
+                      title={title}
+                      loading="lazy" />
                   </a> :
-                  <img src={attachment} alt={title} title={title} loading="lazy" />
+                  <img src={attachment}
+                    srcSet={attachment_srcset}
+                    sizes={IMAGE_SIZES[`col-${columns.length}`] ?? ''}
+                    alt={title}
+                    title={title}
+                    loading="lazy" />
                 }
               </div>
             }

--- a/assets/src/blocks/Columns/imageSizes.js
+++ b/assets/src/blocks/Columns/imageSizes.js
@@ -1,0 +1,23 @@
+export const IMAGE_SIZES = {
+  'col-2': `
+    (min-width: 1600px) 636px,
+    (min-width: 1200px) 546px,
+    (min-width: 1000px) 456px,
+    (min-width: 780px) 336px,
+    (min-width: 580px) 516px,
+    92.31vw`,
+  'col-3': `
+    (min-width: 1600px) 416px,
+    (min-width: 1200px) 356px,
+    (min-width: 1000px) 296px,
+    (min-width: 780px) 336px,
+    (min-width: 580px) 516px,
+    92.31vw`,
+  'col-4': `
+    (min-width: 1600px) 306px,
+    (min-width: 1200px) 261px,
+    (min-width: 1000px) 216px,
+    (min-width: 780px) 336px,
+    (min-width: 580px) 516px,
+    92.31vw`,
+};

--- a/assets/src/blocks/Covers/imageSizes.js
+++ b/assets/src/blocks/Covers/imageSizes.js
@@ -1,18 +1,21 @@
 export const IMAGE_SIZES = {
   campaign: `
-  (min-width: 1200px) 362px,
-  (min-width: 1000px) 302px,
-  (min-width: 780px) 222px,
-  (min-width: 580px) 510px,
-  92.31vw`,
+    (min-width: 1200px) 362px,
+    (min-width: 1000px) 302px,
+    (min-width: 780px) 222px,
+    (min-width: 580px) 510px,
+    92.31vw`,
   content: `
-    (min-width: 1200px) 255px,
-    (min-width: 580px) 216px,
+    (min-width: 1600px) 306px,
+    (min-width: 1200px) 261px,
+    (min-width: 768px) 216px,
+    (min-width: 580px) 254px,
     calc(41.54vw - 20px)`,
   takeAction: `
-  (min-width: 1200px) 354px,
-  (min-width: 1000px) 294px,
-  (min-width: 780px) 333px,
-  (min-width: 580px) 510px,
-  92.31vw`,
+    (min-width: 1600px) 416px,
+    (min-width: 1200px) 356px,
+    (min-width: 1000px) 296px,
+    (min-width: 780px) 336px,
+    (min-width: 580px) 516px,
+    92.31vw`,
 };

--- a/classes/blocks/class-columns.php
+++ b/classes/blocks/class-columns.php
@@ -130,7 +130,11 @@ class Columns extends Base_Block {
 				}
 				[ $img_src ] = wp_get_attachment_image_src( $attachment, $image_size );
 
-				$columns[ $key ]['attachment'] = $img_src;
+				$columns[ $key ]['attachment']        = $img_src;
+				$columns[ $key ]['attachment_srcset'] = wp_get_attachment_image_srcset(
+					$attachment,
+					$image_size
+				);
 			}
 		}
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6855

- Update Covers images `sizes` attribute to various viewport widths
- Update Columns code to insert images `srcset` and `sizes` attributes


## Test

Locally, install gpi `npm run nro:install international`
- compare images used for `/tag/about-us/` , the image format queried should now vary depending on viewport
- use Network tab in browser inspector tools, filter by image filename
  - on prod
![Screenshot from 2023-08-23 12-30-32](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/assets/617346/25305bc0-c55b-4d2e-a26f-6cd1ff808f75)
  - on local
![Screenshot from 2023-08-23 12-33-20](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/assets/617346/be122cc7-af7c-437e-8dfa-ef1d276b1307)
