### PR TITLE
Implement new planet4 block pattern class names

### DIFF
--- a/assets/src/block-templates/register.js
+++ b/assets/src/block-templates/register.js
@@ -19,7 +19,13 @@ const setSupport = metadata => {
 };
 
 export const registerBlockTemplates = blockTemplates => {
-  const templates = blockTemplates || templateList;
+  const templates = blockTemplates || Object.keys(templateList).map(type => templateList[type].map(template => ({
+    ...template,
+    metadata: {
+      ...template.metadata,
+      type,
+    },
+  }))).flat();
   const postType = getCurrentPostType();
 
   templates.forEach(blockTemplate => {
@@ -34,7 +40,29 @@ export const registerBlockTemplates = blockTemplates => {
 
     registerBlockType(metadata, {
       edit: edit(template, templateLock),
-      save,
+      save: props => {
+        if(props.innerBlocks.length) {
+          const className = `${props.innerBlocks[0].attributes.className || ''}`;
+          let patternClassName = '';
+
+          switch (metadata.type) {
+          case 'planet4':
+            patternClassName = 'planet4-pattern';
+            break;
+          case 'pageHeaders':
+            patternClassName = 'page-headers-pattern';
+            break;
+          case 'layouts':
+            patternClassName = 'planet4-layout-pattern';
+            break;
+          }
+
+          if(!className.includes(patternClassName)) {
+            props.innerBlocks[0].attributes.className = `${className} ${patternClassName}`;
+          }
+        }
+        return save();
+      },
     });
   });
 };

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -13,21 +13,29 @@ import * as action from './action';
 import * as getInformed from './get-informed';
 import * as highLevelTopic from './high-level-topic';
 
-export default [
-  sideImgTextCta,
-  quickLinks,
-  deepDive,
-  realityCheck,
-  issues,
-  pageHeader,
-  highlightedCta,
-
-  // layouts.
-  deepDiveTopic,
-  homepage,
-  campaign,
-  takeAction,
-  action,
-  getInformed,
-  highLevelTopic,
-];
+export default {
+  // This section should be match against the 'Categories' Array for each block pattern
+  // Planet 4 patterns
+  planet4: [
+    sideImgTextCta,
+    quickLinks,
+    deepDive,
+    realityCheck,
+    issues,
+    highlightedCta,
+  ],
+  // Page Headers patterns
+  pageHeaders: [
+    pageHeader,
+  ],
+  // Layouts patterns
+  layouts: [
+    deepDiveTopic,
+    homepage,
+    campaign,
+    takeAction,
+    action,
+    getInformed,
+    highLevelTopic,
+  ],
+};


### PR DESCRIPTION
# Description
Modify the way of rendering block templates. This will allow us to get the proper class name assigned to any `planet4 block pattern` and finally then style it instead of making tricky implementations to `groups`.

This new implementation will help us to solve more easier these different tickets (and among others!):
- [PLANET-7226](https://jira.greenpeace.org/browse/PLANET-7226)
- [PLANET-7228](https://jira.greenpeace.org/browse/PLANET-7228)
- [PLANET-7230](https://jira.greenpeace.org/browse/PLANET-7230)

## Testing
Just navigate to [this demo page](https://www-dev.greenpeace.org/test-mars/campaign-demo-page/), open the console and run `document.querySelector(".planet4-layout-pattern")` OR `document.querySelector(".page-headers-pattern")` OR `document.querySelector(".planet4-pattern")`.
