### PR TITLE
Fix Submenu links font family

### DIFF
--- a/assets/src/styles/blocks/Submenu.scss
+++ b/assets/src/styles/blocks/Submenu.scss
@@ -34,7 +34,6 @@ div[data-render="planet4-blocks/submenu"] {
 
     a {
       color: var(--body--color);
-      font-family: var(--headings--font-family);
     }
 
     ul {


### PR DESCRIPTION
### Description

Reported by Quentin on Slack, and by Houssam on Jira: [PLANET-7241](https://jira.greenpeace.org/browse/PLANET-7241)
It shouldn't be the headings font, especially with the new identity

### Testing

Make sure it still looks good both with and without the new identity styles!
