### PR TITLE
Fix Columns block src set console warnings

### DIFF
--- a/assets/src/blocks/Columns/Columns.js
+++ b/assets/src/blocks/Columns/Columns.js
@@ -19,7 +19,7 @@ export const Columns = ({columns, columns_block_style, isCampaign, isExample = f
           cta_link,
           cta_text,
           attachment,
-          attachment_srcset = '',
+          attachment_srcset,
           link_new_tab,
           title,
           description,
@@ -55,14 +55,14 @@ export const Columns = ({columns, columns_block_style, isCampaign, isExample = f
                     {...link_new_tab && {target: '_blank', rel: 'noreferrer'}}
                   >
                     <img src={attachment}
-                      srcSet={attachment_srcset}
+                      srcSet={attachment_srcset || null}
                       sizes={IMAGE_SIZES[`col-${columns.length}`] ?? ''}
                       alt={title}
                       title={title}
                       loading="lazy" />
                   </a> :
                   <img src={attachment}
-                    srcSet={attachment_srcset}
+                    srcSet={attachment_srcset || null}
                     sizes={IMAGE_SIZES[`col-${columns.length}`] ?? ''}
                     alt={title}
                     title={title}


### PR DESCRIPTION
### Description

Without this fix we sometimes pass a boolean as src set, and that results in the following console warning:
```
Warning: Received `false` for a non-boolean attribute `srcSet`.

If you want to write it to the DOM, pass a string instead: srcSet="false" or srcSet={value.toString()}.

If you used to conditionally omit it with srcSet={condition && value}, pass srcSet={condition ? value : undefined} instead.
```
In order to solve this, I applied the same fix as the one we used for the [Articles block](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/main/assets/src/blocks/Articles/ArticlePreview.js#L71).

### Testing

On local I see this warning on the homepage on the `main` branch, but not after this fix.