### PR TITLE
PLANET-6917 Refactor Articles block to use hydration

### DIFF
--- a/assets/src/blocks/Articles/ArticlesBlock.js
+++ b/assets/src/blocks/Articles/ArticlesBlock.js
@@ -1,11 +1,58 @@
+import {renderToString} from 'react-dom/server';
 import {ArticlesEditor} from './ArticlesEditor';
 import {frontendRendered} from '../frontendRendered';
+import {ArticlesFrontend} from './ArticlesFrontend';
+
+const {__} = wp.i18n;
 
 const BLOCK_NAME = 'planet4-blocks/articles';
 
+const attributes = {
+  article_heading: {
+    type: 'string',
+    default: __('Related Articles', 'planet4-blocks'),
+  },
+  articles_description: {
+    type: 'string',
+    default: '',
+  },
+  article_count: {
+    type: 'integer',
+    default: 3,
+  },
+  tags: {
+    type: 'array',
+    default: [],
+  },
+  posts: {
+    type: 'array',
+    default: [],
+  },
+  post_types: {
+    type: 'array',
+    default: [],
+  },
+  read_more_text: {
+    type: 'string',
+    default: __('Load more', 'planet4-blocks'),
+  },
+  read_more_link: {
+    type: 'string',
+    default: '',
+  },
+  button_link_new_tab: {
+    type: 'boolean',
+    default: false,
+  },
+  ignore_categories: {
+    type: 'boolean',
+    default: false,
+  },
+};
+
 export const registerArticlesBlock = () => {
   const {registerBlockType} = wp.blocks;
-  const {__} = wp.i18n;
+  const {RawHTML} = wp.element;
 
   registerBlockType(BLOCK_NAME, {
     title: 'Articles',
@@ -14,94 +61,26 @@ export const registerArticlesBlock = () => {
     supports: {
       html: false, // Disable "Edit as HTMl" block option.
     },
-    attributes: {
-      article_heading: {
-        type: 'string',
-        default: __('Related Articles', 'planet4-blocks'),
-      },
-      articles_description: {
-        type: 'string',
-        default: '',
-      },
-      article_count: {
-        type: 'integer',
-        default: 3,
-      },
-      tags: {
-        type: 'array',
-        default: [],
-      },
-      posts: {
-        type: 'array',
-        default: [],
-      },
-      post_types: {
-        type: 'array',
-        default: [],
-      },
-      read_more_text: {
-        type: 'string',
-        default: __('Load more', 'planet4-blocks'),
-      },
-      read_more_link: {
-        type: 'string',
-        default: '',
-      },
-      button_link_new_tab: {
-        type: 'boolean',
-        default: false,
-      },
-      ignore_categories: {
-        type: 'boolean',
-        default: false,
-      },
-    },
+    attributes,
     edit: ArticlesEditor,
-    save: frontendRendered(BLOCK_NAME),
+    save: props => {
+      const markup = renderToString(
+        <div
+          data-hydrate={BLOCK_NAME}
+          data-attributes={JSON.stringify(props.attributes)}
+        >
+          <ArticlesFrontend {...props} />
+        </div>
+      );
+      return <RawHTML>{markup}</RawHTML>;
+    },
     deprecated: [
       {
-        attributes: {
-          article_heading: {
-            type: 'string',
-            default: __('Related Articles', 'planet4-blocks'),
-          },
-          articles_description: {
-            type: 'string',
-            default: '',
-          },
-          article_count: {
-            type: 'integer',
-            default: 3,
-          },
-          tags: {
-            type: 'array',
-            default: [],
-          },
-          posts: {
-            type: 'array',
-            default: [],
-          },
-          post_types: {
-            type: 'array',
-            default: [],
-          },
-          read_more_text: {
-            type: 'string',
-            default: __('Load more', 'planet4-blocks'),
-          },
-          read_more_link: {
-            type: 'string',
-            default: '',
-          },
-          button_link_new_tab: {
-            type: 'boolean',
-            default: false,
-          },
-          ignore_categories: {
-            type: 'boolean',
-            default: false,
-          },
-        },
+        attributes,
+        save: frontendRendered(BLOCK_NAME),
+      },
+      {
+        attributes,
         save() {
           return null;
         },

--- a/assets/src/blocks/Articles/ArticlesEditor.js
+++ b/assets/src/blocks/Articles/ArticlesEditor.js
@@ -1,4 +1,3 @@
-import {Fragment} from '@wordpress/element';
 import {
   CheckboxControl,
   TextControl as BaseTextControl,
@@ -21,78 +20,76 @@ const TextControl = withCharacterCounter(BaseTextControl);
 
 const renderEdit = (attributes, toAttribute) => {
   return (
-    <Fragment>
-      <InspectorControls>
-        <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
-          <TextControl
-            label={__('Button Text', 'planet4-blocks-backend')}
-            placeholder={__('Override button text', 'planet4-blocks-backend')}
-            help={__('Your default is set to [ Load more ]', 'planet4-blocks-backend')}
-            value={attributes.read_more_text}
-            onChange={toAttribute('read_more_text')}
-          />
-          <URLInput
-            label={__('Button Link', 'planet4-blocks-backend')}
-            value={attributes.read_more_link}
-            onChange={toAttribute('read_more_link')}
-          />
-          <CheckboxControl
-            label={__('Open in a new Tab', 'planet4-blocks-backend')}
-            help={__('Open button link in new tab', 'planet4-blocks-backend')}
-            value={attributes.button_link_new_tab}
-            checked={attributes.button_link_new_tab}
-            onChange={toAttribute('button_link_new_tab')}
-          />
-          <TextControl
-            label={__('Articles count', 'planet4-blocks-backend')}
-            help={__('Number of articles', 'planet4-blocks-backend')}
-            type="number"
-            min={1}
-            value={attributes.article_count}
-            onChange={value =>
-              toAttribute('article_count')(Number(value))}
-          />
-          {attributes.posts !== 'undefined' && attributes.posts.length === 0 &&
-            <Fragment>
-              <TagSelector
-                value={attributes.tags}
-                onChange={toAttribute('tags')}
-              />
-              <p className="FieldHelp">Associate this block with Actions that have specific Tags</p>
-              <PostTypeSelector
-                label={__('Post Types', 'planet4-blocks-backend')}
-                value={attributes.post_types}
-                onChange={toAttribute('post_types')}
-              />
-              <div className="ignore-categories-wrapper">
-                <CheckboxControl
-                  label={__('Ignore categories', 'planet4-blocks-backend')}
-                  help={__('Ignore categories when filtering posts to populate the content of this block', 'planet4-blocks-backend')}
-                  value={attributes.ignore_categories}
-                  checked={attributes.ignore_categories}
-                  onChange={toAttribute('ignore_categories')}
-                />
-              </div>
-            </Fragment>
-          }
-          {attributes.tags.length === 0 && attributes.post_types.length === 0 &&
-            <div>
-              <hr />
-              <p>{__('Manual override', 'planet4-blocks-backend')}</p>
-              <PostSelector
-                label={__('CAUTION: Adding articles individually will override the automatic functionality of this block. For good user experience, please include at least three articles so that spacing and alignment of the design remains intact.', 'planet4-blocks-backend')}
-                selected={attributes.posts || []}
-                onChange={toAttribute('posts')}
-                postType="post"
-                placeholder={__('Select articles', 'planet4-blocks-backend')}
-                maxLength={10}
-                maxSuggestions={20}
+    <InspectorControls>
+      <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
+        <TextControl
+          label={__('Button Text', 'planet4-blocks-backend')}
+          placeholder={__('Override button text', 'planet4-blocks-backend')}
+          help={__('Your default is set to [ Load more ]', 'planet4-blocks-backend')}
+          value={attributes.read_more_text}
+          onChange={toAttribute('read_more_text')}
+        />
+        <URLInput
+          label={__('Button Link', 'planet4-blocks-backend')}
+          value={attributes.read_more_link}
+          onChange={toAttribute('read_more_link')}
+        />
+        <CheckboxControl
+          label={__('Open in a new Tab', 'planet4-blocks-backend')}
+          help={__('Open button link in new tab', 'planet4-blocks-backend')}
+          value={attributes.button_link_new_tab}
+          checked={attributes.button_link_new_tab}
+          onChange={toAttribute('button_link_new_tab')}
+        />
+        <TextControl
+          label={__('Articles count', 'planet4-blocks-backend')}
+          help={__('Number of articles', 'planet4-blocks-backend')}
+          type="number"
+          min={1}
+          value={attributes.article_count}
+          onChange={value =>
+            toAttribute('article_count')(Number(value))}
+        />
+        {attributes.posts !== 'undefined' && attributes.posts.length === 0 &&
+          <>
+            <TagSelector
+              value={attributes.tags}
+              onChange={toAttribute('tags')}
+            />
+            <p className="FieldHelp">Associate this block with Actions that have specific Tags</p>
+            <PostTypeSelector
+              label={__('Post Types', 'planet4-blocks-backend')}
+              value={attributes.post_types}
+              onChange={toAttribute('post_types')}
+            />
+            <div className="ignore-categories-wrapper">
+              <CheckboxControl
+                label={__('Ignore categories', 'planet4-blocks-backend')}
+                help={__('Ignore categories when filtering posts to populate the content of this block', 'planet4-blocks-backend')}
+                value={attributes.ignore_categories}
+                checked={attributes.ignore_categories}
+                onChange={toAttribute('ignore_categories')}
               />
             </div>
-          }
-        </PanelBody>
-      </InspectorControls>
-    </Fragment>
+          </>
+        }
+        {attributes.tags.length === 0 && attributes.post_types.length === 0 &&
+          <div>
+            <hr />
+            <p>{__('Manual override', 'planet4-blocks-backend')}</p>
+            <PostSelector
+              label={__('CAUTION: Adding articles individually will override the automatic functionality of this block. For good user experience, please include at least three articles so that spacing and alignment of the design remains intact.', 'planet4-blocks-backend')}
+              selected={attributes.posts || []}
+              onChange={toAttribute('posts')}
+              postType="post"
+              placeholder={__('Select articles', 'planet4-blocks-backend')}
+              maxLength={10}
+              maxSuggestions={20}
+            />
+          </div>
+        }
+      </PanelBody>
+    </InspectorControls>
   );
 };
 
@@ -100,7 +97,7 @@ const renderView = ({attributes, postType, posts, totalPosts}, toAttribute) => {
   const hasMultiplePages = totalPosts > attributes.article_count;
 
   return (
-    <Fragment>
+    <>
       <Tooltip text={__('Edit text', 'planet4-blocks-backend')}>
         <header className="articles-title-container">
           <RichText
@@ -139,7 +136,7 @@ const renderView = ({attributes, postType, posts, totalPosts}, toAttribute) => {
         </Tooltip>
       )
       }
-    </Fragment>
+    </>
   );
 };
 

--- a/assets/src/blocks/Articles/ArticlesFrontend.js
+++ b/assets/src/blocks/Articles/ArticlesFrontend.js
@@ -1,7 +1,7 @@
 import {ArticlesList} from './ArticlesList';
 import {useArticlesFetch} from './useArticlesFetch';
 
-export const ArticlesFrontend = props => {
+export const ArticlesFrontend = ({attributes}) => {
   const {
     article_heading,
     articles_description,
@@ -9,7 +9,7 @@ export const ArticlesFrontend = props => {
     read_more_link,
     button_link_new_tab,
     className,
-  } = props;
+  } = attributes;
 
   const postType = document.body.getAttribute('data-post-type');
 
@@ -17,9 +17,9 @@ export const ArticlesFrontend = props => {
 
   const postId = !postIdClass ? null : postIdClass.split('-')[1];
 
-  const postCategories = props.post_categories || [];
+  const postCategories = attributes.post_categories || [];
 
-  const {posts, loadNextPage, hasMorePages, loading} = useArticlesFetch(props, postType, postId, document.body.dataset.nro, postCategories);
+  const {posts, loadNextPage, hasMorePages, loading} = useArticlesFetch(attributes, postType, postId, document.body.dataset.nro, postCategories);
 
   if (!posts.length) {
     return null;

--- a/assets/src/blocks/Articles/ArticlesScript.js
+++ b/assets/src/blocks/Articles/ArticlesScript.js
@@ -1,10 +1,14 @@
 import {ArticlesFrontend} from './ArticlesFrontend';
 import {createRoot} from 'react-dom/client';
+import {hydrateBlock} from '../../functions/hydrateBlock';
 
+hydrateBlock('planet4-blocks/articles', ArticlesFrontend);
+
+// Fallback for non migrated content. Remove after migration.
 document.querySelectorAll('[data-render="planet4-blocks/articles"]').forEach(
   blockNode => {
     const attributes = JSON.parse(blockNode.dataset.attributes);
     const rootElement = createRoot(blockNode);
-    rootElement.render(<ArticlesFrontend {...attributes.attributes} />);
+    rootElement.render(<ArticlesFrontend {...attributes} />);
   }
 );

--- a/classes/blocks/class-articles.php
+++ b/classes/blocks/class-articles.php
@@ -42,7 +42,7 @@ class Articles extends Base_Block {
 			[
 				'editor_script'   => 'planet4-blocks',
 				// todo: Remove when all content is migrated.
-				'render_callback' => static function ( $attributes ) {
+				'render_callback' => static function ( $attributes, $content ) {
 					if ( empty( $attributes['read_more_text'] ) ) {
 						$attributes['read_more_text'] = __( 'Load more', 'planet4-blocks' );
 					}
@@ -51,7 +51,7 @@ class Articles extends Base_Block {
 						$attributes['article_heading'] = __( 'Related Articles', 'planet4-blocks' );
 					}
 
-					return self::render_frontend( $attributes );
+					return self::hydrate_frontend( $attributes, $content );
 				},
 				'attributes'      => [
 					'article_heading'      => [


### PR DESCRIPTION
### Description

See [PLANET-6917](https://jira.greenpeace.org/browse/PLANET-6917)
This is to stop using the deprecated `frontendRendered` function

### Testing

Both new and existing Articles blocks (including the ones in posts) should still behave as expected.
