### PR TITLE
Fix ENForm breaking page when missing title size

### DIFF
--- a/assets/src/blocks/ENForm/ENFormFrontend.js
+++ b/assets/src/blocks/ENForm/ENFormFrontend.js
@@ -42,7 +42,7 @@ export const ENFormFrontend = ({attributes}) => {
   const is_side_style = en_form_style === 'side-style';
   const fields = en_form_fields ?? [];
 
-  const HeadingTag = content_title_size;
+  const HeadingTag = content_title_size || 'h1';
 
   const [activeTplId, setActiveTplId] = useState('signup');
   const [errors, setErrors] = useState({});


### PR DESCRIPTION
Provide default content_title_size if it's missing from the block attributes

![Screenshot from 2024-04-09 18-58-53](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/assets/617346/85d24f7f-95ad-404e-a2a3-526d53155d80)

## Test

Locally, import `africa` DB
- try to edit this page `/en/legacy-donation/`
  - on `main` branch, editor crashes (page becomes empty)
  - on this branch, page is editable