### PR TITLE
PLANET-7306: Make sure to not instantiate the Take Action Boxout class twice

### DIFF
--- a/classes/blocks/class-takeactionboxout.php
+++ b/classes/blocks/class-takeactionboxout.php
@@ -7,6 +7,8 @@
 
 namespace P4GBKS\Blocks;
 
+use WP_Block_Type_Registry;
+
 /**
  * Class TakeActionBoxout
  *
@@ -25,6 +27,10 @@ class TakeActionBoxout extends Base_Block {
 	 * TakeActionBoxout constructor.
 	 */
 	public function __construct() {
+		if ( WP_Block_Type_Registry::get_instance()->is_registered( self::get_full_block_name() ) ) {
+			return;
+		}
+
 		$this->register_takeactionboxout_block();
 	}
 


### PR DESCRIPTION
Ref: [PLANET-7306](https://jira.greenpeace.org/browse/PLANET-7306)

# Description
Move the Take Action Boxout block into master-theme

Related to [#2175](https://github.com/greenpeace/planet4-master-theme/pull/2183)