### PR TITLE
Remove autop wrapped function

### DIFF
--- a/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
+++ b/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
@@ -4,7 +4,6 @@ import {RichText, BlockControls} from '@wordpress/block-editor';
 import {ToolbarGroup} from '@wordpress/components';
 import {useSelect} from '@wordpress/data';
 import {useState} from '@wordpress/element';
-import {autop} from '@wordpress/autop';
 
 const {__} = wp.i18n;
 
@@ -159,7 +158,7 @@ const SideContent = ({attributes, setAttributes}) => {
         />
         <RichText
           tagName="div"
-          value={autop(content_description ?? '')}
+          value={content_description ?? ''}
           onChange={desc => setAttributes({content_description: desc})}
           placeholder={__('Enter description', 'planet4-blocks-backend')}
           allowedFormats={['core/bold', 'core/italic']}


### PR DESCRIPTION
# Description
This will avoid to create new paragraphs [after the removal of the multiline prop](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1050).

![Screenshot 2023-09-26 at 11 27 20](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/assets/77975803/d6de6dca-8734-4867-a0ec-838bdfdb3963)

## Testing
Create a new `ENForm` and fill out a description

## More info
https://developer.wordpress.org/reference/functions/wpautop/

<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
