### PR TITLE
PLANET-7326: Detect Carousel header in reusable block

### DIFF
--- a/classes/blocks/class-carouselheader.php
+++ b/classes/blocks/class-carouselheader.php
@@ -36,7 +36,7 @@ class CarouselHeader extends Base_Block {
 	 */
 	public function register_carouselheader_block() {
 		register_block_type(
-			'planet4-blocks/carousel-header',
+			self::get_full_block_name(),
 			[
 				'render_callback' => [ $this, 'front_end_rendered_fallback' ],
 				'attributes'      => [
@@ -89,20 +89,6 @@ class CarouselHeader extends Base_Block {
 		);
 
 		add_action( 'enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ] );
-		add_action(
-			'wp_enqueue_scripts',
-			static function () {
-				if ( has_block( 'planet4-blocks/carousel-header' ) ) {
-					wp_enqueue_script(
-						'hammer',
-						'https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js',
-						[],
-						'2.0.8',
-						true
-					);
-				}
-			}
-		);
 		add_action( 'wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ] );
 	}
 
@@ -113,6 +99,22 @@ class CarouselHeader extends Base_Block {
 	 */
 	public function prepare_data( $fields ): array {
 		return [];
+	}
+
+	/**
+	 * Load additional frontend assets
+	 */
+	public static function enqueue_frontend_assets() {
+		if ( BlockList::has_block( self::get_full_block_name() ) ) {
+			wp_enqueue_script(
+				'hammer',
+				'https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js',
+				[],
+				'2.0.8',
+				true
+			);
+		}
+		parent::enqueue_frontend_assets();
 	}
 
 	/**

--- a/classes/blocks/class-gallery.php
+++ b/classes/blocks/class-gallery.php
@@ -103,20 +103,6 @@ class Gallery extends Base_Block {
 		);
 
 		add_action( 'enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ] );
-		add_action(
-			'wp_enqueue_scripts',
-			static function () {
-				if ( has_block( 'planet4-blocks/gallery' ) ) {
-					wp_enqueue_script(
-						'hammer',
-						'https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js',
-						[],
-						'2.0.8',
-						true
-					);
-				}
-			}
-		);
 		add_action( 'wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ] );
 	}
 
@@ -127,6 +113,22 @@ class Gallery extends Base_Block {
 	 */
 	public function prepare_data( $fields ): array {
 		return [];
+	}
+
+	/**
+	 * Load additional frontend assets
+	 */
+	public static function enqueue_frontend_assets() {
+		if ( BlockList::has_block( self::get_full_block_name() ) ) {
+			wp_enqueue_script(
+				'hammer',
+				'https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js',
+				[],
+				'2.0.8',
+				true
+			);
+		}
+		parent::enqueue_frontend_assets();
 	}
 
 	/**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7326

> When a Carousel Header is used in a Reusable block, the dependency library Hammer is not loaded. It is because we use the `has_block()` native function that can't read into reusable blocks.

Same issue for Gallery block.

## Test

Cf. [demo page on test instance](https://www-dev.greenpeace.org/test-neptune/reusable-block-test-page/)

- create a reusable block with a Carousel Header in it
- use this reusable block in a page
- frontend should show the Carousel and not crash with a console message `Hammer is not defined`