### PR TITLE
PLANET-7318: E2E test for blocks report API endpoint

### DIFF
--- a/tests/e2e/blocks-report-api.spec.js
+++ b/tests/e2e/blocks-report-api.spec.js
@@ -1,0 +1,22 @@
+import {test, expect} from './tools/lib/test-utils.js';
+
+test('Test Blocks report API', async ({page, requestUtils}) => {
+  await page.goto('./wp-admin/');
+
+  const apiRoute = './wp-json/plugin_blocks/v3/plugin_blocks_report';
+  const response = await requestUtils.request.fetch(apiRoute, {
+    failOnStatusCode: true,
+  });
+
+  expect(response.ok()).toBeTruthy();
+  expect(response.headers()['content-type']).toBe('application/json; charset=UTF-8');
+
+  const json = await response.json();
+  expect(json).toHaveProperty('block_types');
+  expect(json).toHaveProperty('block_patterns');
+  expect(json).toHaveProperty('post_types');
+
+  expect(Object.keys(json.block_types)).not.toBe([]);
+  expect(Object.keys(json.block_patterns)).not.toBe([]);
+  expect(Object.keys(json.post_types)).not.toBe([]);
+});


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7318

> Write a Playwright test to ensure the blocks report API endpoint works. 

The test verifies
- HTTP code and header for response
- Response properties
- Content not empty

## Test

Run locally with 
```
npx playwright test --project="firefox" tests/e2e/blocks-report-api.spec.js
```