### PR TITLE
PLANET-7331: Optimize Block report queries

### DIFF
--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -66,8 +66,14 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 		public function plugin_blocks_report_rest_api() {
 			global $wpdb;
 
-
-			do_action( 'qm/start', 'postTypesApi' );
+			$use_cache = ! current_user_can( 'manage_options' );
+			$cache_key = 'plugin_blocks/v3/plugin_blocks_report';
+			if ( $use_cache ) {
+				$report = wp_cache_get( $cache_key, 'api', false, $found );
+				if ( $found ) {
+					return $report;
+				}
+			}
 
 			$types = \get_post_types(
 				[
@@ -94,9 +100,6 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 				array_map( 'intval', array_column( $results, 'post_count' ) )
 			);
 
-			do_action( 'qm/stop', 'postTypesApi' );
-			do_action( 'qm/start', 'usageApi' );
-
 			// Group results.
 			$block_api   = new BlockUsageApi();
 			$pattern_api = new PatternUsageApi();
@@ -105,8 +108,8 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 				'block_patterns' => $pattern_api->get_count(),
 				'post_types'     => $post_types,
 			];
+			wp_cache_set( $cache_key, $report, 'api', 60 * 5 );
 
-			do_action( 'qm/stop', 'usageApi' );
 			return $report;
 		}
 

--- a/classes/controller/menu/class-blocks-usage-controller.php
+++ b/classes/controller/menu/class-blocks-usage-controller.php
@@ -66,6 +66,9 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 		public function plugin_blocks_report_rest_api() {
 			global $wpdb;
 
+
+			do_action( 'qm/start', 'postTypesApi' );
+
 			$types = \get_post_types(
 				[
 					'public'              => true,
@@ -91,6 +94,9 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 				array_map( 'intval', array_column( $results, 'post_count' ) )
 			);
 
+			do_action( 'qm/stop', 'postTypesApi' );
+			do_action( 'qm/start', 'usageApi' );
+
 			// Group results.
 			$block_api   = new BlockUsageApi();
 			$pattern_api = new PatternUsageApi();
@@ -100,6 +106,7 @@ if ( ! class_exists( 'Blocks_Usage_Controller' ) ) {
 				'post_types'     => $post_types,
 			];
 
+			do_action( 'qm/stop', 'usageApi' );
 			return $report;
 		}
 

--- a/classes/search/block/sql/class-like.php
+++ b/classes/search/block/sql/class-like.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Block search regex
+ *
+ * @package P4BKS\Search\Block
+ */
+
+namespace P4GBKS\Search\Block\Sql;
+
+use P4GBKS\Search\Block\Query\Parameters;
+
+/**
+ * Regular expression used in SQL query
+ */
+class Like {
+	/**
+	 * @var Parameters
+	 */
+	private $params;
+
+	/**
+	 * @param Parameters $params Query parameters.
+	 */
+	public function __construct( Parameters $params ) {
+		$this->params = $params;
+	}
+
+	/**
+	 * @return string
+	 * @todo: $params->attributes not implemented.
+	 */
+	public function __toString(): string {
+		$block_ns   = $this->params->namespace();
+		$block_name = $this->params->name();
+
+		if ( 'core' === $block_ns ) {
+			$block = '%';
+		} elseif ( 0 === strpos( $block_name, 'core/' ) ) {
+			$block = explode( '/', $block_name )[1];
+		} else {
+			$name  = $block_name ? $block_name : '%';
+			$block = $block_ns ? $block_ns . '/%' : $name;
+		}
+		$attrs = $this->params->content() ? '%' . $this->params->content() . '%' : '%';
+
+		return sprintf( '%%<!-- wp:%s %s', $block, $attrs );
+	}
+}

--- a/classes/search/block/sql/class-sqlquery.php
+++ b/classes/search/block/sql/class-sqlquery.php
@@ -53,11 +53,13 @@ class SqlQuery implements Block\Query {
 	private function get_sql_query( Block\Query\Parameters ...$params_list ): string {
 		// Prepare query parameters.
 		$regex  = [];
+		$like   = [];
 		$status = [];
 		$type   = [];
 		$order  = [];
 		foreach ( $params_list as $params ) {
-			$regex[] = ( new Regex( $params ) )->__toString();
+			//$regex[] = ( new Regex( $params ) )->__toString();
+			$like[]  = ( new Like( $params ) )->__toString();
 			$status  = array_merge( $status, $params->post_status() ?? [] );
 			$type    = array_merge( $type, $params->post_type() ?? [] );
 			$order   = array_merge( $order, $params->order() ?? [] );
@@ -76,6 +78,9 @@ class SqlQuery implements Block\Query {
 		}
 		foreach ( $regex as $r ) {
 			$sql .= ' AND post_content REGEXP ' . $sql_params->string( $r ) . ' ';
+		}
+		foreach ( $like as $l ) {
+			$sql .= ' AND post_content LIKE ' . $sql_params->string( $l ) . ' ';
 		}
 		if ( ! empty( $order ) ) {
 			$sql .= ' ORDER BY ' . implode( ',', $order );

--- a/classes/search/block/sql/class-sqlquery.php
+++ b/classes/search/block/sql/class-sqlquery.php
@@ -52,17 +52,15 @@ class SqlQuery implements Block\Query {
 	 */
 	private function get_sql_query( Block\Query\Parameters ...$params_list ): string {
 		// Prepare query parameters.
-		$regex  = [];
 		$like   = [];
 		$status = [];
 		$type   = [];
 		$order  = [];
 		foreach ( $params_list as $params ) {
-			//$regex[] = ( new Regex( $params ) )->__toString();
-			$like[]  = ( new Like( $params ) )->__toString();
-			$status  = array_merge( $status, $params->post_status() ?? [] );
-			$type    = array_merge( $type, $params->post_type() ?? [] );
-			$order   = array_merge( $order, $params->order() ?? [] );
+			$like[] = ( new Like( $params ) )->__toString();
+			$status = array_merge( $status, $params->post_status() ?? [] );
+			$type   = array_merge( $type, $params->post_type() ?? [] );
+			$order  = array_merge( $order, $params->order() ?? [] );
 		}
 		$status = array_unique( array_filter( $status ) );
 		$type   = array_unique( array_filter( $type ) );
@@ -75,9 +73,6 @@ class SqlQuery implements Block\Query {
 			WHERE post_status IN ' . $sql_params->string_list( $status );
 		if ( ! empty( $type ) ) {
 			$sql .= ' AND post_type IN ' . $sql_params->string_list( $type );
-		}
-		foreach ( $regex as $r ) {
-			$sql .= ' AND post_content REGEXP ' . $sql_params->string( $r ) . ' ';
 		}
 		foreach ( $like as $l ) {
 			$sql .= ' AND post_content LIKE ' . $sql_params->string( $l ) . ' ';

--- a/classes/search/pattern/class-patternusageapi.php
+++ b/classes/search/pattern/class-patternusageapi.php
@@ -69,7 +69,7 @@ class PatternUsageApi {
 	private function fetch_items(): void {
 		$this->items = $this->usage->get_patterns(
 			$this->params,
-			[ 'use_struct' => false, 'use_class' => false ]
+			[ 'use_struct' => false ]
 		);
 	}
 

--- a/classes/search/pattern/class-patternusageapi.php
+++ b/classes/search/pattern/class-patternusageapi.php
@@ -69,7 +69,7 @@ class PatternUsageApi {
 	private function fetch_items(): void {
 		$this->items = $this->usage->get_patterns(
 			$this->params,
-			[ 'use_struct' => false ]
+			[ 'use_struct' => false, 'use_class' => false ]
 		);
 	}
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7331

3 strategies to avoid timeouts during report request:
- Change `REGEX` queries to `LIKE`
  - this gives 30 to 50% gain on query speed
  - results are still filtered in PHP afterward, so it doesn't change the end result
- Query the namespaces of pattern templates instead of full names
  - this effectively reduces the number of queries for templates from `n` templates to 1
- Cache result
  - to avoid any query spam, results are cached 5 minutes 

This branch is deployed on [Belgium dev site](https://www-dev.greenpeace.org/belgium/wp-json/plugin_blocks/v3/plugin_blocks_report), prod site is currently timing out on this request.
Tested locally using Belgium database, and diffing api result on main branch and this branch - json object should be the same (keys and values)