### PR TITLE
PLANET-7461 Fix editor crash when removing Image caption

### DIFF
--- a/assets/src/components/Image/ImageBlockEdit.js
+++ b/assets/src/components/Image/ImageBlockEdit.js
@@ -22,7 +22,7 @@ export const ImageBlockEdit = BlockEdit => {
     const credits = image?.meta?._credit_text;
     // Compile data for insertion
     // eslint-disable-next-line no-nested-ternary
-    const image_credits = credits && credits.length > 0 && !caption.includes(credits) ?
+    const image_credits = credits && credits.length > 0 && (!caption || !caption.includes(credits)) ?
       (credits.includes('©') ? credits : `© ${credits}`) :
       null;
     const block_id = clientId ? `block-${clientId}` : null;


### PR DESCRIPTION
### Description

See [PLANET-7461](https://jira.greenpeace.org/browse/PLANET-7461)

### Testing 

Add an Image block to a page and click the `Remove caption` option. On `main` branch the editor will crash whereas on this branch it should work fine.