### PR TITLE
Add missing attribute to SlideBackground

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
@@ -19,7 +19,7 @@ const usePageLoaded = () => {
   return pageLoaded;
 };
 
-export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className}) => {
+export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, decoding}) => {
   const pageLoaded = usePageLoaded();
   const [autoplayPaused, setAutoplayPaused] = useState(false);
   const slidesRef = useRef([]);
@@ -102,7 +102,7 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className}) =
               active={currentSlide === index}
               ref={element => slidesRef ? slidesRef.current[index] = element : null}
             >
-              <SlideBackground slide={pageLoaded ? slide : slides[0]} />
+              <SlideBackground decoding={decoding} slide={pageLoaded ? slide : slides[0]} />
               <StaticCaption slide={slide} />
             </Slide>
           ))}

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderScript.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderScript.js
@@ -2,7 +2,7 @@ import {CarouselHeaderFrontend} from './CarouselHeaderFrontend';
 import {hydrateBlock} from '../../functions/hydrateBlock';
 import {createRoot} from 'react-dom/client';
 
-hydrateBlock('planet4-blocks/carousel-header', CarouselHeaderFrontend);
+hydrateBlock('planet4-blocks/carousel-header', CarouselHeaderFrontend, {decoding: true});
 // Fallback for non migrated content. Remove after migration.
 document.querySelectorAll('[data-render=\'planet4-blocks/carousel-header\']').forEach(
   blockNode => {

--- a/assets/src/blocks/CarouselHeader/SlideBackground.js
+++ b/assets/src/blocks/CarouselHeader/SlideBackground.js
@@ -1,4 +1,4 @@
-export const SlideBackground = ({slide}) => {
+export const SlideBackground = ({slide, decoding}) => {
   const {image_url, image_srcset, focal_points, image_alt} = slide;
   return (
     <div className="background-holder">
@@ -7,6 +7,7 @@ export const SlideBackground = ({slide}) => {
         style={{objectPosition: `${(focal_points?.x || .5) * 100}% ${(focal_points?.y || .5) * 100}%`}}
         srcSet={image_srcset}
         alt={image_alt}
+        {...decoding ? {decoding: 'async'} : {}}
       />
     </div>
   );


### PR DESCRIPTION
### Description

This fixes some console warnings. The new `decoding` attribute [was added with WordPress 6.1](https://www.wpexplorer.com/remove-async-decoding-wordpress-images/). Hopefully this also solves some hydration errors that we see on live sites.

### Testing

~For some reason, it seems the `decoding` attribute is not added on test instances...~ This attribute is only added when we use hydration, so with old blocks that still use `data-render` it won't be present. Code has been updated to reflect that! 

On the test instance, here are the 2 examples you can use for testing:
- [new block using hydration](https://www-dev.greenpeace.org/test-phoebe/test-hydrated-carouselheader/), should have the new attribute
- [old block not using hydration](https://www-dev.greenpeace.org/test-phoebe/), should **not** have the new attribute

You can also test this on local, on `main` branch on a page with a CarouselHeader you should see the following console warning:

```
Warning: Extra attributes from the server: decoding
```

But it should be gone once you switch to this branch.
