### PR TITLE
PLANET-7442 Make sure P4 Columns block isn't registered twice

### DIFF
--- a/classes/blocks/class-columns.php
+++ b/classes/blocks/class-columns.php
@@ -8,6 +8,8 @@
 
 namespace P4GBKS\Blocks;
 
+use WP_Block_Type_Registry;
+
 /**
  * Class Columns_Controller
  *
@@ -35,6 +37,10 @@ class Columns extends Base_Block {
 	 * Columns constructor.
 	 */
 	public function __construct() {
+		if ( WP_Block_Type_Registry::get_instance()->is_registered( self::get_full_block_name() ) ) {
+			return;
+		}
+
 		register_block_type(
 			self::get_full_block_name(),
 			[


### PR DESCRIPTION
### Description

See [PLANET-7442](https://jira.greenpeace.org/browse/PLANET-7442)
This is needed now that we are moving it to the theme

**Related PR:** https://github.com/greenpeace/planet4-master-theme/pull/2256

This PR can already be merged even if the master-theme one isn't ready yet.