### PR TITLE
Refactor Split Two Columns block to use hydration

### DIFF
--- a/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsBlock.js
+++ b/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsBlock.js
@@ -1,57 +1,73 @@
-import {SplitTwoColumnsEditor} from './SplitTwoColumnsEditor';
+import {renderToString} from 'react-dom/server';
 import {frontendRendered} from '../frontendRendered';
+import {SplitTwoColumnsEditor} from './SplitTwoColumnsEditor';
+import {SplitTwoColumnsFrontend} from './SplitTwoColumnsFrontend';
 import {splitTwoColumnsV1} from './deprecated/splitTwoColumnsV1';
-
-const {registerBlockType} = wp.blocks;
-const {__} = wp.i18n;
 
 export const BLOCK_NAME = 'planet4-blocks/split-two-columns';
 export const VERSION = 2;
 
+const attributes = {
+  version: {type: 'number', default: VERSION},
+  select_issue: {type: 'number', default: 0},
+  title: {type: 'string', default: ''},
+  issue_description: {type: 'string', default: ''},
+  issue_link_text: {type: 'string', default: ''},
+  issue_link_path: {type: 'string', default: ''},
+  issue_image_id: {type: 'number', default: 0},
+  issue_image_src: {type: 'string', default: ''},
+  issue_image_srcset: {type: 'string', default: ''},
+  issue_image_title: {type: 'string', default: ''},
+  focus_issue_image: {type: 'string', default: '50% 50%'},
+  select_tag: {type: 'number', default: 0},
+  tag_name: {type: 'string', default: ''},
+  tag_description: {type: 'string', default: ''},
+  tag_link: {type: 'string', default: ''},
+  button_text: {type: 'string', default: ''},
+  button_link: {type: 'string', default: ''},
+  tag_image_id: {type: 'number', default: 0},
+  tag_image_src: {type: 'string', default: ''},
+  tag_image_srcset: {type: 'string', default: ''},
+  tag_image_title: {type: 'string', default: ''},
+  focus_tag_image: {type: 'string', default: '50% 50%'},
+  edited: {type: 'object', default: {
+    title: false,
+    issue_description: false,
+    issue_link_text: false,
+    tag_description: false,
+    button_text: false,
+    issue_image_id: false,
+    tag_image_id: false,
+  }},
+};
+
 export const registerSplitTwoColumnsBlock = () => {
+  const {registerBlockType} = wp.blocks;
+  const {RawHTML} = wp.element;
+
   registerBlockType(BLOCK_NAME, {
-    title: __('Split Two Columns', 'planet4-blocks-backend'),
+    title: 'Split Two Columns',
     icon: 'editor-table',
     category: 'planet4-blocks',
-    attributes: {
-      version: {type: 'number', default: VERSION},
-      select_issue: {type: 'number', default: 0},
-      title: {type: 'string', default: ''},
-      issue_description: {type: 'string', default: ''},
-      issue_link_text: {type: 'string', default: ''},
-      issue_link_path: {type: 'string', default: ''},
-      issue_image_id: {type: 'number', default: 0},
-      issue_image_src: {type: 'string', default: ''},
-      issue_image_srcset: {type: 'string', default: ''},
-      issue_image_title: {type: 'string', default: ''},
-      focus_issue_image: {type: 'string', default: '50% 50%'},
-      select_tag: {type: 'number', default: 0},
-      tag_name: {type: 'string', default: ''},
-      tag_description: {type: 'string', default: ''},
-      tag_link: {type: 'string', default: ''},
-      button_text: {type: 'string', default: ''},
-      button_link: {type: 'string', default: ''},
-      tag_image_id: {type: 'number', default: 0},
-      tag_image_src: {type: 'string', default: ''},
-      tag_image_srcset: {type: 'string', default: ''},
-      tag_image_title: {type: 'string', default: ''},
-      focus_tag_image: {type: 'string', default: '50% 50%'},
-      edited: {type: 'object', default: {
-        title: false,
-        issue_description: false,
-        issue_link_text: false,
-        tag_description: false,
-        button_text: false,
-        issue_image_id: false,
-        tag_image_id: false,
-      }},
-    },
+    attributes,
     edit: SplitTwoColumnsEditor,
-    save: frontendRendered(BLOCK_NAME),
+    save: props => {
+      const markup = renderToString(<div
+        data-hydrate={BLOCK_NAME}
+        data-attributes={JSON.stringify(props.attributes)}
+      >
+        <SplitTwoColumnsFrontend {...props} />
+      </div>);
+      return <RawHTML>{markup}</RawHTML>;
+    },
     supports: {
       html: false, // Disable "Edit as HTMl" block option.
     },
     deprecated: [
+      {
+        attributes,
+        save: frontendRendered(BLOCK_NAME),
+      },
       splitTwoColumnsV1,
     ],
   });

--- a/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsEditor.js
+++ b/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsEditor.js
@@ -10,7 +10,7 @@ const useImage = (image_id, url) => {
   return useSelect(select => !image_id ? {url} : select('core').getMedia(image_id));
 };
 
-const renderView = attributes => <SplitTwoColumnsFrontend {...attributes} />;
+const renderView = attributes => <SplitTwoColumnsFrontend attributes={attributes} />;
 const renderEdit = (attributes, setAttributes) => {
   const charLimit = {title: 40, description: 400};
   const params = {attributes, charLimit, setAttributes};

--- a/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsFrontend.js
+++ b/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsFrontend.js
@@ -1,25 +1,26 @@
 import {IMAGE_SIZES} from './imageSizes';
 
-export const SplitTwoColumnsFrontend = ({
-  title,
-  issue_description,
-  issue_link_text,
-  issue_link_path,
-  issue_image_src,
-  issue_image_srcset,
-  issue_image_title,
-  focus_issue_image,
-  tag_name,
-  tag_description,
-  tag_link,
-  button_text,
-  button_link,
-  tag_image_src,
-  tag_image_srcset,
-  tag_image_title,
-  focus_tag_image,
-  className,
-}) => {
+export const SplitTwoColumnsFrontend = ({attributes}) => {
+  const {
+    title,
+    issue_description,
+    issue_link_text,
+    issue_link_path,
+    issue_image_src,
+    issue_image_srcset,
+    issue_image_title,
+    focus_issue_image,
+    tag_name,
+    tag_description,
+    tag_link,
+    button_text,
+    button_link,
+    tag_image_src,
+    tag_image_srcset,
+    tag_image_title,
+    focus_tag_image,
+    className,
+  } = attributes;
   const analytics = action => {
     return {
       'data-ga-category': 'Split Two Columns',

--- a/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsScript.js
+++ b/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsScript.js
@@ -1,10 +1,14 @@
 import {createRoot} from 'react-dom/client';
 import {SplitTwoColumnsFrontend} from './SplitTwoColumnsFrontend';
+import {hydrateBlock} from '../../functions/hydrateBlock';
 
+hydrateBlock('planet4-blocks/split-two-columns', SplitTwoColumnsFrontend);
+
+// Fallback for non migrated content. Remove after migration.
 document.querySelectorAll('[data-render="planet4-blocks/split-two-columns"]').forEach(
   blockNode => {
     const attributes = JSON.parse(blockNode.dataset.attributes);
     const rootElement = createRoot(blockNode);
-    rootElement.render(<SplitTwoColumnsFrontend {...attributes.attributes} />);
+    rootElement.render(<SplitTwoColumnsFrontend {...attributes} />);
   }
 );

--- a/classes/blocks/class-splittwocolumns.php
+++ b/classes/blocks/class-splittwocolumns.php
@@ -79,8 +79,8 @@ class SplitTwoColumns extends Base_Block {
 			[
 				'editor_script'   => 'planet4-blocks',
 				'attributes'      => self::ATTRIBUTES,
-				'render_callback' => function ( $attributes ) {
-					return self::render_frontend( self::update_data( $attributes ) );
+				'render_callback' => function ( $attributes, $content ) {
+					return self::hydrate_frontend( self::update_data( $attributes ), $content );
 				},
 			]
 		);


### PR DESCRIPTION
### Description

See [PLANET-6917](https://jira.greenpeace.org/browse/PLANET-6917)
This is to stop using the deprecated `frontendRendered` function

### Testing

Both existing and new Split Two Columns blocks should still behave as expected.
