### PR TITLE
Fix hydration-related console errors

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
@@ -22,6 +22,7 @@ const usePageLoaded = () => {
 export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className}) => {
   const pageLoaded = usePageLoaded();
   const [autoplayPaused, setAutoplayPaused] = useState(false);
+  const [hydrated, setHydrated] = useState(false);
   const slidesRef = useRef([]);
   const containerRef = useRef(null);
   const {
@@ -32,6 +33,9 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className}) =
     setCarouselHeight,
     autoplayCancelled,
   } = useSlides(slidesRef, slides.length - 1, containerRef);
+
+  // Force re-render to avoid hydration console errors/warnings.
+  useEffect(() => setHydrated(true), []);
 
   useEffect(() => {
     if (!containerRef.current) {
@@ -86,6 +90,10 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className}) =
       clearTimeout(timerRef.current);
     }
   }, [currentSlide, goToNextSlide, slides, carousel_autoplay, autoplayPaused, autoplayCancelled, pageLoaded]);
+
+  if (!hydrated) {
+    return null;
+  }
 
   return (
     <section

--- a/assets/src/blocks/Gallery/GalleryFrontend.js
+++ b/assets/src/blocks/Gallery/GalleryFrontend.js
@@ -22,10 +22,12 @@ export const GalleryFrontend = ({
 }) => {
   const [images, setImages] = useState([]);
   const [items, setItems] = useState([]);
+  const [hydrated, setHydrated] = useState(false);
+
   const {isOpen, index, openLightbox, closeLightbox} = useLightbox();
-  const className = attributes.className ?? '';
-  const layout = getGalleryLayout(className, attributes.gallery_block_style ?? '');
-  const postType = document.body.getAttribute('data-post-type');
+
+  // Force re-render to avoid hydration console errors/warnings.
+  useEffect(() => setHydrated(true), []);
 
   useEffect(() => {
     setItems(imagesToItems(images));
@@ -40,6 +42,14 @@ export const GalleryFrontend = ({
       setImages(attributes.image_data);
     }
   }, [attributes]);
+
+  if (!hydrated) {
+    return null;
+  }
+
+  const className = attributes.className ?? '';
+  const layout = getGalleryLayout(className, attributes.gallery_block_style ?? '');
+  const postType = document.body.getAttribute('data-post-type');
 
   return (
     <section className={`block ${GALLERY_BLOCK_CLASSES[layout]} ${className}`}>


### PR DESCRIPTION
### Description

See [PLANET-7279](https://jira.greenpeace.org/browse/PLANET-7279)
We need to force a re-render to make sure that the component renders the same content server-side as it does during the initial client-side render.
I found this explanation and fix [here](https://nextjs.org/docs/messages/react-hydration-error#solution-1-using-useeffect-to-run-on-the-client-only).

### Testing

On local on `main` branch, I see the hydration warnings on the homepage for example but on this branch they are gone.