### PR TITLE
PLANET-7300: Ensure to not re-instantiate the Accrordion class block from plugin

### DIFF
--- a/classes/blocks/class-accordion.php
+++ b/classes/blocks/class-accordion.php
@@ -8,6 +8,8 @@
 
 namespace P4GBKS\Blocks;
 
+use WP_Block_Type_Registry;
+
 /**
  * Class Accordion
  *
@@ -26,6 +28,10 @@ class Accordion extends Base_Block {
 	 * Accordion constructor.
 	 */
 	public function __construct() {
+		if ( WP_Block_Type_Registry::get_instance()->is_registered( self::get_full_block_name() ) ) {
+			return;
+		}
+
 		$this->register_accordion_block();
 	}
 


### PR DESCRIPTION
Ref: [PLANET-7300](https://jira.greenpeace.org/browse/PLANET-7300)

# Description
Move the Accordion block to master-theme

Related to [#2173](https://github.com/greenpeace/planet4-master-theme/pull/2173)