### PR TITLE
Fix Page Header padding values

### DIFF
--- a/assets/src/styles/blocks/PageHeader.scss
+++ b/assets/src/styles/blocks/PageHeader.scss
@@ -7,7 +7,10 @@ $text-column-padding-in: 24px;
 .wp-block-media-text.alignfull.is-pattern-p4-page-header {
   grid-template-columns: 100%;
   width: 100vw;
-  padding: $sp-6 0;
+
+  @include medium-and-up {
+    padding-bottom: $sp-5;
+  }
 
   @include large-and-up {
     padding: $sp-7 0;
@@ -18,7 +21,6 @@ $text-column-padding-in: 24px;
     grid-row: 1;
 
     img {
-      max-height: 270px;
       object-fit: cover;
     }
   }


### PR DESCRIPTION
**Description:** 

Removed extra padding on the top of Page Header layout to match [Figma](https://www.figma.com/file/9NtbY8n3at8uOEJTsLrETb/P4-Design-System?type=design&node-id=720-31759&mode=design&t=hestPSgmXBRcVBY8-0) designs. 
Also adjusted image height on smaller screens.

**Testing:**
Test instance [page](https://www-dev.greenpeace.org/test-iocaste/test-page-header/) with fix 
Control [Page](https://www-dev.greenpeace.org/africa/en/testing-page-header/)

<!--
Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.
Ideally this should also be part of the commit summary.
-->
