### PR TITLE
Disable Split Two Columns blocks on new IA

### DIFF
--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -132,7 +132,6 @@ const PAGE_BLOCK_TYPES = [
 	'planet4-blocks/happypoint',
 	'planet4-blocks/media-video',
 	'planet4-blocks/social-media',
-	'planet4-blocks/split-two-columns',
 	'planet4-blocks/spreadsheet',
 	'planet4-blocks/submenu',
 	'planet4-blocks/timeline',
@@ -186,7 +185,6 @@ const ACTION_BLOCK_TYPES = [
 	'planet4-blocks/happypoint',
 	'planet4-blocks/media-video',
 	'planet4-blocks/social-media',
-	'planet4-blocks/split-two-columns',
 	'planet4-blocks/spreadsheet',
 	'planet4-blocks/submenu',
 	'planet4-blocks/timeline',
@@ -290,6 +288,7 @@ function set_allowed_block_types( $allowed_block_types, $context ) {
 		PAGE_BLOCK_TYPES,
 		! Features::is_active( 'beta_blocks' ) ? [] : BETA_PAGE_BLOCK_TYPES,
 		! $enform_active ? [] : [ 'planet4-blocks/enform' ],
+		(bool) planet4_get_option( 'new_ia' ) ? [] : [ 'planet4-blocks/split-two-columns' ],
 		BLOCK_TEMPLATES,
 	);
 

--- a/tests/e2e/split-two-columns.spec.js
+++ b/tests/e2e/split-two-columns.spec.js
@@ -4,6 +4,13 @@ import {publishPostAndVisit} from './tools/lib/post.js';
 test.useAdminLoggedIn();
 
 test('Create and check check split two column block', async ({page, admin, editor}) => {
+  await admin.visitAdminPage('admin.php', 'page=planet4_settings_navigation');
+  const checkbox = page.locator('#new_ia');
+  const featureIsActiveOnInstance = await checkbox.isChecked();
+  if (featureIsActiveOnInstance) {
+    test.skip();
+  }
+
   await admin.createNewPost({postType: 'page', title: 'Test S2C block', legacyCanvas: true});
 
   // Adding Split Two Column Block


### PR DESCRIPTION
This disables the block when new IA is enabled. The block relies on Explore page children pages, so it can't be used when new IA feature flag is on.

This also conditionally runs its e2e test only when new IA is off.

### Testing

1. Disable new IA from: _Planet 4 > Navigation_
2. Navigate to the plugin directory and run: `npx playwright test tests/e2e/split-two-columns.spec.js`
3. Test should pass
4. Enabled new IA form: _Planet 4 > Navigation_
5. Re-run: `npx playwright test tests/e2e/split-two-columns.spec.js`
6. Test should pass (report should say skipped)