### PR TITLE
Fix Split Two Columns components name case

### DIFF
--- a/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsEditor.js
+++ b/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsEditor.js
@@ -1,8 +1,8 @@
 import {Fragment} from '@wordpress/element';
 import {BLOCK_NAME, VERSION} from './register';
-import {SplittwocolumnsFrontend} from './SplitTwoColumnsFrontend';
-import {SplittwocolumnsSettings} from './SplitTwoColumnsSettings';
-import {SplittwocolumnsInPlaceEdit} from './SplitTwoColumnsInPlaceEdit';
+import {SplitTwoColumnsFrontend} from './SplitTwoColumnsFrontend';
+import {SplitTwoColumnsSettings} from './SplitTwoColumnsSettings';
+import {SplitTwoColumnsInPlaceEdit} from './SplitTwoColumnsInPlaceEdit';
 
 const {apiFetch} = wp;
 const {useSelect} = wp.data;
@@ -11,7 +11,7 @@ const useImage = (image_id, url) => {
   return useSelect(select => !image_id ? {url} : select('core').getMedia(image_id));
 };
 
-export const SplittwocolumnsEditor = ({attributes, setAttributes, isSelected}) => {
+export const SplitTwoColumnsEditor = ({attributes, setAttributes, isSelected}) => {
   // Todo: Never directly change things in a render, this will cause issues. Render should only render or attach listeners.
   updateDeprecatedData(attributes, setAttributes, BLOCK_NAME, VERSION);
 
@@ -40,15 +40,15 @@ export const SplittwocolumnsEditor = ({attributes, setAttributes, isSelected}) =
   );
 };
 
-const renderView = ({attributes}) => <SplittwocolumnsFrontend {...attributes} />;
+const renderView = ({attributes}) => <SplitTwoColumnsFrontend {...attributes} />;
 const renderEdit = ({attributes}, setAttributes) => {
   const charLimit = {title: 40, description: 400};
   const params = {attributes, charLimit, setAttributes};
 
   return (
     <Fragment>
-      <SplittwocolumnsInPlaceEdit {...params} />
-      <SplittwocolumnsSettings {...params} />
+      <SplitTwoColumnsInPlaceEdit {...params} />
+      <SplitTwoColumnsSettings {...params} />
     </Fragment>
   );
 };

--- a/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsFrontend.js
+++ b/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsFrontend.js
@@ -1,6 +1,6 @@
 import {IMAGE_SIZES} from './imageSizes';
 
-export const SplittwocolumnsFrontend = ({
+export const SplitTwoColumnsFrontend = ({
   title,
   issue_description,
   issue_link_text,

--- a/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsInPlaceEdit.js
+++ b/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsInPlaceEdit.js
@@ -5,7 +5,7 @@ const {__} = wp.i18n;
 
 // WYSIWYG in-place editor
 
-export const SplittwocolumnsInPlaceEdit = ({attributes, setAttributes}) => {
+export const SplitTwoColumnsInPlaceEdit = ({attributes, setAttributes}) => {
   const {
     title,
     issue_description,

--- a/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsSettings.js
+++ b/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsSettings.js
@@ -7,7 +7,7 @@ const {useSelect} = wp.data;
 const {__} = wp.i18n;
 
 // Sidebar settings
-export const SplittwocolumnsSettings = ({attributes, charLimit, setAttributes}) => {
+export const SplitTwoColumnsSettings = ({attributes, charLimit, setAttributes}) => {
   const {
     title,
     select_issue,

--- a/assets/src/blocks/SplitTwoColumns/register.js
+++ b/assets/src/blocks/SplitTwoColumns/register.js
@@ -1,4 +1,4 @@
-import {SplittwocolumnsEditor} from './SplitTwoColumnsEditor';
+import {SplitTwoColumnsEditor} from './SplitTwoColumnsEditor';
 import {frontendRendered} from '../frontendRendered';
 import {splitTwoColumnsV1} from './deprecated/splitTwoColumnsV1';
 
@@ -46,7 +46,7 @@ export const registerSplittwocolumnsBlock = () => {
         tag_image_id: false,
       }},
     },
-    edit: SplittwocolumnsEditor,
+    edit: SplitTwoColumnsEditor,
     save: frontendRendered(BLOCK_NAME),
     supports: {
       html: false, // Disable "Edit as HTMl" block option.

--- a/assets/src/frontendIndex.js
+++ b/assets/src/frontendIndex.js
@@ -1,6 +1,6 @@
 import {ArticlesFrontend} from './blocks/Articles/ArticlesFrontend';
 import {CookiesFrontend} from './blocks/Cookies/CookiesFrontend';
-import {SplittwocolumnsFrontend} from './blocks/SplitTwoColumns/SplitTwoColumnsFrontend';
+import {SplitTwoColumnsFrontend} from './blocks/SplitTwoColumns/SplitTwoColumnsFrontend';
 import {HappypointFrontend} from './blocks/Happypoint/HappypointFrontend';
 import {SubmenuFrontend} from './blocks/Submenu/SubmenuFrontend';
 import {MediaFrontend} from './blocks/Media/MediaFrontend';
@@ -16,7 +16,7 @@ import {createRoot} from 'react-dom/client';
 const COMPONENTS = {
   'planet4-blocks/articles': ArticlesFrontend,
   'planet4-blocks/cookies': CookiesFrontend,
-  'planet4-blocks/split-two-columns': SplittwocolumnsFrontend,
+  'planet4-blocks/split-two-columns': SplitTwoColumnsFrontend,
   'planet4-blocks/happypoint': HappypointFrontend,
   'planet4-blocks/submenu': SubmenuFrontend,
   'planet4-blocks/media-video': MediaFrontend,


### PR DESCRIPTION
### Description

We should use camel case. This is in preparation for a bigger refactor to stop using the deprecated `frontendRendered` function.
