### PR TITLE
PLANET-7197: Adapt block loading order

### DIFF
--- a/classes/blocks/class-accordion.php
+++ b/classes/blocks/class-accordion.php
@@ -26,7 +26,7 @@ class Accordion extends Base_Block {
 	 * Accordion constructor.
 	 */
 	public function __construct() {
-		add_action( 'init', [ $this, 'register_accordion_block' ] );
+		$this->register_accordion_block();
 	}
 
 	/**

--- a/classes/blocks/class-carouselheader.php
+++ b/classes/blocks/class-carouselheader.php
@@ -28,7 +28,7 @@ class CarouselHeader extends Base_Block {
 	 * CarouselHeader constructor.
 	 */
 	public function __construct() {
-		add_action( 'init', [ $this, 'register_carouselheader_block' ] );
+		$this->register_carouselheader_block();
 	}
 
 	/**

--- a/classes/blocks/class-enform.php
+++ b/classes/blocks/class-enform.php
@@ -88,7 +88,7 @@ class ENForm extends Base_Block {
 	 * ENForm constructor.
 	 */
 	public function __construct() {
-		add_action( 'init', [ $this, 'register_enform_block' ] );
+		$this->register_enform_block();
 	}
 
 	/**

--- a/classes/blocks/class-gallery.php
+++ b/classes/blocks/class-gallery.php
@@ -38,7 +38,7 @@ class Gallery extends Base_Block {
 	 * Gallery constructor.
 	 */
 	public function __construct() {
-		add_action( 'init', [ $this, 'register_gallery_block' ] );
+		$this->register_gallery_block();
 	}
 
 	/**

--- a/classes/blocks/class-guestbook.php
+++ b/classes/blocks/class-guestbook.php
@@ -8,6 +8,8 @@
 
 namespace P4GBKS\Blocks;
 
+use WP_Block_Type_Registry;
+
 /**
  * Class GuestBook
  *
@@ -26,6 +28,10 @@ class GuestBook extends Base_Block {
 	 * GuestBook constructor.
 	 */
 	public function __construct() {
+		if ( WP_Block_Type_Registry::get_instance()->is_registered( self::get_full_block_name() ) ) {
+			return;
+		}
+
 		register_block_type(
 			self::get_full_block_name(),
 		);
@@ -41,5 +47,12 @@ class GuestBook extends Base_Block {
 	 */
 	public function prepare_data( $fields ): array {
 		return [];
+	}
+
+	/**
+	 * GuestBook camelized name.
+	 */
+	public static function get_camelized_block_name(): string {
+		return 'GuestBook';
 	}
 }

--- a/classes/blocks/class-socialmedia.php
+++ b/classes/blocks/class-socialmedia.php
@@ -35,7 +35,7 @@ class SocialMedia extends Base_Block {
 	 * SocialMedia constructor.
 	 */
 	public function __construct() {
-		add_action( 'init', [ $this, 'register_socialmedia_block' ] );
+		$this->register_socialmedia_block();
 	}
 
 	/**

--- a/classes/blocks/class-spreadsheet.php
+++ b/classes/blocks/class-spreadsheet.php
@@ -25,7 +25,7 @@ class Spreadsheet extends Base_Block {
 	 * SpreadsheetTable constructor.
 	 */
 	public function __construct() {
-		add_action( 'init', [ $this, 'register_spreadsheet_block' ] );
+		$this->register_spreadsheet_block();
 	}
 
 	/**

--- a/classes/blocks/class-takeactionboxout.php
+++ b/classes/blocks/class-takeactionboxout.php
@@ -25,7 +25,7 @@ class TakeActionBoxout extends Base_Block {
 	 * TakeActionBoxout constructor.
 	 */
 	public function __construct() {
-		add_action( 'init', [ $this, 'register_takeactionboxout_block' ] );
+		$this->register_takeactionboxout_block();
 	}
 
 	/**

--- a/classes/blocks/class-timeline.php
+++ b/classes/blocks/class-timeline.php
@@ -26,7 +26,7 @@ class Timeline extends Base_Block {
 	 * Timeline constructor.
 	 */
 	public function __construct() {
-		add_action( 'init', [ $this, 'register_timeline_block' ] );
+		$this->register_timeline_block();
 	}
 
 	/**

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -63,52 +63,8 @@ final class Loader {
 		$this->load_commands();
 		$this->check_requirements();
 
-		// Load Blocks.
-		new Blocks\Accordion();
-		new Blocks\Articles();
-		new Blocks\CarouselHeader();
-		new Blocks\Columns();
-		new Blocks\Cookies();
-		new Blocks\Counter();
-		new Blocks\Covers();
-		new Blocks\Gallery();
-		new Blocks\Happypoint();
-		new Blocks\Media();
-		new Blocks\SocialMedia();
-		new Blocks\SplitTwoColumns();
-		new Blocks\Spreadsheet();
-		new Blocks\SubMenu();
-		new Blocks\SubPages();
-		new Blocks\TakeActionBoxout();
-		new Blocks\Timeline();
-		new Blocks\SocialMediaCards();
-		new Blocks\ENForm();
-		new Blocks\GuestBook();
-
-		/**
-		 * Create Planet 4 block patterns categories.
-		*/
-		if ( ! function_exists( 'register_block_pattern_category' ) ) {
-			return;
-		}
-
-		register_block_pattern_category(
-			'planet4',
-			[ 'label' => 'Planet 4' ],
-		);
-		register_block_pattern_category(
-			'page-headers',
-			[ 'label' => 'Page Headers' ],
-		);
-
-		register_block_pattern_category(
-			'layouts',
-			[ 'label' => 'Layouts' ],
-		);
-
-		// Load block patterns.
-		Block_Pattern::register_all();
-
+		// During PLANET-6373 transition, priority between theme and plugin matters.
+		add_action( 'init', [ static::class, 'add_blocks' ], 30 );
 		// Load parallax library for Media & Text block.
 		add_action(
 			'wp_enqueue_scripts',
@@ -176,6 +132,56 @@ final class Loader {
 		foreach ( $services as $service ) {
 			( new $service( $view ) )->load();
 		}
+	}
+
+	/**
+	 * Load blocks from Plugin.
+	 */
+	public static function add_blocks(): void {
+		new Blocks\Accordion();
+		new Blocks\Articles();
+		new Blocks\CarouselHeader();
+		new Blocks\Columns();
+		new Blocks\Cookies();
+		new Blocks\Counter();
+		new Blocks\Covers();
+		new Blocks\Gallery();
+		new Blocks\Happypoint();
+		new Blocks\Media();
+		new Blocks\SocialMedia();
+		new Blocks\SplitTwoColumns();
+		new Blocks\Spreadsheet();
+		new Blocks\SubMenu();
+		new Blocks\SubPages();
+		new Blocks\TakeActionBoxout();
+		new Blocks\Timeline();
+		new Blocks\SocialMediaCards();
+		new Blocks\ENForm();
+		new Blocks\GuestBook();
+
+		/**
+		 * Create Planet 4 block patterns categories.
+		*/
+		if ( ! function_exists( 'register_block_pattern_category' ) ) {
+			return;
+		}
+
+		register_block_pattern_category(
+			'planet4',
+			[ 'label' => 'Planet 4' ],
+		);
+		register_block_pattern_category(
+			'page-headers',
+			[ 'label' => 'Page Headers' ],
+		);
+
+		register_block_pattern_category(
+			'layouts',
+			[ 'label' => 'Layouts' ],
+		);
+
+		// Load block patterns.
+		Block_Pattern::register_all();
 	}
 
 	/**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7197
Related to: https://github.com/greenpeace/planet4-master-theme/pull/2020

## Summary

Adapt blocks loading logic to allow master-theme to load blocks in priority.

## Details
- load all blocks via hook `add_action('init')`
  - blocks were not uniformly loaded, some right away with plugin loading and others through `init`
  - loading globally with `init` allows to set a `priority` parameter and make it higher(later) than master-theme
- fix GuestBook assets loading
  - camelized name was not matching assets name
- rewrite Spreadsheet test to not depend on external API
  - mock of spreadsheet API calls with static data, this will speed the test and avoid a backend call to google API