### PR TITLE
PLANET-7242: Fix title text covered by background

### DIFF
--- a/assets/src/styles/blocks/PageHeader.scss
+++ b/assets/src/styles/blocks/PageHeader.scss
@@ -62,8 +62,7 @@ $text-column-padding-in: 24px;
     padding: 0;
     font-size: inherit;
     font-weight: inherit;
-    line-height: inherit;
-
+    line-height: var(--page-header-title--line-height, 1em);
     box-decoration-break: clone;
     box-shadow: 8px 0 0 var(--transparent-button--active--color, #fff), calc(8px * -1) 0 0 var(--transparent-button--active--color, #fff);
   }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7242
Requires: https://github.com/greenpeace/planet4-master-theme/pull/2113

> On some of the header pages, the title may appear as though it's blocked or covered by the background of the second line.

__Before__
![Screenshot from 2023-08-31 18-03-08](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/assets/617346/78e36dc5-8bd6-4283-b256-b6d756cecc61)


__After__
![Screenshot from 2023-08-31 18-01-57](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/assets/617346/f95bc4e6-5e7c-42cd-acf0-7befb5f63aed)

[Test page on Leda](https://www-dev.greenpeace.org/test-leda/1176-2/)