### PR TITLE
PLANET-7238: Update test for WP6.4

### DIFF
--- a/assets/src/blocks/ENForm/ENFormFrontend.js
+++ b/assets/src/blocks/ENForm/ENFormFrontend.js
@@ -1,6 +1,5 @@
 import {ShareButtons} from '../../components/ShareButtons/ShareButtons';
 import {FormGenerator} from './FormGenerator';
-import * as wpData from '@wordpress/data';
 import {useState} from '@wordpress/element';
 import {unescape} from '../../functions/unescape';
 
@@ -11,7 +10,6 @@ const {__} = wp.i18n;
 export const ENFormFrontend = ({attributes}) => {
   const {
     en_page_id,
-    en_form_id,
     en_form_style,
     en_form_fields,
     enform_goal,
@@ -42,16 +40,7 @@ export const ENFormFrontend = ({attributes}) => {
 
   const style_has_image = ['full-width-bg', 'side-style'].includes(en_form_style);
   const is_side_style = en_form_style === 'side-style';
-
-  let fields = en_form_fields ?? [];
-  if (!fields.length && wpData?.useSelect !== undefined) {
-    const form_post = wpData.useSelect(select => {
-      return en_form_id ?
-        select('core').getEntityRecord('postType', 'p4en_form', en_form_id) :
-        [];
-    });
-    fields = form_post?.p4enform_fields ?? [];
-  }
+  const fields = en_form_fields ?? [];
 
   const HeadingTag = content_title_size;
 

--- a/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
+++ b/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
@@ -179,6 +179,7 @@ const Signup = ({attributes, setAttributes}) => {
     const enform_post = en_form_id ? select('core').getEntityRecord('postType', 'p4en_form', en_form_id) : {};
     return enform_post?.p4enform_fields || [];
   }, [en_form_id]);
+  setAttributes({en_form_fields: fields});
 
   return (
     <div className="enform">

--- a/tests/e2e/covers-content.spec.js
+++ b/tests/e2e/covers-content.spec.js
@@ -8,11 +8,11 @@ test('Test Covers block with Content covers style', async ({page, admin, editor}
   await admin.createNewPost({postType: 'page', title: 'Test Covers block', legacyCanvas: true});
 
   // Add Covers block.
-  await addCoversBlock(page, editor, 'Default');
+  await addCoversBlock(page, editor, 'Content');
 
   // Publish page.
   await publishPostAndVisit({page, editor});
 
   // Make sure block shows as expected in the frontend.
-  await checkCoversBlock(page, 'Default');
+  await checkCoversBlock(page, 'Content');
 });

--- a/tests/e2e/tools/lib/covers.js
+++ b/tests/e2e/tools/lib/covers.js
@@ -14,7 +14,8 @@ async function addCoversBlock(page, editor, style = '') {
   if (style) {
     const stylePicker = await page.locator('.block-editor-block-styles__variants');
     //CSS selector needs single word,hence remove word after space(eg Take Action=>Take).
-    await stylePicker.locator(`button[aria-label^=${style.split(' ')[0]}]`).click();
+    const label = style === 'Content' ? /Content|Default/ : style.split(' ')[0];
+    await stylePicker.getByRole('button', {name: label}).click();
   }
 
   const settings = await editor.canvas.getByRole('region', {name: 'Editor settings'});
@@ -54,7 +55,7 @@ async function addCoversBlock(page, editor, style = '') {
   }
 
   // Default style, i.e 'Content cover'.
-  if (style === 'Default') {
+  if (style === 'Content') {
     // Fill in the Post types.
     const postTypesInput = await page.getByLabel('Select Post Types');
     await postTypesInput.scrollIntoViewIfNeeded();
@@ -70,7 +71,7 @@ async function addCoversBlock(page, editor, style = '') {
 
 async function checkCoversBlock(page, style) {
   // Default style, i.e 'Content cover'.
-  if (style === 'Default') {
+  if (style === 'Content') {
     await expect(page.locator('.content-covers-block')).toBeVisible();
     const frontendCovers = await page.locator('.post-column.cover').all();
     for (const [, cover] of frontendCovers.entries()) {


### PR DESCRIPTION
Update tests [failing](https://output.circle-artifacts.com/output/job/37c06ecc-62a1-492e-81fb-7209d893abb8/artifacts/0/home/circleci/artifacts/playwright/plugins/e2e-report/index.html) in WordPress 6.4.
- EN Form test failing because of a `useSelect` used in a frontend component passed in `renderToString`
- Covers content test failing because the style selector now shows the name `Content` instead of `Default`