### PR TITLE
PLANET-7302 Make sure Cookies block isn't already registered

### DIFF
--- a/assets/src/blocks/Cookies/CookiesFieldResetButton.js
+++ b/assets/src/blocks/Cookies/CookiesFieldResetButton.js
@@ -13,6 +13,9 @@ export const CookiesFieldResetButton = ({fieldName, toAttribute, currentValue}) 
 
   return (
     <div className="field-reset-button">
+      <Tooltip text={__('This value is defined in the settings, in Planet 4 > Cookies', 'planet4-blocks-backend')}>
+        <span className="info">i</span>
+      </Tooltip>
       <span
         className="cta"
         onClick={() => toAttribute(fieldName)(undefined)}
@@ -20,9 +23,6 @@ export const CookiesFieldResetButton = ({fieldName, toAttribute, currentValue}) 
       >
         {__('Use default value', 'planet4-blocks-backend')}
       </span>
-      <Tooltip text={__('This value is defined in the settings, in Planet 4 > Cookies', 'planet4-blocks-backend')}>
-        <span className="info">i</span>
-      </Tooltip>
     </div>
   );
 };

--- a/assets/src/styles/blocks/Cookies/CookiesEditor.scss
+++ b/assets/src/styles/blocks/Cookies/CookiesEditor.scss
@@ -5,10 +5,10 @@
 
   .field-reset-button {
     display: inline-block;
-    color: var(--link--color);
+    color: var(--grey-600);
     margin-inline-start: 16px;
-    font-family: var(--font-family-primary);
-    font-size: 14px;
+    font-family: var(--font-family-tertiary);
+    font-size: 13px;
     vertical-align: middle;
     white-space: nowrap;
 
@@ -21,13 +21,13 @@
     }
 
     .info {
-      margin-inline-start: 8px;
+      margin-inline-end: 8px;
       border-radius: 50%;
       width: 18px;
       height: 18px;
       display: inline-block;
       text-align: center;
-      border: solid 1px var(--grey-900);
+      border: solid 1px var(--grey-600);
     }
   }
 }

--- a/classes/blocks/class-cookies.php
+++ b/classes/blocks/class-cookies.php
@@ -7,6 +7,8 @@
 
 namespace P4GBKS\Blocks;
 
+use WP_Block_Type_Registry;
+
 /**
  * Class Cookies
  *
@@ -21,6 +23,10 @@ class Cookies extends Base_Block {
 	 * Cookies constructor.
 	 */
 	public function __construct() {
+		if ( WP_Block_Type_Registry::get_instance()->is_registered( self::get_full_block_name() ) ) {
+			return;
+		}
+
 		register_block_type(
 			self::get_full_block_name(),
 			[


### PR DESCRIPTION
### Description

See [PLANET-7302](https://jira.greenpeace.org/browse/PLANET-7302)

This PR also includes small style fixes for the `CookiesFieldResetButton` component, following this [mockup](https://www.figma.com/file/9NtbY8n3at8uOEJTsLrETb/P4-Design-System?type=design&node-id=4843%3A11035&mode=design&t=9qnx7PZ7YsEeosgJ-1). This was forgotten when working on the new identity.

**Related PR:** https://github.com/greenpeace/planet4-master-theme/pull/2167