### PR TITLE
PLANET-7314: Fix Page Header on small screens

### DIFF
--- a/assets/src/styles/blocks/PageHeader.scss
+++ b/assets/src/styles/blocks/PageHeader.scss
@@ -6,7 +6,6 @@ $text-column-padding-in: 24px;
 
 .wp-block-media-text.alignfull.is-pattern-p4-page-header {
   grid-template-columns: 100%;
-  min-width: 360px;
   width: 100vw;
   padding: $sp-6 0;
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7314

Demo page: https://www-dev.greenpeace.org/test-rhea/page-header-demo-page/

# Description
Remove the `min-width` property since seems not be not necessary in this case.

<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
