### PR TITLE
PLANET-7295 Fix related articles block and block patterns report

### DIFF
--- a/classes/blocks/class-blocklist.php
+++ b/classes/blocks/class-blocklist.php
@@ -73,7 +73,7 @@ class BlockList {
 	 *
 	 * @return string[] List of unique block names.
 	 */
-	public static function parse_block_list( string $content, &$seen = [], $post_id = 0, bool $include_articles ): array {
+	public static function parse_block_list( string $content, &$seen = [], $post_id = 0, bool $include_articles = false ): array {
 		// Add Articles block in posts where it's included from the settings.
 		$initial_blocks = $include_articles ? [ 'planet4-blocks/articles' ] : [];
 

--- a/classes/blocks/class-blocklist.php
+++ b/classes/blocks/class-blocklist.php
@@ -75,14 +75,14 @@ class BlockList {
 	 */
 	public static function parse_block_list( string $content, &$seen = [], $post_id = 0, bool $include_articles = false ): array {
 		// Add Articles block in posts where it's included from the settings.
-		$initial_blocks = $include_articles ? [ 'planet4-blocks/articles' ] : [];
+		$initial_blocks = $include_articles ? [ 'blockName' => 'planet4-blocks/articles' ] : [];
 
 		if ( ! has_blocks( $content ) ) {
 			return $initial_blocks;
 		}
 
 		$content_blocks = ( new WP_Block_Parser() )->parse( $content );
-		$blocks         = array_merge( $initial_blocks, $content_blocks );
+		$blocks         = array_merge( [ $initial_blocks ], $content_blocks );
 		$parsed         = array_filter( $blocks, fn ( $b ) => ! empty( $b['blockName'] ) );
 		if ( ! isset( $seen[ $post_id ] ) ) {
 			$seen[ $post_id ] = [];


### PR DESCRIPTION
This was introduced at 9f2037e7b8973601e954bdd7e38a0f1cc7983c4c but broke patterns report since it introduced a new argument with no default value needed at [pattern search](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/9f2037e7b8973601e954bdd7e38a0f1cc7983c4c/classes/search/pattern/class-patterndata.php#L113).

Exception raised before this fix when visiting
`/wp-json/plugin_blocks/v3/plugin_blocks_report/`:

```
Fatal error: Uncaught ArgumentCountError: Too few arguments to function
P4GBKS\Blocks\BlockList::parse_block_list(), 1 passed in
/var/www/html/wp-content/plugins/planet4-plugin-gutenberg-blocks/classes/search/pattern/class-patterndata.php
on line 113 and exactly 4 expected in
/var/www/html/wp-content/plugins/planet4-plugin-gutenberg-blocks/classes/blocks/class-blocklist.php:76
Stack trace: #0 /var/www/html/wp-content/plugins/planet4-plugin-gutenberg-blocks/classes/search/pattern/class-patterndata.php(113):
P4GBKS\Blocks\BlockList::parse_block_list()
```

I also noticed that "Related Articles" block didn't work properly. I adjusted the array merge code to make it work.

### Testing

- Blocks report API endpoint (see url above) should now be working in this branch
- This shouldn't affect "Related Articles" block on Posts added by the the "Include Articles Block" dropdown menu

<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
