### PR TITLE
PLANET-7323: Remove Lodash dependencies

### DIFF
--- a/assets/src/ImageBlockExtension.js
+++ b/assets/src/ImageBlockExtension.js
@@ -1,6 +1,5 @@
 import {Button, ButtonGroup, PanelBody} from '@wordpress/components';
 import {InspectorControls} from '@wordpress/block-editor';
-import assign from 'lodash.assign';
 
 const {addFilter} = wp.hooks;
 const {__} = wp.i18n;
@@ -44,8 +43,8 @@ const addExtraAttributes = function() {
       return settings;
     }
 
-    // Use Lodash's assign to gracefully handle if attributes are undefined
-    settings.attributes = assign(settings.attributes, {
+    settings.attributes = {
+      ...settings.attributes,
       captionStyle: {
         type: 'string',
         default: captionStyleOptions[0].value,
@@ -54,7 +53,7 @@ const addExtraAttributes = function() {
         type: 'string',
         default: captionAlignmentOptions[1].value,
       },
-    });
+    };
 
     return settings;
   };

--- a/assets/src/blocks/Accordion/AccordionEditor.js
+++ b/assets/src/blocks/Accordion/AccordionEditor.js
@@ -6,8 +6,7 @@ import {
   CheckboxControl,
   Button,
 } from '@wordpress/components';
-
-import {debounce} from 'lodash';
+import {debounce} from '@wordpress/compose';
 
 const {__} = wp.i18n;
 

--- a/assets/src/blocks/Happypoint/HappypointEditor.js
+++ b/assets/src/blocks/Happypoint/HappypointEditor.js
@@ -3,8 +3,7 @@ import {useSelect} from '@wordpress/data';
 import {HappypointFrontend} from './HappypointFrontend';
 import {OverrideFormHelp} from './OverrideFormHelp';
 import {USE_NONE, USE_IFRAME_URL, USE_EMBED_CODE} from './HappyPointConstants';
-
-import {debounce} from 'lodash';
+import {debounce} from '@wordpress/compose';
 
 import {
   InspectorControls,

--- a/assets/src/blocks/Media/MediaEditor.js
+++ b/assets/src/blocks/Media/MediaEditor.js
@@ -1,7 +1,7 @@
 import {Fragment, useCallback} from '@wordpress/element';
 import {PanelBody, TextControl} from '@wordpress/components';
 import {MediaPlaceholder, InspectorControls, RichText} from '@wordpress/block-editor';
-import {debounce} from 'lodash';
+import {debounce} from '@wordpress/compose';
 
 import {MediaElementVideo} from './MediaElementVideo';
 import {useSelect} from '@wordpress/data';

--- a/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsInPlaceEdit.js
+++ b/assets/src/blocks/SplitTwoColumns/SplitTwoColumnsInPlaceEdit.js
@@ -1,5 +1,5 @@
 import {RichText} from '@wordpress/block-editor';
-import {debounce} from 'lodash';
+import {debounce} from '@wordpress/compose';
 
 const {__} = wp.i18n;
 

--- a/assets/src/blocks/Spreadsheet/SpreadsheetEditor.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetEditor.js
@@ -2,7 +2,7 @@ import {useState} from '@wordpress/element';
 import {InspectorControls} from '@wordpress/block-editor';
 import ColorPaletteControl from '../../components/ColorPaletteControl/ColorPaletteControl';
 import {SpreadsheetFrontend} from './SpreadsheetFrontend';
-import {debounce} from 'lodash';
+import {debounce} from '@wordpress/compose';
 import {TextControl, PanelBody} from '@wordpress/components';
 
 const {__} = wp.i18n;

--- a/assets/src/blocks/Timeline/TimelineEditorScript.js
+++ b/assets/src/blocks/Timeline/TimelineEditorScript.js
@@ -13,7 +13,7 @@ import {useStyleSheet} from '../../components/useStyleSheet/useStyleSheet';
 import {Timeline} from './Timeline';
 import {languages} from './TimelineLanguages';
 import {URLDescriptionHelp} from './URLDescriptionHelp';
-import {debounce, noConflict} from 'lodash';
+import {debounce} from '@wordpress/compose';
 
 const {__} = wp.i18n;
 const TIMELINE_JS_VERSION = '3.8.12';
@@ -24,16 +24,9 @@ const positions = [
 ];
 
 const loadAssets = () => {
-  // Revert TimelineJS global usage of lodash, as it conflicts with Wordpress underscore lib
-  // see https://jira.greenpeace.org/browse/PLANET-5960
-  const revertLodash = function() {
-    noConflict();
-  };
-
   // eslint-disable-next-line no-unused-vars
   const [scriptLoaded, scriptError] = useScript(
-    `https://cdn.knightlab.com/libs/timeline3/${TIMELINE_JS_VERSION}/js/timeline-min.js`,
-    revertLodash
+    `https://cdn.knightlab.com/libs/timeline3/${TIMELINE_JS_VERSION}/js/timeline-min.js`
   );
 
   // eslint-disable-next-line no-unused-vars

--- a/assets/src/components/AssignOnlyFlatTermSelector/AssignOnlyFlatTermSelector.js
+++ b/assets/src/components/AssignOnlyFlatTermSelector/AssignOnlyFlatTermSelector.js
@@ -4,11 +4,6 @@
  */
 
 /**
- * External dependencies
- */
-import {unescape as unescapeString} from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {useEffect, useMemo, useState} from '@wordpress/element';
@@ -16,6 +11,7 @@ import {FormTokenField, withFilters} from '@wordpress/components';
 import {useSelect, useDispatch} from '@wordpress/data';
 import {store as coreStore} from '@wordpress/core-data';
 import {useDebounce} from '@wordpress/compose';
+import {decodeEntities} from '@wordpress/html-entities';
 
 const {__, _x, sprintf} = wp.i18n;
 
@@ -38,8 +34,8 @@ const DEFAULT_QUERY = {
 };
 
 const isSameTermName = (termA, termB) =>
-  unescapeString(termA).toLowerCase() ===
-  unescapeString(termB).toLowerCase();
+  decodeEntities(termA).toLowerCase() ===
+  decodeEntities(termB).toLowerCase();
 
 const termNamesToIds = (names, terms) => names.map(
   termName => terms.find(term => isSameTermName(term.name, termName)).id
@@ -100,7 +96,7 @@ export const AssignOnlyFlatTermSelector = ({slug}) => {
   useEffect(() => {
     if (hasResolvedTerms) {
       const newValues = (terms ?? []).map(term =>
-        unescapeString(term.name)
+        decodeEntities(term.name)
       );
 
       setValues(newValues);
@@ -109,7 +105,7 @@ export const AssignOnlyFlatTermSelector = ({slug}) => {
 
   const suggestions = useMemo(() => {
     return (searchResults ?? []).map(term =>
-      unescapeString(term.name)
+      decodeEntities(term.name)
     );
   }, [searchResults]);
 

--- a/assets/src/components/ColorPaletteControl/ColorPaletteControl.js
+++ b/assets/src/components/ColorPaletteControl/ColorPaletteControl.js
@@ -1,4 +1,3 @@
-import {isEmpty} from 'lodash';
 import classnames from 'classnames';
 import {withInstanceId} from '@wordpress/compose';
 import {BaseControl, ColorPalette} from '@wordpress/components';
@@ -9,7 +8,7 @@ function ColorPaletteControl({label, className, value, help, instanceId, onChang
   // eslint-disable-next-line no-shadow
   const optionsAsColors = options.map(({value, ...props}) => ({color: value, ...props}));
 
-  return !isEmpty(options) && (
+  return options.length > 0 && (
     <BaseControl label={label} id={id} help={help}
       className={classnames(className, 'components-color-palette-control')}>
       <ColorPalette

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,6 @@
         "dotenv": "^16.3.1",
         "eslint-plugin-react": "^7.20.3",
         "file-loader": "^6.2.0",
-        "lodash": "^4.17.21",
-        "lodash.assign": "^4.2.0",
         "mini-css-extract-plugin": "^0.7.0",
         "optimize-css-assets-webpack-plugin": "^6.0.1",
         "playwright": "^1.37.1",
@@ -27000,11 +26998,6 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.assign": {
-      "version": "4.2.0",
       "dev": true,
       "license": "MIT"
     },
@@ -54288,10 +54281,6 @@
     },
     "lodash": {
       "version": "4.17.21",
-      "dev": true
-    },
-    "lodash.assign": {
-      "version": "4.2.0",
       "dev": true
     },
     "lodash.debounce": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
     "dotenv": "^16.3.1",
     "eslint-plugin-react": "^7.20.3",
     "file-loader": "^6.2.0",
-    "lodash": "^4.17.21",
-    "lodash.assign": "^4.2.0",
     "mini-css-extract-plugin": "^0.7.0",
     "optimize-css-assets-webpack-plugin": "^6.0.1",
     "playwright": "^1.37.1",


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7323

> WordPress 6.4 removes Lodash dependency and provide alternative implementations of its functions.
We are currently using Lodash for duplication of WP components and some utilities but not importing it ourselves, so the Editor crashes in 6.4.

This is a port of Gutenberg removal of Lodash ([remove _.get](https://github.com/WordPress/gutenberg/pull/52561), [remove _.debounce](https://github.com/WordPress/gutenberg/pull/43943), etc.)

## Test

- E2E tests should pass
- Our port of the FlatTermSelector should still work as expected (Post Types selection in post edition)