### PR TITLE
Fix ENForm background color

### DIFF
--- a/assets/src/styles/blocks/ENForm/ENFormEditorStyle.scss
+++ b/assets/src/styles/blocks/ENForm/ENFormEditorStyle.scss
@@ -32,7 +32,7 @@
 
   .enform-full-width {
     /* Default enform text color is white, editor background color too */
-    background: grey;
+    background: var(--p4-dark-green-800);
 
     div.submit div.btn {
       width: 32%;

--- a/assets/src/styles/blocks/ENForm/components/_enform-full-width-bg.scss
+++ b/assets/src/styles/blocks/ENForm/components/_enform-full-width-bg.scss
@@ -28,8 +28,6 @@
   }
 
   .enform {
-    background: none;
-
     .form-description {
       margin-bottom: 16px;
     }

--- a/assets/src/styles/blocks/ENForm/components/_enform-full-width.scss
+++ b/assets/src/styles/blocks/ENForm/components/_enform-full-width.scss
@@ -1,4 +1,6 @@
 .enform-full-width {
+  background: var(--p4-dark-green-800);
+
   .container {
     padding: 0;
   }

--- a/assets/src/styles/blocks/ENForm/components/_enform.scss
+++ b/assets/src/styles/blocks/ENForm/components/_enform.scss
@@ -93,7 +93,6 @@
   }
   margin-top: 36px;
   height: inherit;
-  background: var(--white);
   width: 100%;
 
   form {


### PR DESCRIPTION
### Description

The full width version of the block (without background image) should have a green background, see [Slack thread](https://greenpeace-gpi.slack.com/archives/G015K63081W/p1712740351855869)

**Related PR:** https://github.com/greenpeace/planet4-master-theme/pull/2252

### Testing

On the jupiter instance you can deactivate the ["all blocks" feature](https://www-dev.greenpeace.org/test-jupiter/wp-admin/admin.php?page=planet4_settings_features), and then use [this page](https://www-dev.greenpeace.org/test-jupiter/just-an-enform/) to test the plugin version of the block.