### PR TITLE
Use requested post types in block count

### DIFF
--- a/classes/search/block/class-blockusage.php
+++ b/classes/search/block/class-blockusage.php
@@ -94,7 +94,7 @@ class BlockUsage {
 			'include'     => $posts_ids,
 			'orderby'     => empty( $params->order() ) ? null : array_fill_keys( $params->order(), 'ASC' ),
 			'post_status' => $params->post_status(),
-			'post_type'   => [ 'post', 'page', 'campaign' ],
+			'post_type'   => $params->post_type(),
 		];
 
 		$this->posts = get_posts( $posts_args ) ?? [];

--- a/classes/search/block/class-blockusageapi.php
+++ b/classes/search/block/class-blockusageapi.php
@@ -37,7 +37,15 @@ class BlockUsageApi {
 	public function __construct() {
 		$this->usage  = new BlockUsage();
 		$this->params = ( new Parameters() )
-			->with_post_status( self::DEFAULT_POST_STATUS );
+			->with_post_status( self::DEFAULT_POST_STATUS )
+			->with_post_type(
+				\get_post_types(
+					[
+						'public'              => true,
+						'exclude_from_search' => false,
+					]
+				)
+			);
 	}
 
 	/**


### PR DESCRIPTION
Block count was filtering blocks for only post/page/campaign post types, missing at least p4_action.

## Test 
- Create an action page (`p4_action`) and add a block to it
  - it should appear in block report (Blocks > Report)