### PR TITLE
 Fix hydration errors and duplicated blocks

### DIFF
--- a/assets/src/blocks/Covers/CoversScript.js
+++ b/assets/src/blocks/Covers/CoversScript.js
@@ -1,6 +1,16 @@
+import {createRoot} from 'react-dom/client';
 import {CoversFrontend} from './CoversFrontend';
 import {hydrateBlock} from '../../functions/hydrateBlock';
 import {BLOCK_NAME} from './CoversConstants';
 
 hydrateBlock(BLOCK_NAME, CoversFrontend);
+
+// Fallback for non migrated content. Remove after migration.
+document.querySelectorAll(BLOCK_NAME).forEach(
+  blockNode => {
+    const attributes = JSON.parse(blockNode.dataset.attributes);
+    const rootElement = createRoot(blockNode);
+    rootElement.render(<CoversFrontend {...attributes} />);
+  }
+);
 

--- a/assets/src/blocks/ENForm/ENFormScript.js
+++ b/assets/src/blocks/ENForm/ENFormScript.js
@@ -1,5 +1,14 @@
+import {createRoot} from 'react-dom/client';
 import {ENFormFrontend} from './ENFormFrontend';
 import {hydrateBlock} from '../../functions/hydrateBlock';
 
 hydrateBlock('planet4-blocks/enform', ENFormFrontend);
 
+// Fallback for non migrated content. Remove after migration.
+document.querySelectorAll('planet4-blocks/enform').forEach(
+  blockNode => {
+    const attributes = JSON.parse(blockNode.dataset.attributes);
+    const rootElement = createRoot(blockNode);
+    rootElement.render(<ENFormFrontend {...attributes} />);
+  }
+);

--- a/assets/src/blocks/Gallery/GalleryScript.js
+++ b/assets/src/blocks/Gallery/GalleryScript.js
@@ -1,4 +1,14 @@
+import {createRoot} from 'react-dom/client';
 import {GalleryFrontend} from './GalleryFrontend';
 import {hydrateBlock} from '../../functions/hydrateBlock';
 
 hydrateBlock('planet4-blocks/gallery', GalleryFrontend, {renderLightbox: true});
+
+// Fallback for non migrated content. Remove after migration.
+document.querySelectorAll('[data-render="planet4-blocks/gallery"]').forEach(
+  blockNode => {
+    const attributes = JSON.parse(blockNode.dataset.attributes);
+    const rootElement = createRoot(blockNode);
+    rootElement.render(<GalleryFrontend {...attributes} renderLightbox />);
+  }
+);

--- a/assets/src/blocks/Timeline/TimelineScript.js
+++ b/assets/src/blocks/Timeline/TimelineScript.js
@@ -1,5 +1,14 @@
+import {createRoot} from 'react-dom/client';
 import {TimelineFrontend} from './TimelineFrontend';
 import {hydrateBlock} from '../../functions/hydrateBlock';
 
 hydrateBlock('planet4-blocks/timeline', TimelineFrontend);
 
+// Fallback for non migrated content. Remove after migration.
+document.querySelectorAll('planet4-blocks/timeline').forEach(
+  blockNode => {
+    const attributes = JSON.parse(blockNode.dataset.attributes);
+    const rootElement = createRoot(blockNode);
+    rootElement.render(<TimelineFrontend {...attributes} />);
+  }
+);

--- a/assets/src/functions/hydrateBlock.js
+++ b/assets/src/functions/hydrateBlock.js
@@ -12,7 +12,7 @@ export const hydrateBlock = (blockName, Component, csrAttributes = {}) => { // e
   const blocks = document.querySelectorAll(`[data-hydrate="${blockName}"]`);
   blocks.forEach(
     blockNode => {
-      if(blockNode) {
+      if (blockNode) {
         const attributes = JSON.parse(blockNode.dataset.attributes);
         hydrateRoot(blockNode, <Component {...attributes} {...csrAttributes} />);
       }

--- a/classes/blocks/class-base-block.php
+++ b/classes/blocks/class-base-block.php
@@ -246,15 +246,17 @@ abstract class Base_Block {
 		$json = wp_json_encode( [ 'attributes' => $attributes ] );
 
 		// This will double check to parse ONLY hydrated blocks.
-		if ( strpos( $content, 'data-hydrate' ) ) {
-			// Parse to get the only the block content and not the whole block.
-			preg_match_all( '/>/', $content, $matches, PREG_OFFSET_CAPTURE );
-			$start   = $matches[0][1][1] + 1;
-			$content = substr( $content, $start );
-			preg_match_all( '/<\/div>/', $content, $matches, PREG_OFFSET_CAPTURE );
-			$end     = $matches[0][ count( $matches[0] ) - 2 ][1];
-			$content = substr( $content, 0, $end );
+		if ( ! strpos( $content, 'data-hydrate' ) ) {
+			return self::render_frontend( $attributes );
 		}
+
+		// Parse to get the only the block content and not the whole block.
+		preg_match_all( '/>/', $content, $matches, PREG_OFFSET_CAPTURE );
+		$start   = $matches[0][1][1] + 1;
+		$content = substr( $content, $start );
+		preg_match_all( '/<\/div>/', $content, $matches, PREG_OFFSET_CAPTURE );
+		$end     = $matches[0][ count( $matches[0] ) - 2 ][1];
+		$content = substr( $content, 0, $end );
 
 		return '<div data-hydrate="' . self::get_full_block_name() . '" data-attributes="' . htmlspecialchars( $json ) . '">' . $content . '</div>';
 	}


### PR DESCRIPTION
### Description

We need to make sure that blocks without the `data-hydrate` attribute are rendered correctly. Before this fix we would sometimes render blocks with `data-render` inside of a `data-hydrate` attribute which would result in duplicated blocks.

I've added a commit for some old blocks not rendering in the frontend, which might solve [PLANET-7202](https://jira.greenpeace.org/browse/PLANET-7202) for the Gallery block for example

### Testing

All hydration-related console errors and warnings should be gone. If you have a page with previously duplicated blocks (for example on local I had it on the `Explore` page) it should no longer be happening. All blocks (both with `data-hydrate` and `data-render`) should be rendered properly.