### PR TITLE
PLANET-7297 Fix Carousel Header editor slide change

### DIFF
--- a/assets/src/blocks/CarouselHeader/SidebarSlide.js
+++ b/assets/src/blocks/CarouselHeader/SidebarSlide.js
@@ -5,7 +5,7 @@ import {
   CheckboxControl,
 } from '@wordpress/components';
 import {URLInput} from '../../components/URLInput/URLInput';
-import {useState, useEffect} from '@wordpress/element';
+import {useState} from '@wordpress/element';
 const {__} = wp.i18n;
 
 export const SidebarSlide = ({
@@ -37,13 +37,10 @@ export const SidebarSlide = ({
 
   const onToggleHandler = opened => {
     setIsOpened(opened);
-  };
-
-  useEffect(() => {
-    if (isOpened) {
+    if (opened) {
       goToSlideHandler(index);
     }
-  }, [isOpened, goToSlideHandler, index]);
+  };
 
   return (
     <div


### PR DESCRIPTION
### Description

See [PLANET-7297](https://jira.greenpeace.org/browse/PLANET-7297)

Before this fix, it would go wild in the editor if several slides were open at the same time via the sidebar.

### Testing

In the editor, add a CarouselHeader with at least 2 slides. Then open said slides one after another using the sidebar tabs. On `main` branch the block will keep going back and forth between the 2 slides, whereas on this branch it will stay on the latest open one which is the expected behaviour.
