### PR TITLE
Fix CoversScript selector

### DIFF
--- a/assets/src/blocks/Covers/CoversScript.js
+++ b/assets/src/blocks/Covers/CoversScript.js
@@ -6,7 +6,7 @@ import {BLOCK_NAME} from './CoversConstants';
 hydrateBlock(BLOCK_NAME, CoversFrontend);
 
 // Fallback for non migrated content. Remove after migration.
-document.querySelectorAll(`[data-render=${BLOCK_NAME}]`).forEach(
+document.querySelectorAll(`[data-render="${BLOCK_NAME}"]`).forEach(
   blockNode => {
     const attributes = JSON.parse(blockNode.dataset.attributes);
     const rootElement = createRoot(blockNode);


### PR DESCRIPTION
### Description

We forgot to add quotation marks 😬 resulting in the block not showing in the frontend and the following error message in the console:

```
Uncaught DOMException: Failed to execute 'querySelectorAll' on 'Document': '[data-render=planet4-blocks/covers]' is not a valid selector.
```
[Example live page](https://www.greenpeace.org/aotearoa/petition/open-letter-oil-exploration-petition/)

### Testing

- [Broken version](https://www-dev.greenpeace.org/test-rhea/take-action/)
- [Fixed version](https://www-dev.greenpeace.org/test-pandora/take-action/)