### PR TITLE
Rename object_to_array function

### DIFF
--- a/planet4-gutenberg-blocks.php
+++ b/planet4-gutenberg-blocks.php
@@ -385,6 +385,32 @@ if ( class_exists( Elasticpress\Indexables::class ) ) {
 	);
 }
 
+add_filter( 'timber/twig', 'p4_blocks_en_forms_twig_filters' );
+
+/**
+ * Adds functionality to Twig.
+ *
+ * @param \Twig\Environment $twig The Twig environment.
+ * @return \Twig\Environment
+ */
+function p4_blocks_en_forms_twig_filters( $twig ) {
+	// Adding functions as filters.
+	$twig->addFilter(
+		new Twig_SimpleFilter(
+			'object_to_array_plugin',
+			function ( $std_class_object ) {
+				$response = [];
+				foreach ( $std_class_object as $key => $value ) {
+					$response[ $key ] = $value;
+				}
+				return $response;
+			}
+		)
+	);
+
+	return $twig;
+}
+
 /*
 ==========================
 	L O A D  P L U G I N

--- a/templates/blocks/enform/enform_post.twig
+++ b/templates/blocks/enform/enform_post.twig
@@ -57,10 +57,10 @@
 				{% endif %}
 				{% if 'GEN' == field.en_type %}
 					{% set i = 0 %}
-					{% for locale, question_options in field.question_options|object_to_array %}
+					{% for locale, question_options in field.question_options|object_to_array_plugin %}
 						{% if ( locale == field.selected_locale ) %}
 							{% for question_option in question_options %}
-								{% set question_option = question_option|object_to_array %}
+								{% set question_option = question_option|object_to_array_plugin %}
 								<div class="en__field en__field--check en__field--{{ field.id }}">
 									<div class="en__field__element en__field__element--check form-group form-check-label-block custom-control p4-custom-control-input">
 										<label class="custom-control">
@@ -114,10 +114,10 @@
 					{{ field.label|e('wp_kses_post')|raw }}
 				</span><br />
 				{% set i = 0 %}
-				{% for locale, radio_options in field.radio_options|object_to_array %}
+				{% for locale, radio_options in field.radio_options|object_to_array_plugin %}
 					{% if ( locale == field.selected_locale ) %}
 						{% for radio_option in radio_options %}
-							{% set radio_option = radio_option|object_to_array %}
+							{% set radio_option = radio_option|object_to_array_plugin %}
 							<div class="en__field en__field--check en__field--{{ field.id }}">
 								<div class="en__field__element en__field__element--check form-group form-check-label-block custom-control p4-custom-control-input">
 									<label class="custom-control">


### PR DESCRIPTION
### Description

See [Slack thread](https://greenpeace-gpi.slack.com/archives/C016H6ELXAL/p1713776950660969)
This is to avoid registering the same function twice

**Related PR:** https://github.com/greenpeace/planet4-master-theme/pull/2265
