### PR TITLE
PLANET-6924: Fix Tag and Post Type selector

### DIFF
--- a/assets/src/components/PostTypeSelector/PostTypeSelector.js
+++ b/assets/src/components/PostTypeSelector/PostTypeSelector.js
@@ -1,43 +1,34 @@
-import {Component} from '@wordpress/element';
+import {memo, useMemo} from '@wordpress/element';
 import {compose} from '@wordpress/compose';
 import {withSelect} from '@wordpress/data';
 import {FormTokenField} from '@wordpress/components';
+import {useSelector} from '../../functions/useSelector';
 
-class PostTypeSelector extends Component {
-  constructor(props) {
-    super(props);
+const PostTypeSelector = memo(props => {
+  const {suggestions, onChange, label, placeholder, value, ...ownProps} = props;
+  const [parsedSuggestions, parsedValue, handleChange] = useSelector(suggestions, value, onChange);
 
-    this.handleChange = this.handleChange.bind(this);
-  }
-
-  handleChange(value) {
-    const postTypeIds = value.map(postTypeName => {
-      return this.props.postTypes.find(postType => postType.name === postTypeName).id;
-    });
-    this.props.onChange(postTypeIds);
-  }
-
-  render() {
-    // eslint-disable-next-line no-unused-vars
-    const {postTypes, onChange, label, placeholder, value, ...ownProps} = this.props;
-
-    if (!postTypes || postTypes.length === 0) {
-      return null;
-    }
-
-    return <FormTokenField
-      suggestions={postTypes.map(postType => postType.name)}
+  return useMemo(() => (
+    <FormTokenField
+      suggestions={parsedSuggestions}
       label={label || 'Select Post Types'}
-      onChange={this.handleChange}
+      onChange={handleChange}
       placeholder={placeholder || 'Select Post Types'}
-      value={value ? value.map(postTypeId => postTypes.find(postType => Number(postType.id) === Number(postTypeId)).name) : []}
+      value={parsedValue}
       {...ownProps}
-    />;
-  }
-}
+    />
+  ), [
+    label,
+    handleChange,
+    ownProps,
+    placeholder,
+    parsedSuggestions,
+    parsedValue,
+  ]);
+});
 
 export default compose(
   withSelect(select => ({
-    postTypes: select('core').getEntityRecords('taxonomy', 'p4-page-type'),
+    suggestions: select('core').getEntityRecords('taxonomy', 'p4-page-type') || [],
   }))
 )(PostTypeSelector);

--- a/assets/src/components/TagSelector/TagSelector.js
+++ b/assets/src/components/TagSelector/TagSelector.js
@@ -1,64 +1,34 @@
-import {Component} from '@wordpress/element';
+import {memo, useMemo} from '@wordpress/element';
 import {compose} from '@wordpress/compose';
 import {withSelect} from '@wordpress/data';
-import {
-  FormTokenField,
-} from '@wordpress/components';
+import {FormTokenField} from '@wordpress/components';
+import {useSelector} from '../../functions/useSelector';
 
-class TagSelector extends Component {
-  constructor(props) {
-    super(props);
+const TagSelector = memo(props => {
+  const {suggestions, onChange, label, placeholder, value, ...ownProps} = props;
+  const [parsedSuggestions, parsedValue, handleChange] = useSelector(suggestions, value, onChange);
 
-    this.handleChange = this.handleChange.bind(this);
-    this.getValue = this.getValue.bind(this);
-  }
-
-  handleChange(value) {
-    const tagIds = value.map(token => {
-      return this.props.tagSuggestions.find(tag => tag.name === token).id;
-    });
-    this.props.onChange(tagIds);
-  }
-
-  getValue() {
-    const {tagSuggestions, value} = this.props;
-
-    if (!tagSuggestions || !value) {
-      return null;
-    }
-
-    const tags = value.reduce((accumulator, tagId) => {
-      const tag = tagSuggestions.find(tagFound => Number(tagFound.id) === Number(tagId));
-      if (tag) {
-        accumulator.push(tag);
-      }
-      return accumulator;
-    }, []);
-
-    return tags.map(tag => tag.name);
-  }
-
-  render() {
-    // eslint-disable-next-line no-unused-vars
-    const {tagSuggestions, onChange, label, placeholder, value, ...ownProps} = this.props;
-
-    if (!tagSuggestions || tagSuggestions.length === 0) {
-      return null;
-    }
-
-    return <FormTokenField
-      suggestions={tagSuggestions.map(tagSuggestion => tagSuggestion.name)}
+  return useMemo(() => (
+    <FormTokenField
+      suggestions={parsedSuggestions}
       label={label || 'Select Tags'}
-      onChange={this.handleChange}
+      onChange={handleChange}
       placeholder={placeholder || 'Select Tags'}
-      value={this.getValue()}
+      value={parsedValue}
       {...ownProps}
-    />;
-  }
-}
+    />
+  ), [
+    label,
+    handleChange,
+    ownProps,
+    placeholder,
+    parsedSuggestions,
+    parsedValue,
+  ]);
+});
 
 export default compose(
   withSelect(select => ({
-    tagSuggestions: select('core').getEntityRecords('taxonomy', 'post_tag', {hide_empty: false, per_page: -1}),
+    suggestions: select('core').getEntityRecords('taxonomy', 'post_tag', {hide_empty: false, per_page: -1}) || [],
   }))
 )(TagSelector);

--- a/assets/src/functions/useSelector.js
+++ b/assets/src/functions/useSelector.js
@@ -1,0 +1,52 @@
+import {useCallback, useEffect, useState} from '@wordpress/element';
+
+/**
+ * This function clean up list with potentially including undefined values
+ *
+ * @param {Array} list
+ * @return {Array} A new list excluding 'undefined' values
+ */
+const cleanUpList = list => list.filter(item => item !== undefined);
+
+/**
+ * This hook parse tags, post-types from form token field
+ *
+ * @param {Array}    suggestions list of suggestions (tags, post-types, etc.)
+ * @param {Array}    value       receive a list of IDs
+ * @param {Function} onChange    returns all the IDs to search
+ * @return {Array} A list with parsed suggestions, parsed values and the common handleChange function
+ */
+export const useSelector = (
+  suggestions,
+  value,
+  onChange
+) => {
+  const [parsedSuggestions, setParsedSuggestions] = useState([]);
+  const [parsedValue, setParsedValue] = useState([]);
+
+  const handleChange = useCallback(searchText => {
+    onChange(
+      cleanUpList(
+        searchText.map(text => suggestions.find(item => item.name === text)?.id)
+      )
+    );
+  }, [suggestions, onChange]);
+
+  useEffect(() => {
+    setParsedValue(
+      cleanUpList(value.map(id => suggestions.find(item => item.id === id)?.name))
+    );
+  }, [suggestions, value]);
+
+  useEffect(() => {
+    if(suggestions.length) {
+      setParsedSuggestions(suggestions.map(item => item.name));
+    }
+  }, [suggestions]);
+
+  return [
+    parsedSuggestions,
+    parsedValue,
+    handleChange,
+  ];
+};


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6924

# Description
There are a bunch of improvements included on this PR.

### Fixed the issue
You can validate by following the next steps:
1. Create a new page and insert an [Articles block ](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/28368631fa78eda6a4d15761f9b9251792828bbe/assets/src/blocks/Articles)
2. You can test it on filling with wrong tags or post types (that solves the issue reported)

Also..
### Code refactored
- Since the [TagSelector](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/4fd6f3b6798e2106c33ae35908aba8b019441004/assets/src/components/TagSelector/TagSelector.js) and the [PostTypeSelector](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/4fd6f3b6798e2106c33ae35908aba8b019441004/assets/src/components/PostTypeSelector/PostTypeSelector.js) were using the common logic I decided to move that to a custom hook.
- Migrate both components from a Class to a Functional
