### PR TITLE
 PLANET-7565: Fix tests broken by WordPress v6.6.x

### DIFF
--- a/tests/e2e/tools/lib/editor.js
+++ b/tests/e2e/tools/lib/editor.js
@@ -14,13 +14,8 @@
 async function openComponentPanel({editor}, panelTitle) {
   await editor.openDocumentSettingsSidebar();
   const editorSettings = await editor.canvas.getByRole('region', {name: 'Editor settings'});
-  await editorSettings.locator('.edit-post-sidebar__panel-tabs button').first().click();
-  const panelButton = await editorSettings.getByRole('button', {name: panelTitle, exact: true});
-  const panelExpanded = await panelButton.getAttribute('aria-expanded');
-  if (panelExpanded === 'false') {
-    await panelButton.click();
-  }
-
+  await editorSettings.locator('.editor-sidebar__panel-tabs button').first().click();
+  await editorSettings.getByLabel('button', {name: panelTitle, exact: true});
   return editorSettings;
 }
 

--- a/tests/e2e/tools/lib/editor.js
+++ b/tests/e2e/tools/lib/editor.js
@@ -15,8 +15,7 @@ async function openComponentPanel({editor}, panelTitle) {
   await editor.openDocumentSettingsSidebar();
   const editorSettings = await editor.canvas.getByRole('region', {name: 'Editor settings'});
   await editorSettings.locator('.editor-sidebar__panel-tabs button').first().click();
-  
-  const panelButton = await editorSettings.getByLabel('button', {name: panelTitle, exact: true});
+  const panelButton = await editorSettings.getByRole('button', {name: panelTitle, exact: true});
   const panelExpanded = await panelButton.getAttribute('aria-expanded');
   if (panelExpanded === 'false') {
     await panelButton.click();

--- a/tests/e2e/tools/lib/editor.js
+++ b/tests/e2e/tools/lib/editor.js
@@ -15,7 +15,13 @@ async function openComponentPanel({editor}, panelTitle) {
   await editor.openDocumentSettingsSidebar();
   const editorSettings = await editor.canvas.getByRole('region', {name: 'Editor settings'});
   await editorSettings.locator('.editor-sidebar__panel-tabs button').first().click();
-  await editorSettings.getByLabel('button', {name: panelTitle, exact: true});
+  
+  const panelButton = await editorSettings.getByLabel('button', {name: panelTitle, exact: true});
+  const panelExpanded = await panelButton.getAttribute('aria-expanded');
+  if (panelExpanded === 'false') {
+    await panelButton.click();
+  }
+
   return editorSettings;
 }
 

--- a/tests/e2e/tools/lib/post.js
+++ b/tests/e2e/tools/lib/post.js
@@ -24,8 +24,6 @@ async function updatePost({page}) {
 
 async function createPostWithFeaturedImage({admin, editor}, params) {
   await admin.createNewPost({...params, legacyCanvas: true});
-  // const editorSettings = await openComponentPanel({editor}, 'Featured image');
-
   const editorSettings = await editor.canvas.getByRole('region', {name: 'Editor settings'});
   await editorSettings.getByRole('button', {name: 'Set featured image'}).click();
   const imageModal = await editor.canvas.getByRole('dialog', {name: 'Featured image'});

--- a/tests/e2e/tools/lib/post.js
+++ b/tests/e2e/tools/lib/post.js
@@ -16,7 +16,7 @@ async function publishPostAndVisit({page, editor}) {
 }
 
 async function updatePost({page}) {
-  const updateButton = await page.locator('.edit-post-header__settings').getByRole('button', {name: 'Update'});
+  const updateButton = await page.locator('.editor-header__settings').getByRole('button', {name: 'Save'});
   await updateButton.click();
 
   return page.waitForSelector('.components-snackbar');

--- a/tests/e2e/tools/lib/post.js
+++ b/tests/e2e/tools/lib/post.js
@@ -1,5 +1,3 @@
-import {openComponentPanel} from './editor.js';
-
 async function publishPost({page, editor}) {
   await editor.publishPost();
 
@@ -26,7 +24,9 @@ async function updatePost({page}) {
 
 async function createPostWithFeaturedImage({admin, editor}, params) {
   await admin.createNewPost({...params, legacyCanvas: true});
-  const editorSettings = await openComponentPanel({editor}, 'Featured image');
+  // const editorSettings = await openComponentPanel({editor}, 'Featured image');
+
+  const editorSettings = await editor.canvas.getByRole('region', {name: 'Editor settings'});
   await editorSettings.getByRole('button', {name: 'Set featured image'}).click();
   const imageModal = await editor.canvas.getByRole('dialog', {name: 'Featured image'});
   const mediaLibTab = await imageModal.getByRole('tab', {name: 'Media Library'});


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7565

<hr>

**DESCRIPTION:**
This PR fixes the failing automated tests after upgrading WordPress to its LTS version ([6.6.1 of 23 July, 2024](https://wordpress.org/download/releases/)).