### PR TITLE
Implement spacer block

### DIFF
--- a/assets/src/blocks/Spacer/SpacerBlock.js
+++ b/assets/src/blocks/Spacer/SpacerBlock.js
@@ -1,0 +1,53 @@
+import {renderToString} from 'react-dom/server';
+import {SpacerEditor} from './SpacerEditor';
+import { SpacerFrontend } from './SpacerFrontend';
+
+const {registerBlockType} = wp.blocks;
+const {RawHTML} = wp.element;
+const {__} = wp.i18n;
+
+const BLOCK_NAME = 'planet4-blocks/spacer';
+
+export const registerSpacerBlock = () => {
+  console.log('registerSpacerBlock')
+  registerBlockType(BLOCK_NAME, {
+    title: __('Planet 4 Spacer', 'planet4-blocks-backend'),
+    icon: 'format-image',
+    category: 'planet4-blocks',
+    supports: {
+      multiple: true,
+    },
+    attributes: {
+      small: {
+        type: 'number',
+        default: 10,
+      },
+      medium: {
+        type: 'number',
+        default: 10,
+      },
+      large: {
+        type: 'number',
+        default: 10,
+      },
+      xlarge: {
+        type: 'number',
+        default: 10,
+      },
+    },
+    edit: SpacerEditor,
+    save: props => {
+      const {attributes} = props;
+      console.log(attributes)
+      const markup = renderToString(
+        <div
+          data-hydrate={BLOCK_NAME}
+          data-attributes={JSON.stringify(attributes)}
+        >
+          <SpacerFrontend {...props} />
+        </div>
+      );
+      return <RawHTML>{ markup }</RawHTML>;
+    },
+  });
+}

--- a/assets/src/blocks/Spacer/SpacerBlock.js
+++ b/assets/src/blocks/Spacer/SpacerBlock.js
@@ -1,6 +1,6 @@
 import {renderToString} from 'react-dom/server';
 import {SpacerEditor} from './SpacerEditor';
-import { SpacerFrontend } from './SpacerFrontend';
+import {SpacerFrontend} from './SpacerFrontend';
 
 const {registerBlockType} = wp.blocks;
 const {RawHTML} = wp.element;
@@ -9,36 +9,38 @@ const {__} = wp.i18n;
 const BLOCK_NAME = 'planet4-blocks/spacer';
 
 export const registerSpacerBlock = () => {
-  console.log('registerSpacerBlock')
   registerBlockType(BLOCK_NAME, {
     title: __('Planet 4 Spacer', 'planet4-blocks-backend'),
-    icon: 'format-image',
+    icon: 'welcome-widgets-menus',
     category: 'planet4-blocks',
     supports: {
       multiple: true,
     },
     attributes: {
       small: {
-        type: 'number',
-        default: 10,
+        type: 'string',
+        default: '16px',
       },
       medium: {
-        type: 'number',
-        default: 10,
+        type: 'string',
+        default: '16px',
       },
       large: {
-        type: 'number',
-        default: 10,
+        type: 'string',
+        default: '16px',
       },
       xlarge: {
-        type: 'number',
-        default: 10,
+        type: 'string',
+        default: '16px',
+      },
+      xxlarge: {
+        type: 'string',
+        default: '16px',
       },
     },
     edit: SpacerEditor,
     save: props => {
       const {attributes} = props;
-      console.log(attributes)
       const markup = renderToString(
         <div
           data-hydrate={BLOCK_NAME}
@@ -50,4 +52,4 @@ export const registerSpacerBlock = () => {
       return <RawHTML>{ markup }</RawHTML>;
     },
   });
-}
+};

--- a/assets/src/blocks/Spacer/SpacerEditor.js
+++ b/assets/src/blocks/Spacer/SpacerEditor.js
@@ -1,61 +1,68 @@
-import {
-  TextControl,
-  PanelBody,
-} from '@wordpress/components';
+import {useCallback, useMemo} from '@wordpress/element';
 import {InspectorControls} from '@wordpress/block-editor';
-import { SpacerFrontend } from './SpacerFrontend';
+import {SpacerFrontend} from './SpacerFrontend';
+
+const {__} = wp.i18n;
+const {
+  PanelBody,
+  __experimentalUnitControl: UnitControl,
+} = wp.components;
+
 
 export const SpacerEditor = ({attributes, isSelected, setAttributes}) => {
-  const toAttribute = attributeName => value => {
+
+  const toAttribute = useCallback(attributeName => value => {
     if (isSelected) {
       setAttributes({[attributeName]: value});
     }
-  };
+  }, [isSelected, setAttributes]);
 
-  const renderEdit = () => (
+  const renderEdit = useCallback(() => (
     <InspectorControls>
       <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
-        <TextControl
+        <UnitControl
           label={__('Small', 'planet4-blocks-backend')}
-          help={__('Viewport width up to 768px', 'planet4-blocks-backend')}
-          type="number"
+          help={__('Apply to screens up to 768px', 'planet4-blocks-backend')}
           value={attributes.small}
-          onChange={value => toAttribute('small')(Number(value))}
+          onChange={value => toAttribute('small')(value)}
         />
-        <TextControl
+        <UnitControl
           label={__('Medium', 'planet4-blocks-backend')}
-          help={__('Viewport width higher than 768px', 'planet4-blocks-backend')}
-          type="number"
+          help={__('Apply to screens that are more than 768px', 'planet4-blocks-backend')}
           value={attributes.medium}
-          onChange={value => toAttribute('medium')(Number(value))}
+          onChange={value => toAttribute('medium')(value)}
         />
-        <TextControl
+        <UnitControl
           label={__('Large', 'planet4-blocks-backend')}
-          help={__('Viewport width higher than 992px', 'planet4-blocks-backend')}
-          type="number"
+          help={__('Apply to screens that are more than 992px', 'planet4-blocks-backend')}
           value={attributes.large}
-          onChange={value => toAttribute('large')(Number(value))}
+          onChange={value => toAttribute('large')(value)}
         />
-        <TextControl
+        <UnitControl
           label={__('XLarge', 'planet4-blocks-backend')}
-          help={__('Viewport width higher than 1200px', 'planet4-blocks-backend')}
-          type="number"
+          help={__('Apply to screens that are more than 1200px', 'planet4-blocks-backend')}
           value={attributes.xlarge}
-          onChange={value => toAttribute('xlarge')(Number(value))}
+          onChange={value => toAttribute('xlarge')(value)}
+        />
+        <UnitControl
+          label={__('XXLarge', 'planet4-blocks-backend')}
+          help={__('Apply to screens that are more than 1600px', 'planet4-blocks-backend')}
+          value={attributes.xxlarge}
+          onChange={value => toAttribute('xxlarge')(value)}
         />
       </PanelBody>
     </InspectorControls>
-  );
+  ), [attributes, toAttribute]);
 
-  const renderView = () => (
-    <SpacerFrontend attributes={attributes} />
-  )
+  const renderView = useCallback(() => {
+    return <SpacerFrontend attributes={attributes} />;
+  }, [attributes]);
 
-  return (
+  return useMemo(() => (
     <>
       {isSelected && renderEdit()}
       {renderView()}
     </>
-  );
+  ), [isSelected, renderEdit, renderView]);
 };
 

--- a/assets/src/blocks/Spacer/SpacerEditor.js
+++ b/assets/src/blocks/Spacer/SpacerEditor.js
@@ -1,0 +1,61 @@
+import {
+  TextControl,
+  PanelBody,
+} from '@wordpress/components';
+import {InspectorControls} from '@wordpress/block-editor';
+import { SpacerFrontend } from './SpacerFrontend';
+
+export const SpacerEditor = ({attributes, isSelected, setAttributes}) => {
+  const toAttribute = attributeName => value => {
+    if (isSelected) {
+      setAttributes({[attributeName]: value});
+    }
+  };
+
+  const renderEdit = () => (
+    <InspectorControls>
+      <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
+        <TextControl
+          label={__('Small', 'planet4-blocks-backend')}
+          help={__('Viewport width up to 768px', 'planet4-blocks-backend')}
+          type="number"
+          value={attributes.small}
+          onChange={value => toAttribute('small')(Number(value))}
+        />
+        <TextControl
+          label={__('Medium', 'planet4-blocks-backend')}
+          help={__('Viewport width higher than 768px', 'planet4-blocks-backend')}
+          type="number"
+          value={attributes.medium}
+          onChange={value => toAttribute('medium')(Number(value))}
+        />
+        <TextControl
+          label={__('Large', 'planet4-blocks-backend')}
+          help={__('Viewport width higher than 992px', 'planet4-blocks-backend')}
+          type="number"
+          value={attributes.large}
+          onChange={value => toAttribute('large')(Number(value))}
+        />
+        <TextControl
+          label={__('XLarge', 'planet4-blocks-backend')}
+          help={__('Viewport width higher than 1200px', 'planet4-blocks-backend')}
+          type="number"
+          value={attributes.xlarge}
+          onChange={value => toAttribute('xlarge')(Number(value))}
+        />
+      </PanelBody>
+    </InspectorControls>
+  );
+
+  const renderView = () => (
+    <SpacerFrontend attributes={attributes} />
+  )
+
+  return (
+    <>
+      {isSelected && renderEdit()}
+      {renderView()}
+    </>
+  );
+};
+

--- a/assets/src/blocks/Spacer/SpacerEditorScript.js
+++ b/assets/src/blocks/Spacer/SpacerEditorScript.js
@@ -1,3 +1,3 @@
 import {registerSpacerBlock} from './SpacerBlock';
-console.log('Spacer Editor sctipt')
+
 registerSpacerBlock();

--- a/assets/src/blocks/Spacer/SpacerEditorScript.js
+++ b/assets/src/blocks/Spacer/SpacerEditorScript.js
@@ -1,0 +1,3 @@
+import {registerSpacerBlock} from './SpacerBlock';
+console.log('Spacer Editor sctipt')
+registerSpacerBlock();

--- a/assets/src/blocks/Spacer/SpacerFrontend.js
+++ b/assets/src/blocks/Spacer/SpacerFrontend.js
@@ -4,7 +4,9 @@ export const SpacerFrontend = ({attributes}) => {
   const [size, setSize] = useState();
 
   const updateSize = useCallback(() => {
-    if(window.innerWidth > 1200) {
+    if(window.innerWidth > 1600) {
+      setSize(attributes.xxlarge);
+    } else if(window.innerWidth > 1200) {
       setSize(attributes.xlarge);
     } else if(window.innerWidth > 992) {
       setSize(attributes.large);
@@ -13,17 +15,23 @@ export const SpacerFrontend = ({attributes}) => {
     } else {
       setSize(attributes.small);
     }
-  }, [size]);
+  }, [attributes]);
 
   useEffect(() => {
-    window.addEventListener('resize', function(evt) {
+    updateSize();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [attributes]);
+
+  useEffect(() => {
+    window.addEventListener('resize', () => {
       updateSize();
-    })
+    });
 
     updateSize();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return useMemo(() => (
-    <div style={{height: `${size}px`, backgroundColor: 'lightgrey'}} />
-  ), [attributes, size]);
-}
+    <div style={{height: size}} />
+  ), [size]);
+};

--- a/assets/src/blocks/Spacer/SpacerFrontend.js
+++ b/assets/src/blocks/Spacer/SpacerFrontend.js
@@ -1,0 +1,29 @@
+import {useCallback, useEffect, useMemo, useState} from '@wordpress/element';
+
+export const SpacerFrontend = ({attributes}) => {
+  const [size, setSize] = useState();
+
+  const updateSize = useCallback(() => {
+    if(window.innerWidth > 1200) {
+      setSize(attributes.xlarge);
+    } else if(window.innerWidth > 992) {
+      setSize(attributes.large);
+    } else if(window.innerWidth > 768) {
+      setSize(attributes.medium);
+    } else {
+      setSize(attributes.small);
+    }
+  }, [size]);
+
+  useEffect(() => {
+    window.addEventListener('resize', function(evt) {
+      updateSize();
+    })
+
+    updateSize();
+  }, []);
+
+  return useMemo(() => (
+    <div style={{height: `${size}px`, backgroundColor: 'lightgrey'}} />
+  ), [attributes, size]);
+}

--- a/assets/src/blocks/Spacer/SpacerScript.js
+++ b/assets/src/blocks/Spacer/SpacerScript.js
@@ -1,0 +1,4 @@
+import {SpacerFrontend} from './SpacerFrontend';
+import {hydrateBlock} from '../../functions/hydrateBlock';
+
+hydrateBlock('planet4-blocks/spacer', SpacerFrontend);

--- a/classes/blocks/class-spacer.php
+++ b/classes/blocks/class-spacer.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Spacer block class
+ *
+ * @package P4GBKS
+ * @since 0.1
+ */
+
+namespace P4GBKS\Blocks;
+
+/**
+ * Class Spacer
+ *
+ * @package P4GBKS\Blocks
+ */
+class Spacer extends Base_Block {
+
+	/**
+	 * Block name.
+	 *
+	 * @const string BLOCK_NAME.
+	 */
+	const BLOCK_NAME = 'spacer';
+	/**
+	 * Spacer constructor.
+	 */
+	public function __construct() {
+		add_action( 'init', [ $this, 'register_gallery_block' ] );
+	}
+
+	/**
+	 * Register Gallery block.
+	 */
+	public function register_gallery_block() {
+		register_block_type(
+			self::get_full_block_name(),
+			[  // - Register the block for the editor
+				'editor_script' => 'planet4-blocks',  // in the PHP side.
+				'render_callback' => static function ( $attributes, $content ) {
+					return self::hydrate_frontend( $attributes, $content );
+				},
+				'attributes'    => [
+					'small' => [
+						'type'    => 'number',
+						'default' => 10,
+					],
+					'medium' => [
+						'type'    => 'number',
+						'default' => 10,
+					],
+					'large' => [
+						'type'    => 'number',
+						'default' => 10,
+					],
+					'xlarge' => [
+						'type'    => 'number',
+						'default' => 10,
+					],
+				],
+			]
+		);
+
+		add_action( 'enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ] );
+		add_action( 'wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ] );
+	}
+
+	/**
+	 * Required by the `Base_Block` class.
+	 *
+	 * @param array $fields Unused, required by the abstract function.
+	 */
+	public function prepare_data( $fields ): array {
+		return [];
+	}
+}

--- a/classes/blocks/class-spacer.php
+++ b/classes/blocks/class-spacer.php
@@ -25,36 +25,40 @@ class Spacer extends Base_Block {
 	 * Spacer constructor.
 	 */
 	public function __construct() {
-		add_action( 'init', [ $this, 'register_gallery_block' ] );
+		add_action( 'init', [ $this, 'register_block' ] );
 	}
 
 	/**
-	 * Register Gallery block.
+	 * Register Spacer block.
 	 */
-	public function register_gallery_block() {
+	public function register_block() {
 		register_block_type(
 			self::get_full_block_name(),
 			[  // - Register the block for the editor
-				'editor_script' => 'planet4-blocks',  // in the PHP side.
+				'editor_script'   => 'planet4-blocks',  // in the PHP side.
 				'render_callback' => static function ( $attributes, $content ) {
 					return self::hydrate_frontend( $attributes, $content );
 				},
-				'attributes'    => [
-					'small' => [
-						'type'    => 'number',
-						'default' => 10,
+				'attributes'      => [
+					'small'   => [
+						'type'    => 'string',
+						'default' => '16px',
 					],
-					'medium' => [
-						'type'    => 'number',
-						'default' => 10,
+					'medium'  => [
+						'type'    => 'string',
+						'default' => '16px',
 					],
-					'large' => [
-						'type'    => 'number',
-						'default' => 10,
+					'large'   => [
+						'type'    => 'string',
+						'default' => '16px',
 					],
-					'xlarge' => [
-						'type'    => 'number',
-						'default' => 10,
+					'xlarge'  => [
+						'type'    => 'string',
+						'default' => '16px',
+					],
+					'xxlarge' => [
+						'type'    => 'string',
+						'default' => '16px',
 					],
 				],
 			]

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -84,6 +84,7 @@ final class Loader {
 		new Blocks\SocialMediaCards();
 		new Blocks\ENForm();
 		new Blocks\GuestBook();
+		new Blocks\Spacer();
 
 		/**
 		 * Create Planet 4 block patterns categories.

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -115,7 +115,6 @@ const POST_BLOCK_TYPES = [
 	'planet4-blocks/spreadsheet',
 	'planet4-blocks/take-action-boxout',
 	'planet4-blocks/timeline',
-	'planet4-blocks/spacer',
 	'leadin/hubspot-form-block',
 	'gravityforms/form',
 ];
@@ -139,7 +138,6 @@ const PAGE_BLOCK_TYPES = [
 	'planet4-blocks/timeline',
 	'planet4-blocks/enform',
 	'planet4-blocks/guestbook',
-	'planet4-blocks/spacer',
 	'leadin/hubspot-form-block',
 	'gravityforms/form',
 ];

--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -115,6 +115,7 @@ const POST_BLOCK_TYPES = [
 	'planet4-blocks/spreadsheet',
 	'planet4-blocks/take-action-boxout',
 	'planet4-blocks/timeline',
+	'planet4-blocks/spacer',
 	'leadin/hubspot-form-block',
 	'gravityforms/form',
 ];
@@ -138,6 +139,7 @@ const PAGE_BLOCK_TYPES = [
 	'planet4-blocks/timeline',
 	'planet4-blocks/enform',
 	'planet4-blocks/guestbook',
+	'planet4-blocks/spacer',
 	'leadin/hubspot-form-block',
 	'gravityforms/form',
 ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,7 @@ const publicJsConfig = {
     TimelineScript: './assets/src/blocks/Timeline/TimelineScript.js',
     GalleryScript: './assets/src/blocks/Gallery/GalleryScript.js',
     GuestBookScript: './assets/src/blocks/GuestBook/GuestBookScript.js',
+    SpacerScript: './assets/src/blocks/Spacer/SpacerScript.js',
   },
 };
 const adminJsConfig = {
@@ -67,8 +68,10 @@ const adminJsConfig = {
     SocialMediaEditorScript: './assets/src/blocks/SocialMedia/SocialMediaEditorScript.js',
     GalleryEditorScript: './assets/src/blocks/Gallery/GalleryEditorScript.js',
     GuestBookEditorScript: './assets/src/blocks/GuestBook/GuestBookEditorScript.js',
+    SpacerEditorScript: './assets/src/blocks/Spacer/SpacerEditorScript.js',
   },
 };
+
 const cssConfig = {
   ...defaultConfig,
   entry: {


### PR DESCRIPTION
# Description
We deal with a bunch of UI issues when we use the `core/spacer` since you are able only to define one size. Thus, it's hard to fit with responsive UI.
Could be great if we can define inline `@media query` but according to [W3](https://www.w3docs.com/snippets/css/is-it-possible-to-use-the-css-media-rule-inline.html), that is not possible for now.

Within the new `'planet4-blocks/spacer'`, you'll be able to define for `small`, `medium`, `large` and `extra large` screens.

![Screenshot 2023-09-08 at 08 46 09](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/assets/77975803/ffaf9421-188b-418d-84ea-7a37394a39fc)

This new implementation will help us to solve more easier these different tickets (and among others!):
- [PLANET-7226](https://jira.greenpeace.org/browse/PLANET-7226)
- [PLANET-7228](https://jira.greenpeace.org/browse/PLANET-7228)
- [PLANET-7230](https://jira.greenpeace.org/browse/PLANET-7230)

## Testing
Just create a new page and add a `'planet4-blocks/spacer'`. Then, play around with different sizes through different medias.

https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/assets/77975803/82621ae6-e568-46a3-b148-b32852d9d4a1

