### PR TITLE
Fix Split Two Columns editor component

### DIFF
--- a/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsEditor.js
+++ b/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsEditor.js
@@ -1,4 +1,3 @@
-import {Fragment} from '@wordpress/element';
 import {BLOCK_NAME, VERSION} from './SplitTwoColumnsBlock';
 import {SplitTwoColumnsFrontend} from './SplitTwoColumnsFrontend';
 import {SplitTwoColumnsSettings} from './SplitTwoColumnsSettings';
@@ -9,6 +8,32 @@ const {useSelect} = wp.data;
 
 const useImage = (image_id, url) => {
   return useSelect(select => !image_id ? {url} : select('core').getMedia(image_id));
+};
+
+const renderView = attributes => <SplitTwoColumnsFrontend {...attributes} />;
+const renderEdit = (attributes, setAttributes) => {
+  const charLimit = {title: 40, description: 400};
+  const params = {attributes, charLimit, setAttributes};
+
+  return (
+    <>
+      <SplitTwoColumnsInPlaceEdit {...params} />
+      <SplitTwoColumnsSettings {...params} />
+    </>
+  );
+};
+
+// Query an updated version of attributes when version is deprecated
+const updateDeprecatedData = (attributes, setAttributes, blockName, version) => {
+  if (attributes.version && parseInt(attributes.version) >= version) {
+    return;
+  }
+
+  apiFetch({
+    path: 'planet4/v1/update_block/' + blockName,
+    method: 'POST',
+    data: attributes,
+  }).then(data => setAttributes(data));
 };
 
 export const SplitTwoColumnsEditor = ({attributes, setAttributes, isSelected}) => {
@@ -25,43 +50,17 @@ export const SplitTwoColumnsEditor = ({attributes, setAttributes, isSelected}) =
   const issue_image = useImage(issue_image_id, issue_image_src);
   const tag_image = useImage(tag_image_id, tag_image_src);
 
-  // Todo: Never directly change things in a render, this will cause issues. Render should only render or attach listeners.
-  setAttributes({
+  const newAttributes = {
+    ...attributes,
     issue_image_src: issue_image?.source_url ?? issue_image?.url ?? '',
     issue_image_title: issue_image?.title?.raw ?? issue_image?.title ?? '',
     tag_image_src: tag_image?.source_url ?? tag_image?.url ?? '',
     tag_image_title: tag_image?.title?.raw ?? tag_image?.title ?? '',
-  });
+  };
 
   return (
     isSelected ?
-      renderEdit({attributes}, setAttributes) :
-      renderView({attributes})
+      renderEdit(newAttributes, setAttributes) :
+      renderView(newAttributes)
   );
-};
-
-const renderView = ({attributes}) => <SplitTwoColumnsFrontend {...attributes} />;
-const renderEdit = ({attributes}, setAttributes) => {
-  const charLimit = {title: 40, description: 400};
-  const params = {attributes, charLimit, setAttributes};
-
-  return (
-    <Fragment>
-      <SplitTwoColumnsInPlaceEdit {...params} />
-      <SplitTwoColumnsSettings {...params} />
-    </Fragment>
-  );
-};
-
-// Query an updated version of attributes when version is deprecated
-const updateDeprecatedData = (attributes, setAttributes, blockName, version) => {
-  if (attributes.version && parseInt(attributes.version) >= version) {
-    return;
-  }
-
-  apiFetch({
-    path: 'planet4/v1/update_block/' + blockName,
-    method: 'POST',
-    data: attributes,
-  }).then(data => setAttributes(data));
 };


### PR DESCRIPTION
### Description

Otherwise we get a console warning: 
```
Warning: Cannot update a component (`EditorInitialization`) while rendering a different component (`SplitTwoColumnsEditor`).
```

### Testing

Both existing and new Split Two Columns blocks should still work as expected. On `main` branch you should see the console warning, but not on this branch.
