### PR TITLE
Add new command to WP command palette

### DIFF
--- a/assets/src/addNewCommands.js
+++ b/assets/src/addNewCommands.js
@@ -1,0 +1,27 @@
+const {dispatch} = wp.data;
+const {__} = wp.i18n;
+
+const isNewIAEnabled = window.p4ge_vars.planet4_options.new_ia ?? false;
+
+const plusIcon = (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+    <path d="M18 11.2h-5.2V6h-1.6v5.2H6v1.6h5.2V18h1.6v-5.2H18z"></path>
+  </svg>
+);
+
+// Add our custom commands to WordPress command palette introduced in version 6.3.
+export const addNewCommands = () => {
+  if (!isNewIAEnabled) {
+    return;
+  }
+  // Add new Action.
+  dispatch(wp.commands.store).registerCommand({
+    name: 'planet4-blocks/add-new-action',
+    label: __('Add new Action', 'planet4-blocks-backend'),
+    icon: plusIcon,
+    callback: ({close}) => {
+      document.location.href = 'post-new.php?post_type=p4_action';
+      close();
+    },
+  });
+};

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -20,6 +20,7 @@ import {blockEditorValidation} from './BlockEditorValidation';
 import {registerBlock as registerShareButtonsBlock} from './blocks/ShareButtons/ShareButtonsBlock';
 import {registerPageHeaderBlock} from './blocks/PageHeader/PageHeaderBlock';
 import {registerBlockTemplates} from './block-templates/register';
+import {addNewCommands} from './addNewCommands';
 
 blockEditorValidation();
 new ArticlesBlock();
@@ -44,6 +45,7 @@ replaceTaxonomyTermSelectors();
 setupCustomSidebar();
 setUpCssVariables();
 blockEditorValidation();
+addNewCommands();
 
 const {registerBlockVariation} = wp.blocks;
 const {__} = wp.i18n;


### PR DESCRIPTION
### Description

See [docs](https://make.wordpress.org/core/2023/07/17/introducing-the-wordpress-command-palette-api/)
This one is to create a new Action, but we could add more custom ones if needed.

### Testing

Make sure you are using WordPress version 6.3 or later. Then navigate to any post/page/etc and you should see the `Add new Action` command in the palette if the new IA is enabled. You can also test it on the [telesto test instance](https://www-dev.greenpeace.org/test-telesto).