### PR TITLE
PLANET-7287 Social Media block crashes in the editor

### DIFF
--- a/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
@@ -1,10 +1,9 @@
 import {useEffect} from '@wordpress/element';
-import {InspectorControls} from '@wordpress/block-editor';
+import {InspectorControls, RichText} from '@wordpress/block-editor';
 import {
   RadioControl,
   SelectControl,
   PanelBody,
-  RichText,
 } from '@wordpress/components';
 import {SocialMediaEmbed} from './SocialMediaEmbed';
 import {URLInput} from '../../components/URLInput/URLInput';


### PR DESCRIPTION
**REF: [PLANET-7287](https://jira.greenpeace.org/browse/PLANET-7287)**

**Testing:**
Before fix block crashed when trying to add in the editor. Now the block can be added and used.

<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
