### PR TITLE
PLANET-7313: Fix header text cut off

### DIFF
--- a/assets/src/styles/blocks/PageHeader.scss
+++ b/assets/src/styles/blocks/PageHeader.scss
@@ -55,16 +55,18 @@ $text-column-padding-in: 24px;
     font-size: $font-size-xxl;
     font-weight: 700;
     line-height: initial;
+    margin-inline-start: -$sp-1;
   }
 
-  h1.has-background {
+  .wp-block-heading.has-background {
     display: inline;
     padding: 0;
     font-size: inherit;
     font-weight: inherit;
-    line-height: var(--page-header-title--line-height, 1em);
+    line-height: 150%;
     box-decoration-break: clone;
-    box-shadow: 8px 0 0 var(--transparent-button--active--color, #fff), calc(8px * -1) 0 0 var(--transparent-button--active--color, #fff);
+    box-shadow: 8px 0 0 var(--white);
+    padding-inline-start: $sp-1;
   }
 
   p {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7313

👉 [Demo page](https://www-dev.greenpeace.org/test-nix/1263-2/)

# Description
Standardize the header line height avoiding issues within different sizes. Now, the `PageHeader heading` layout is following its [proper layout](https://www.figma.com/file/9NtbY8n3at8uOEJTsLrETb/P4-Design-System?type=design&node-id=720-31483&mode=dev)

<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
