### PR TITLE
Refactor ENForm block to use hydration

### DIFF
--- a/assets/src/blocks/ENForm/ENFormBlock.js
+++ b/assets/src/blocks/ENForm/ENFormBlock.js
@@ -1,43 +1,15 @@
+import {renderToString} from 'react-dom/server';
 import {ENFormEditor} from './ENFormEditor';
+import {ENFormFrontend} from './ENFormFrontend';
 import {ENFormV1} from './deprecated/ENFormV1.js';
-import {frontendRendered} from '../frontendRendered';
+import {ENFormV2} from './deprecated/ENFormV2.js';
 
-const {__} = wp.i18n;
-const BLOCK_NAME = 'planet4-blocks/enform';
-
-const attributes = {
-  en_page_id: {type: 'integer'},
-  enform_goal: {type: 'string'},
-  en_form_style: {type: 'string', default: 'side-style'},
-  title: {type: 'string'},
-  description: {type: 'string'},
-  campaign_logo: {type: 'boolean'},
-  content_title: {type: 'string'},
-  content_title_size: {type: 'string', default: 'h1'},
-  content_description: {type: 'string'},
-  button_text: {type: 'string'},
-  text_below_button: {type: 'string'},
-  thankyou_title: {type: 'string'},
-  thankyou_subtitle: {type: 'string'},
-  thankyou_donate_message: {type: 'string'},
-  thankyou_social_media_message: {type: 'string'},
-  donate_button_checkbox: {type: 'boolean'},
-  donate_text: {type: 'string', default: __('Donate', 'planet4-engagingnetworks')},
-  thankyou_url: {type: 'string'},
-  custom_donate_url: {type: 'string'},
-  background: {type: 'integer'},
-  background_image_src: {type: 'string', default: ''},
-  background_image_srcset: {type: 'string'},
-  background_image_sizes: {type: 'string'},
-  background_image_focus: {type: 'string', default: '50% 50%'},
-  en_form_id: {type: 'integer'},
-  en_form_fields: {type: 'array', default: []},
-  social: {type: 'object', default: {}},
-  social_accounts: {type: 'object', default: {}},
-};
+export const BLOCK_NAME = 'planet4-blocks/enform';
 
 export const registerENForm = () => {
   const {registerBlockType} = wp.blocks;
+  const {RawHTML} = wp.element;
+  const {__} = wp.i18n;
 
   registerBlockType(BLOCK_NAME, {
     title: 'EN Form',
@@ -51,15 +23,51 @@ export const registerENForm = () => {
       {name: 'full-width', label: 'Page body/text size width'},
       {name: 'side-style', label: 'Form on the side', isDefault: true},
     ],
-    attributes,
+    attributes: {
+      en_page_id: {type: 'integer'},
+      enform_goal: {type: 'string'},
+      en_form_style: {type: 'string', default: 'side-style'},
+      title: {type: 'string'},
+      description: {type: 'string'},
+      campaign_logo: {type: 'boolean'},
+      content_title: {type: 'string'},
+      content_title_size: {type: 'string', default: 'h1'},
+      content_description: {type: 'string'},
+      button_text: {type: 'string'},
+      text_below_button: {type: 'string'},
+      thankyou_title: {type: 'string'},
+      thankyou_subtitle: {type: 'string'},
+      thankyou_donate_message: {type: 'string'},
+      thankyou_social_media_message: {type: 'string'},
+      donate_button_checkbox: {type: 'boolean'},
+      donate_text: {type: 'string', default: __('Donate', 'planet4-engagingnetworks')},
+      thankyou_url: {type: 'string'},
+      custom_donate_url: {type: 'string'},
+      background: {type: 'integer'},
+      background_image_src: {type: 'string', default: ''},
+      background_image_srcset: {type: 'string'},
+      background_image_sizes: {type: 'string'},
+      background_image_focus: {type: 'string', default: '50% 50%'},
+      en_form_id: {type: 'integer'},
+      en_form_fields: {type: 'array', default: []},
+      social: {type: 'object', default: {}},
+      social_accounts: {type: 'object', default: {}},
+    },
     edit: ENFormEditor,
     save: props => {
       // Sort attributes in a predictable order
-      const ordered_attrs = Object.fromEntries(Object.entries(props.attributes).sort());
+      const orderedAttributes = Object.fromEntries(Object.entries(props.attributes).sort());
 
-      return frontendRendered(BLOCK_NAME)(ordered_attrs, props?.className);
+      const markup = renderToString(<div
+        data-hydrate={BLOCK_NAME}
+        data-attributes={JSON.stringify(orderedAttributes)}
+      >
+        <ENFormFrontend attributes={orderedAttributes} />
+      </div>);
+      return <RawHTML>{markup}</RawHTML>;
     },
     deprecated: [
+      ENFormV2,
       ENFormV1,
     ],
   });

--- a/assets/src/blocks/ENForm/ENFormFrontend.js
+++ b/assets/src/blocks/ENForm/ENFormFrontend.js
@@ -8,7 +8,7 @@ import {inputId} from './inputId';
 
 const {__} = wp.i18n;
 
-export const ENFormFrontend = attributes => {
+export const ENFormFrontend = ({attributes}) => {
   const {
     en_page_id,
     en_form_id,

--- a/assets/src/blocks/ENForm/ENFormScript.js
+++ b/assets/src/blocks/ENForm/ENFormScript.js
@@ -1,10 +1,5 @@
 import {ENFormFrontend} from './ENFormFrontend';
-import {createRoot} from 'react-dom/client';
+import {hydrateBlock} from '../../functions/hydrateBlock';
 
-document.querySelectorAll('[data-render=\'planet4-blocks/enform\']').forEach(
-  blockNode => {
-    const attributes = JSON.parse(blockNode.dataset.attributes);
-    const rootElement = createRoot(blockNode);
-    rootElement.render(<ENFormFrontend {...attributes.attributes} />);
-  }
-);
+hydrateBlock('planet4-blocks/enform', ENFormFrontend);
+

--- a/assets/src/blocks/ENForm/deprecated/ENFormV2.js
+++ b/assets/src/blocks/ENForm/deprecated/ENFormV2.js
@@ -1,0 +1,43 @@
+import {BLOCK_NAME} from '../ENFormBlock';
+import {frontendRendered} from '../../frontendRendered';
+
+const {__} = wp.i18n;
+
+export const ENFormV2 = {
+  attributes: {
+    en_page_id: {type: 'integer'},
+    enform_goal: {type: 'string'},
+    en_form_style: {type: 'string', default: 'side-style'},
+    title: {type: 'string'},
+    description: {type: 'string'},
+    campaign_logo: {type: 'boolean'},
+    content_title: {type: 'string'},
+    content_title_size: {type: 'string', default: 'h1'},
+    content_description: {type: 'string'},
+    button_text: {type: 'string'},
+    text_below_button: {type: 'string'},
+    thankyou_title: {type: 'string'},
+    thankyou_subtitle: {type: 'string'},
+    thankyou_donate_message: {type: 'string'},
+    thankyou_social_media_message: {type: 'string'},
+    donate_button_checkbox: {type: 'boolean'},
+    donate_text: {type: 'string', default: __('Donate', 'planet4-engagingnetworks')},
+    thankyou_url: {type: 'string'},
+    custom_donate_url: {type: 'string'},
+    background: {type: 'integer'},
+    background_image_src: {type: 'string', default: ''},
+    background_image_srcset: {type: 'string'},
+    background_image_sizes: {type: 'string'},
+    background_image_focus: {type: 'string', default: '50% 50%'},
+    en_form_id: {type: 'integer'},
+    en_form_fields: {type: 'array', default: []},
+    social: {type: 'object', default: {}},
+    social_accounts: {type: 'object', default: {}},
+  },
+  save: props => {
+    // Sort attributes in a predictable order
+    const ordered_attrs = Object.fromEntries(Object.entries(props.attributes).sort());
+
+    return frontendRendered(BLOCK_NAME)(ordered_attrs, props?.className);
+  },
+};

--- a/assets/src/frontendIndex.js
+++ b/assets/src/frontendIndex.js
@@ -6,7 +6,6 @@ import {MediaFrontend} from './blocks/Media/MediaFrontend';
 import {ColumnsFrontend} from './blocks/Columns/ColumnsFrontend';
 import {setupMediaElementJS} from './blocks/Media/setupMediaElementJS';
 import {setupLightboxForImages} from './components/Lightbox/setupLightboxForImages';
-import {ENFormFrontend} from './blocks/ENForm/ENFormFrontend';
 import {setupParallax} from './components/Parallax/setupParallax';
 
 import {createRoot} from 'react-dom/client';
@@ -19,7 +18,6 @@ const COMPONENTS = {
   'planet4-blocks/submenu': SubmenuFrontend,
   'planet4-blocks/media-video': MediaFrontend,
   'planet4-blocks/columns': ColumnsFrontend,
-  'planet4-blocks/enform': ENFormFrontend,
 };
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/classes/blocks/class-enform.php
+++ b/classes/blocks/class-enform.php
@@ -116,10 +116,10 @@ class ENForm extends Base_Block {
 			$block_name,
 			[
 				'attributes'      => static::$attributes,
-				'render_callback' => function ( $attributes ) {
+				'render_callback' => function ( $attributes, $content ) {
 					$attributes = static::update_data( $attributes );
 
-					return self::render_frontend( $attributes );
+					return self::hydrate_frontend( $attributes, $content );
 				},
 			]
 		);


### PR DESCRIPTION
### Description

See [PLANET-6917](https://jira.greenpeace.org/browse/PLANET-6917)
This is to stop using the deprecated `frontendRendered` function

### Testing

Both existing and new EN form blocks should still behave as expected in the frontend and in the editor.