### PR TITLE
PLANET-7330 Take menu order option into account for ordering Covers block

### DIFF
--- a/classes/blocks/class-covers.php
+++ b/classes/blocks/class-covers.php
@@ -255,8 +255,9 @@ class Covers extends Base_Block {
 			'post_type'        => ActionPage::POST_TYPE,
 			'post_status'      => 'publish',
 			'orderby'          => [
-				'date'  => 'DESC',
-				'title' => 'ASC',
+				'menu_order' => 'ASC',
+				'date'       => 'DESC',
+				'title'      => 'ASC',
 			],
 			'suppress_filters' => false,
 			'numberposts'      => self::numberposts( $layout ),
@@ -454,7 +455,7 @@ class Covers extends Base_Block {
 				usort(
 					$actions,
 					function ( $a, $b ) {
-						return $b->post_date <=> $a->post_date;
+						return $a->menu_order <=> $b->menu_order;
 					}
 				);
 			}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7330

---

The `menu_order` option was missing from the `orderby` parapmeters.

Since we also still look for Act children pages, sorting after merging the two arrays was also adjusted to use that option instead of publication date.

### Testing
#### Just with Actions
1. Add a Covers block with a Tag that has at least 3 Actions to show.
2. See the one that is shown first. Probably it's going to be the one with the most recent publication date.
3. Edit one of this Actions and in the Sidebar change the Order to `2` under "Post Attributes".
4. Refresh the frontend page with the Covers block. Now that Action should be the last one.
#### With both Actions and Act children pages
1. Uncheck the "New IA" feature flag under _Planet 4 > Navigation_ in order to see what page is designated as the "Act" page. If none, select one and save. Then re-activate the "New IA" feature flag.
2. Create a child page under the "Act" page, and the same Tag as in Actions above.
3. Check in which place it's being displayed in the covers block.
4. Adjust Order under "Page Attributes" and validate it's affecting the order in the Covers block.