### PR TITLE
Refactor Timeline block to use hydration

### DIFF
--- a/assets/src/blocks/Timeline/TimelineBlock.js
+++ b/assets/src/blocks/Timeline/TimelineBlock.js
@@ -1,5 +1,7 @@
+import {renderToString} from 'react-dom/server';
 import {frontendRendered} from '../frontendRendered';
 import {TimelineEditor} from './TimelineEditorScript';
+import {TimelineFrontend} from './TimelineFrontend';
 
 const BLOCK_NAME = 'planet4-blocks/timeline';
 
@@ -32,6 +34,7 @@ const attributes = {
 
 export const registerTimelineBlock = () => {
   const {registerBlockType} = wp.blocks;
+  const {RawHTML} = wp.element;
 
   registerBlockType(BLOCK_NAME, {
     title: 'Timeline',
@@ -42,8 +45,22 @@ export const registerTimelineBlock = () => {
     },
     attributes,
     edit: TimelineEditor,
-    save: frontendRendered(BLOCK_NAME),
+    save: props => {
+      const markup = renderToString(
+        <div
+          data-hydrate={BLOCK_NAME}
+          data-attributes={JSON.stringify(props.attributes)}
+        >
+          <TimelineFrontend {...props} />
+        </div>
+      );
+      return <RawHTML>{markup}</RawHTML>;
+    },
     deprecated: [
+      {
+        attributes,
+        save: frontendRendered(BLOCK_NAME),
+      },
       {
         attributes,
         save() {

--- a/assets/src/blocks/Timeline/TimelineFrontend.js
+++ b/assets/src/blocks/Timeline/TimelineFrontend.js
@@ -1,12 +1,12 @@
 import {Timeline} from './Timeline';
 
-export const TimelineFrontend = props => {
+export const TimelineFrontend = ({attributes}) => {
   const {
     timeline_title,
     description,
     className,
     ...nodeProps
-  } = props;
+  } = attributes;
 
   return (
     <section className={`block timeline-block ${className ?? ''}`}>

--- a/assets/src/blocks/Timeline/TimelineScript.js
+++ b/assets/src/blocks/Timeline/TimelineScript.js
@@ -1,10 +1,5 @@
 import {TimelineFrontend} from './TimelineFrontend';
+import {hydrateBlock} from '../../functions/hydrateBlock';
 
-document.addEventListener('DOMContentLoaded', () => {
-  const timelineBlocks = [...document.querySelectorAll('[data-render="planet4-blocks/timeline"]')];
+hydrateBlock('planet4-blocks/timeline', TimelineFrontend);
 
-  timelineBlocks.forEach(blockNode => {
-    const attributes = JSON.parse(blockNode.dataset.attributes);
-    wp.element.render(<TimelineFrontend {...attributes.attributes} />, blockNode);
-  });
-});

--- a/classes/blocks/class-timeline.php
+++ b/classes/blocks/class-timeline.php
@@ -40,7 +40,7 @@ class Timeline extends Base_Block {
 			[
 				'editor_script'   => 'planet4-blocks',
 				// todo: Remove when all content is migrated.
-				'render_callback' => [ self::class, 'render_frontend' ],
+				'render_callback' => [ self::class, 'hydrate_frontend' ],
 				'attributes'      => [
 					'timeline_title'    => [
 						'type'    => 'string',


### PR DESCRIPTION
### Description

See [PLANET-6917](https://jira.greenpeace.org/browse/PLANET-6917)
This is to stop using the deprecated `frontendRendered` function.

### Testing

The Timeline (both old and new blocks) should still behave as expected. You can use [this sheet](https://docs.google.com/spreadsheets/d/1XruuRzjiu4t2ia7NaBXMqItr4NAbc7ctcolg1uhlIL4/edit#gid=0) for testing! It seems that the Timeline block is broken in test instances, I get a message error there (both before and after this refactor, there's actually a [bug ticket](https://jira.greenpeace.org/browse/PLANET-7175) about it) but on local it works fine