### PR TITLE
Refactor Spreadsheet sorting function to use dataset

### DIFF
--- a/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
@@ -28,7 +28,8 @@ export const SpreadsheetFrontend = ({
   const [sortDirection, setSortDirection] = useState('asc');
   const [sortColumnIndex, setSortColumnIndex] = useState(null);
 
-  const onHeaderClick = index => {
+  const onHeaderClick = event => {
+    const index = parseInt(event.currentTarget.dataset.index);
     if (index === sortColumnIndex) {
       setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
     } else {
@@ -163,7 +164,8 @@ export const SpreadsheetFrontend = ({
                         `spreadsheet-sorted-by sort-${sortDirection}` :
                         ''
                     )}
-                    onClick={() => onHeaderClick(index)}
+                    onClick={onHeaderClick}
+                    data-index={index}
                     key={index}
                     scope="col"
                     title={cell}>


### PR DESCRIPTION
### Description

This change is based on [this comment](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1102#discussion_r1365445772). It's to avoid creating multiple functions when rendering.

### Testing 

The Spreadsheet sorting function should still behave as expected.