### PR TITLE
PLANET-7286 Fix Media & Text parallax effect

### DIFF
--- a/assets/src/components/Parallax/setupParallax.js
+++ b/assets/src/components/Parallax/setupParallax.js
@@ -14,6 +14,6 @@ export const setupParallax = () => {
   });
 
   if (mobileSpeedAllSetup) {
-    return new Rellax('.is-style-parallax img', {}); // eslint-disable-line no-undef
+    return new Rellax('.is-style-parallax img', {center: true}); // eslint-disable-line no-undef
   }
 };


### PR DESCRIPTION
### Description

See [PLANET-7286](https://jira.greenpeace.org/browse/PLANET-7286)

It looked broken when applied to blocks situated lower on the page. This solution is not perfect, but I think that it already looks much better and it's a quick fix!

### Testing

Make sure to test in different screen sizes. As you scroll down the page, the parallax effect should now look better than before:
- [Fixed version](https://www-dev.greenpeace.org/test-rhea/parallax-tests-2/)
- [Broken version](https://www-dev.greenpeace.org/test-saturn/parallax-tests-broken-version/)