### PR TITLE
PLANET-7565: Replaced deprecated imports in WordPress 6.6.x

### DIFF
--- a/assets/src/BlockEditorValidation.js
+++ b/assets/src/BlockEditorValidation.js
@@ -1,5 +1,5 @@
 const {registerPlugin} = wp.plugins;
-const {PluginPrePublishPanel} = wp.editPost;
+const {PluginPrePublishPanel} = wp.editor;
 const {select, dispatch, subscribe, useSelect} = wp.data;
 const {__} = wp.i18n;
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7565

<hr>

**DESCRIPTION:**
This PR replaces the `PluginPrePublishPanel` component of being imported from `wp.editPost` with `wp.editor` according to the changes introduced by WordPress 6.6

![Screenshot from 2024-07-31 11-15-08](https://github.com/user-attachments/assets/a56f3f3b-6d50-49fa-ace9-1ed50258cdc7)