### PR TITLE
PLANET-7256 Refactor post Post Types selector

### DIFF
--- a/assets/src/replaceTaxonomyTermSelectors.js
+++ b/assets/src/replaceTaxonomyTermSelectors.js
@@ -1,4 +1,4 @@
-import AssignOnlyFlatTermSelector from './components/AssignOnlyFlatTermSelector/AssignOnlyFlatTermSelector';
+import {AssignOnlyFlatTermSelector} from './components/AssignOnlyFlatTermSelector/AssignOnlyFlatTermSelector';
 import {TermSelector} from './components/TermSelector/TermSelector';
 
 function customizeTaxonomySelectors(OriginalComponent) {


### PR DESCRIPTION
### Description

See [PLANET-7256](https://jira.greenpeace.org/browse/PLANET-7256)
For this component we override a [WordPress component](https://github.com/WordPress/gutenberg/blob/master/packages/editor/src/components/post-taxonomies/flat-term-selector.js) that they rewrote since then, so we need to update our version too. We essentially use the same code but remove the possibility to create new post types in the editor.

### Testing

You can test either on any post either on local or on the atlas test instance, and make sure creating new post types isn't possible via the editor.