### PR TITLE
PLANET-7334: Fix HappyPoint height on mobile with Recaptcha

### DIFF
--- a/assets/src/styles/blocks/Happypoint.scss
+++ b/assets/src/styles/blocks/Happypoint.scss
@@ -13,7 +13,8 @@
   }
 
   @include mobile-only {
-    height: 544px;
+    height: auto;
+    min-height: 544px;
   }
 
   @include medium-and-up {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7334

A Happy Point containing an embed Hubspot form with Recaptcha doesn't always fit the entire form, the submit button is pushed down when Recaptcha appears after page loading; the wrapper div can't resize for that.
Passing its height to `auto` on mobile allows it to resize according to the change of the content.

<img src="https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/assets/617346/f10a3914-4199-4334-b9c2-bf68d9a788f5" float="left" />
<img src="https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/assets/617346/fb80eeff-15b4-465c-9e72-917f8d0d74e7" />
