### PR TITLE
PLANET-7500: Backend text changes on Happypoint block

### DIFF
--- a/languages/planet4-blocks-backend.pot
+++ b/languages/planet4-blocks-backend.pot
@@ -1168,16 +1168,8 @@ msgstr ""
 msgid "Select focal point for issue image"
 msgstr ""
 
-#: assets/src/blocks/Happypoint/HappypointEditor.js:187
-msgid "Select image focal point"
-msgstr ""
-
-#: assets/src/blocks/Happypoint/HappypointEditor.js:190
-msgid "Drag the mouse to the focal area or input the position with numbers for more precision."
-msgstr ""
-
-#: assets/src/blocks/Happypoint/HappypointEditor.js:198
-msgid "Drag "left" to move across the horizontal axis and slide "top" upwards to move through the vertical axis."
+#: assets/src/blocks/Happypoint/HappypointEditor.js:191
+msgid "Select focus point for background image"
 msgstr ""
 
 #: assets/src/blocks/Gallery/GalleryEditor.js:85


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7500

This PR introduces the following changes to the editor of the Happypoint block:
- The text "Select focus point for background image" was replaced with "Select image focal point".
- The text "Drag the mouse to the focal area or input the position with numbers for more precision" was added below the title.
- The text “Drag “left” to move across the horizontal axis and slide “top” upwards to move through the vertical axis.” was added at the end of the component.

**NOTE:** While the original requirements were different, I couldn't find a way to introduce text above/below the image because that image is part of the [FocalPointPicker](https://developer.wordpress.org/block-editor/reference-guides/components/focal-point-picker/) component. This component is part of the WordPress native components and, unless I'm wrong, cannot be modified. If someone else knows how to edit this component to fulfill the original requirements (maybe there's a hook or similar), please let me know.

![image](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/assets/59029273/96e854dc-8149-4dfe-b6db-0b95e60d6349)