### PR TITLE
PLANET-7425 Fix ignore_categories behaviour for the Articles block

### DIFF
--- a/assets/src/blocks/Articles/ArticlesEditor.js
+++ b/assets/src/blocks/Articles/ArticlesEditor.js
@@ -143,21 +143,19 @@ const renderView = ({attributes, postType, posts, totalPosts}, toAttribute) => {
 export const ArticlesEditor = props => {
   const {isSelected, attributes, setAttributes} = props;
 
-  const {postType, postId} = useSelect(select => ({
+  const {postType, postId, postCategories} = useSelect(select => ({
     postType: select('core/editor').getCurrentPostType(),
     postId: select('core/editor').getCurrentPostId(),
-  })
-  , []);
+    postCategories: select('core/editor').getEditedPostAttribute('categories'),
+  }), []);
 
-  const {posts, totalPosts} = useArticlesFetch(attributes, postType, postId);
+  const {posts, totalPosts} = useArticlesFetch(attributes, postType, postId, postCategories);
 
   const toAttribute = attributeName => value => setAttributes({[attributeName]: value});
 
   return (
     <div>
-      {
-        isSelected && renderEdit(attributes, toAttribute)
-      }
+      {isSelected && renderEdit(attributes, toAttribute)}
       {renderView({attributes, postType, posts, totalPosts}, toAttribute)}
     </div>
   );

--- a/assets/src/blocks/Articles/ArticlesFrontend.js
+++ b/assets/src/blocks/Articles/ArticlesFrontend.js
@@ -12,7 +12,8 @@ export const ArticlesFrontend = ({attributes}) => {
   } = attributes;
 
   const postType = document.body.getAttribute('data-post-type');
-  const postCategories = document.body.getAttribute('data-post-categories')?.split(',') || [];
+  const postCategories = document.body.getAttribute('data-post-categories') ?
+    document.body.getAttribute('data-post-categories').split(',') : [];
 
   const postIdClass = [...document.body.classList].find(classNameFound => /^postid-\d+$/.test(classNameFound));
 

--- a/assets/src/blocks/Articles/ArticlesFrontend.js
+++ b/assets/src/blocks/Articles/ArticlesFrontend.js
@@ -12,14 +12,13 @@ export const ArticlesFrontend = ({attributes}) => {
   } = attributes;
 
   const postType = document.body.getAttribute('data-post-type');
+  const postCategories = document.body.getAttribute('data-post-categories')?.split(',') || [];
 
   const postIdClass = [...document.body.classList].find(classNameFound => /^postid-\d+$/.test(classNameFound));
 
   const postId = !postIdClass ? null : postIdClass.split('-')[1];
 
-  const postCategories = attributes.post_categories || [];
-
-  const {posts, loadNextPage, hasMorePages, loading} = useArticlesFetch(attributes, postType, postId, document.body.dataset.nro, postCategories);
+  const {posts, loadNextPage, hasMorePages, loading} = useArticlesFetch(attributes, postType, postId, postCategories, document.body.dataset.nro);
 
   if (!posts.length) {
     return null;

--- a/assets/src/blocks/Articles/useArticlesFetch.js
+++ b/assets/src/blocks/Articles/useArticlesFetch.js
@@ -5,7 +5,7 @@ import {getAbortController} from '../../functions/getAbortController';
 
 const {apiFetch} = wp;
 
-export const useArticlesFetch = (attributes, postType, postId, baseUrl = null, postCategories = []) => {
+export const useArticlesFetch = (attributes, postType, postId, postCategories = [], baseUrl = null) => {
   const {article_count, post_types, posts, tags, ignore_categories} = attributes;
 
   const [totalPosts, setTotalPosts] = useState(null);
@@ -31,9 +31,12 @@ export const useArticlesFetch = (attributes, postType, postId, baseUrl = null, p
       offset: prevPosts.length,
     };
 
+    if (!ignore_categories) {
+      args.categories = postCategories;
+    }
+
     if (postType === 'post') {
       args.exclude_post_id = postId;
-      args.categories = postCategories;
     }
 
     const path = addQueryArgs('planet4/v1/get-posts', args);

--- a/classes/blocks/class-articles.php
+++ b/classes/blocks/class-articles.php
@@ -148,6 +148,20 @@ class Articles extends Base_Block {
 			$args = self::filter_posts_by_pages_tags( $fields );
 		}
 
+		// These should not be applied if there is a manual override of posts.
+		if ( empty( $fields['posts'] ) ) {
+			// Take categories into account if needed.
+			if ( true !== $fields['ignore_categories'] && isset( $fields['categories'] ) ) {
+				$args['category__in'] = $fields['categories'] ?? [];
+			}
+
+			// For posts we need to exclude the current post.
+			$exclude_post_id = (int) ( $fields['exclude_post_id'] ?? '' );
+			if ( $exclude_post_id ) {
+				$args['post__not_in'] = [ $exclude_post_id ];
+			}
+		}
+
 		// If there is an offset, it means that it's not a first load, but a load more action.
 		// In this case we want to get only the needed amount of posts,
 		// since we already got the total amount in the first load.
@@ -285,13 +299,6 @@ class Articles extends Base_Block {
 	 * @return array
 	 */
 	private static function filter_posts_by_page_types_or_tags( &$fields ) {
-
-		$exclude_post_id   = (int) ( $fields['exclude_post_id'] ?? '' );
-		$ignore_categories = $fields['ignore_categories'];
-
-		// Get page categories.
-		$category_id_array = $fields['categories'] ?? [];
-
 		// If any p4_page_type was selected extract the term's slug to be used in the wp query below.
 		// post_types attribute filtering.
 		$post_types = $fields['post_types'] ?? [];
@@ -321,17 +328,6 @@ class Articles extends Base_Block {
 
 		// Get all posts with arguments.
 		$args = self::DEFAULT_POST_ARGS;
-
-		if ( true !== $ignore_categories ) {
-			if ( $category_id_array ) {
-				$args['category__in'] = $category_id_array;
-			}
-		}
-
-		// For post page block so current main post will exclude.
-		if ( $exclude_post_id ) {
-			$args['post__not_in'] = [ $exclude_post_id ];
-		}
 
 		// Add filter for p4-page-type terms.
 		if ( ! empty( $post_types ) ) {

--- a/classes/blocks/class-articles.php
+++ b/classes/blocks/class-articles.php
@@ -151,8 +151,12 @@ class Articles extends Base_Block {
 		// These should not be applied if there is a manual override of posts.
 		if ( empty( $fields['posts'] ) ) {
 			// Take categories into account if needed.
-			if ( true !== $fields['ignore_categories'] && isset( $fields['categories'] ) ) {
-				$args['category__in'] = $fields['categories'] ?? [];
+			if (
+				true !== $fields['ignore_categories'] &&
+				isset( $fields['categories'] ) &&
+				! empty( $fields['categories'] )
+			) {
+				$args['category__in'] = $fields['categories'];
 			}
 
 			// For posts we need to exclude the current post.


### PR DESCRIPTION
### Description

See [PLANET-7425](https://jira.greenpeace.org/browse/PLANET-7425)

**Related PR:** https://github.com/greenpeace/planet4-master-theme/pull/2212

### Testing

Both in Pages and Posts, the `ignore_categories` attribute should now work as expected!