### PR TITLE
PLANET-7486 Fix Page Header block for RTL sites

### DIFF
--- a/assets/src/styles/blocks/PageHeader.scss
+++ b/assets/src/styles/blocks/PageHeader.scss
@@ -28,12 +28,19 @@ $text-column-padding-in: 24px;
   .wp-block-media-text__content {
     grid-column: 1;
     grid-row: 2;
-
     width: fit-content;
     margin: -$sp-5x $sp-3 $sp-3;
     padding-inline-start: 0;
-    padding-inline-end: 0;
     z-index: 1;
+
+    @include medium-and-less {
+      padding-inline-end: 0;
+
+      html[dir="rtl"] & {
+        direction: rtl;
+        padding-inline-end: $sp-1;
+      }
+    }
 
     .wp-block-button {
       width: auto;
@@ -58,10 +65,10 @@ $text-column-padding-in: 24px;
     font-size: $font-size-xxl;
     font-weight: 700;
     line-height: initial;
-    margin-inline-start: -$sp-1;
 
     @include medium-and-less {
       padding: 0 $sp-1;
+      margin: 0 (-$sp-1);
     }
   }
 

--- a/assets/src/styles/blocks/PageHeader.scss
+++ b/assets/src/styles/blocks/PageHeader.scss
@@ -35,9 +35,18 @@ $text-column-padding-in: 24px;
     padding-inline-end: 0;
     z-index: 1;
 
-    .wp-block-button,
-    .wp-block-button a {
+    .wp-block-button {
       width: auto;
+
+      a {
+        width: auto;
+      }
+
+      @include medium-and-less {
+        html[dir="rtl"] & {
+          margin-left: auto;
+        }
+      }
     }
   }
 
@@ -50,6 +59,10 @@ $text-column-padding-in: 24px;
     font-weight: 700;
     line-height: initial;
     margin-inline-start: -$sp-1;
+
+    @include medium-and-less {
+      padding: 0 $sp-1;
+    }
   }
 
   .wp-block-heading.has-background {
@@ -79,8 +92,10 @@ $text-column-padding-in: 24px;
 
     .wp-block-media-text__content {
       margin: -$sp-5x $sp-5x 0;
-      padding-inline-start: 0;
-      padding-inline-end: 0;
+
+      html[dir="rtl"] & {
+        margin-left: auto;
+      }
     }
 
     .wp-block-group:first-child {
@@ -156,12 +171,6 @@ $text-column-padding-in: 24px;
         text-align: left;
       }
     }
-
-    .wp-block-group:first-child {
-      html[dir="rtl"] & {
-        left: calc(#{$title-width-l} - #{$text-column-width-l} + #{$text-column-padding-in});
-      }
-    }
   }
 
   @include x-large-and-up {
@@ -169,19 +178,13 @@ $text-column-padding-in: 24px;
 
     .wp-block-group:first-child {
       html[dir="rtl"] & {
-        left: calc(#{$title-width-l} - #{$text-column-width-xl} + #{$text-column-padding-in});
+        left: 0;
       }
     }
   }
 
   @include xx-large-and-up {
     grid-template-columns: $text-column-width-xxl auto;
-
-    .wp-block-group:first-child {
-      html[dir="rtl"] & {
-        left: calc(#{$title-width-l} - #{$text-column-width-xxl} + #{$text-column-padding-in});
-      }
-    }
   }
 }
 
@@ -196,10 +199,6 @@ $text-column-padding-in: 24px;
     .wp-block-group:first-child {
       left: calc(-1 * (#{$title-width-l} - #{$text-column-width-l} + #{$text-column-padding-in}));
       text-align: right;
-
-      html[dir="rtl"] & {
-        left: 0;
-      }
     }
 
     .wp-block-media-text__media {


### PR DESCRIPTION
### Description

See [PLANET-7486](https://jira.greenpeace.org/browse/PLANET-7486)

I've asked Houssam to have a look to make sure that the behaviour is the one we want.

### Testing

You can compare the fixed version with the broken one by adding `dir="rtl"` to the html element on the following pages:
- [broken](https://www-dev.greenpeace.org/test-rhea/page-headers/)
- [fixed](https://www-dev.greenpeace.org/test-oberon/page-headers/)

Please make sure to test all screen sizes. Of course the LTR version should still look good as well 🙂 