### PR TITLE
PLANET-7252: Incorrect typeface used for caption in Gallery Carousel block

### DIFF
--- a/assets/src/styles/blocks/Gallery/styles/GalleryCarousel.scss
+++ b/assets/src/styles/blocks/Gallery/styles/GalleryCarousel.scss
@@ -109,7 +109,7 @@
     p {
       color: $grey-60;
       font-size: $font-size-xxs;
-      font-family: var(--headings--font-family);
+      font-family: var(--image-figcaption--font-family, var(--headings--font-family));
       line-height: 1.4;
       margin-bottom: 0;
       display: -webkit-box;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7252

> Replace the "GP Sans" with the "Source Sans3" typeface for the caption of images in the Gallery Carousel block.


![Screenshot from 2023-09-12 10-55-30](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/assets/617346/4b330867-fa24-4419-b938-11d3fd693354)

## Test

On local or [test instance](https://www-dev.greenpeace.org/test-rhea/about-us-2/)
- check that carousel caption font is `SourceSans3` with new Visual identity is enabled (in Appearance > Customize > Site Identity)