### PR TITLE
Fix hydrateBlock method

### DIFF
--- a/assets/src/functions/hydrateBlock.js
+++ b/assets/src/functions/hydrateBlock.js
@@ -12,8 +12,8 @@ export const hydrateBlock = (blockName, Component, csrAttributes = {}) => { // e
   const blocks = document.querySelectorAll(`[data-hydrate="${blockName}"]`);
   blocks.forEach(
     blockNode => {
-      const attributes = JSON.parse(blockNode.dataset.attributes);
-      if(blockNode.length) {
+      if(blockNode) {
+        const attributes = JSON.parse(blockNode.dataset.attributes);
         hydrateRoot(blockNode, <Component {...attributes} {...csrAttributes} />);
       }
     }


### PR DESCRIPTION
# Description
Before the implementation of `hydrateRoot` the `blockNode` has been evaulated as an `Array` instead of an `HTML Selector`. This `if ` clause is added to avoid inconsistencies within the component since in some cases we're getting a warning message something similar to "`<div>` is rendered but should be `<p>`".

The problem was raised after the merge of [this line](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/commit/baf89cb928e78228d8776165ddd021f365d1118c#diff-ea83b4bc3c4de5b445d5e8cc611f40046841a40eb55e6205430201302584c4dcR16-R18) and it affected the `CarouselHeader` among other blocks.

## Testing
Using the current branch within the [international dev site](https://github.com/greenpeace/planet4-international/blob/main/composer-local.json#L6).

<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
