### PR TITLE
PLANET-7301: Ensure to not re-instantiate the Carousel Header block from plugin

### DIFF
--- a/classes/blocks/class-carouselheader.php
+++ b/classes/blocks/class-carouselheader.php
@@ -8,6 +8,8 @@
 
 namespace P4GBKS\Blocks;
 
+use WP_Block_Type_Registry;
+
 /**
  * Class CarouselHeader
  * Registers the CarouselHeader block.
@@ -28,6 +30,10 @@ class CarouselHeader extends Base_Block {
 	 * CarouselHeader constructor.
 	 */
 	public function __construct() {
+		if ( WP_Block_Type_Registry::get_instance()->is_registered( self::get_full_block_name() ) ) {
+			return;
+		}
+
 		$this->register_carouselheader_block();
 	}
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7301

# Description
Move the CarouselHeader block to master-theme

Related to https://github.com/greenpeace/planet4-master-theme/pull/2171

<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
