### PR TITLE
PLANET-7444 Fix left/right aligned images in all post types

### DIFF
--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -63,14 +63,21 @@
     position: relative;
   }
 
-  .alignleft {
-    margin: 0 $sp-1 $sp-1 0;
-    padding-top: 6px;
+  @include small-and-up {
+    &.alignleft {
+      float: left;
+      margin-inline-end: $sp-1;
+    }
+
+    &.alignright {
+      float: right;
+      margin-inline-start: $sp-1;
+    }
   }
 
-  .alignright {
-    margin: 0 0 $sp-1 $sp-1;
-    padding-top: 6px;
+  &.aligncenter {
+    margin-left: auto;
+    margin-right: auto;
   }
 
   @include medium-and-up {

--- a/assets/src/styles/blocks/core-overrides/Image.scss
+++ b/assets/src/styles/blocks/core-overrides/Image.scss
@@ -63,16 +63,14 @@
     position: relative;
   }
 
-  @include small-and-up {
-    &.alignleft {
-      float: left;
-      margin-inline-end: $sp-1;
-    }
+  &.alignleft {
+    float: left;
+    margin-inline-end: $sp-1;
+  }
 
-    &.alignright {
-      float: right;
-      margin-inline-start: $sp-1;
-    }
+  &.alignright {
+    float: right;
+    margin-inline-start: $sp-1;
   }
 
   &.aligncenter {


### PR DESCRIPTION
### Description

See [PLANET-7444](https://jira.greenpeace.org/browse/PLANET-7444)
This was only working in posts.

**Related PR:** https://github.com/greenpeace/planet4-master-theme/pull/2226

### Testing

I've added the various Image alignments on the following:
- [Page](https://www-dev.greenpeace.org/test-pandora/page-with-images/)
- [Post](https://www-dev.greenpeace.org/test-pandora/story/1273/post-with-images/)
- [Action](https://www-dev.greenpeace.org/test-pandora/petitions/action-with-images/)