### PR TITLE
Fix double declaration of pre-publish checklist

### DIFF
--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -18,7 +18,6 @@ import {blockEditorValidation} from './BlockEditorValidation';
 import {registerBlock as registerShareButtonsBlock} from './blocks/ShareButtons/ShareButtonsBlock';
 import {registerBlockTemplates} from './block-templates/register';
 
-blockEditorValidation();
 registerColumnsBlock();
 new CookiesBlock();
 new HappypointBlock();


### PR DESCRIPTION
Remove duplicate call of block validation system
`blockEditorValidation` is already called l.40, triggering the console warning `Plugin "pre-publish-checklist" is already registered.`.