### PR TITLE
PLANET-7220: Add definitions to blocks settings

### DIFF
--- a/assets/src/blocks/Columns/ColumnsBlock.js
+++ b/assets/src/blocks/Columns/ColumnsBlock.js
@@ -9,7 +9,7 @@ const {registerBlockType} = wp.blocks;
 export const registerColumnsBlock = () =>
   registerBlockType('planet4-blocks/columns', {
     title: 'Planet 4 Columns',
-    description: 'The columns block comes in four styles and groups static content in an aligned, responsive and styled column.',
+    description: __('The columns block comes in four styles and groups static content in an aligned, responsive and styled column.', 'planet4-blocks-backend'),
     icon: 'grid-view',
     category: 'planet4-blocks',
     attributes: {

--- a/assets/src/blocks/Columns/ColumnsBlock.js
+++ b/assets/src/blocks/Columns/ColumnsBlock.js
@@ -9,6 +9,7 @@ const {registerBlockType} = wp.blocks;
 export const registerColumnsBlock = () =>
   registerBlockType('planet4-blocks/columns', {
     title: 'Planet 4 Columns',
+    description: 'The columns block comes in four styles and groups static content in an aligned, responsive and styled column.',
     icon: 'grid-view',
     category: 'planet4-blocks',
     attributes: {

--- a/assets/src/blocks/Columns/ColumnsEditor.js
+++ b/assets/src/blocks/Columns/ColumnsEditor.js
@@ -78,6 +78,14 @@ const renderEdit = (attributes, toAttribute, setAttributes, isSelected) => {
             );
           })}
         </PanelBody>
+        <PanelBody title={__('Learn more about this block ', 'planet4-blocks-backend')} initialOpen={false}>
+          <p className="components-base-control__help">
+            <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/columns/" rel="noreferrer">
+              P4 Handbook Columns
+            </a>
+            {' '} &#127963;&#65039;
+          </p>
+        </PanelBody>
       </InspectorControls>
     </>
   );

--- a/assets/src/blocks/Happypoint/HappypointBlock.js
+++ b/assets/src/blocks/Happypoint/HappypointBlock.js
@@ -8,6 +8,7 @@ export class HappypointBlock {
 
     registerBlockType('planet4-blocks/happypoint', {
       title: __('Happypoint', 'planet4-blocks-backend'),
+      description: __('The happy point block embeds (via iFrame) a “Subscribe” or engagement form on top of a full-width background image.', 'planet4-blocks-backend'),
       icon: 'format-image',
       category: 'planet4-blocks',
       supports: {

--- a/assets/src/blocks/Happypoint/HappypointBlock.js
+++ b/assets/src/blocks/Happypoint/HappypointBlock.js
@@ -7,7 +7,7 @@ export class HappypointBlock {
     const {__} = wp.i18n;
 
     registerBlockType('planet4-blocks/happypoint', {
-      title: __('Happypoint', 'planet4-blocks-backend'),
+      title: 'Happypoint',
       description: __('The happy point block embeds (via iFrame) a “Subscribe” or engagement form on top of a full-width background image.', 'planet4-blocks-backend'),
       icon: 'format-image',
       category: 'planet4-blocks',

--- a/assets/src/blocks/Happypoint/HappypointEditor.js
+++ b/assets/src/blocks/Happypoint/HappypointEditor.js
@@ -203,6 +203,14 @@ export const HappypointEditor = ({attributes, setAttributes, isSelected}) => {
                 </div>
               }
             </PanelBody>
+            <PanelBody title={__('Learn more about this block ', 'planet4-blocks-backend')} initialOpen={false}>
+              <p className="components-base-control__help">
+                <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/happy-point/" rel="noreferrer">
+            P4 Handbook Happy Point
+                </a>
+                {' '} &#128588;
+              </p>
+            </PanelBody>
           </InspectorControls>
           <BlockControls>
             {id && 0 < id && (

--- a/assets/src/blocks/SocialMedia/SocialMediaBlock.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaBlock.js
@@ -9,6 +9,7 @@ const BLOCK_NAME = 'planet4-blocks/social-media';
 
 export const registerSocialMediaBlock = () => registerBlockType(BLOCK_NAME, {
   title: 'Social Media',
+  description: 'An embed-style block, customized to display and align content from Facebook and Instagram by inputting the URL.',
   icon: 'share',
   category: 'planet4-blocks',
   attributes: {

--- a/assets/src/blocks/SocialMedia/SocialMediaBlock.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaBlock.js
@@ -3,13 +3,14 @@ import {socialMediaV1} from './deprecated/socialMediaV1';
 import {OEMBED_EMBED_TYPE, FACEBOOK_PAGE_TAB_TIMELINE} from './SocialMediaConstants.js';
 import {SocialMediaFrontend} from './SocialMediaFrontend.js';
 
+const {__} = wp.i18n;
 const {registerBlockType} = wp.blocks;
 
 const BLOCK_NAME = 'planet4-blocks/social-media';
 
 export const registerSocialMediaBlock = () => registerBlockType(BLOCK_NAME, {
   title: 'Social Media',
-  description: 'An embed-style block, customized to display and align content from Facebook and Instagram by inputting the URL.',
+  description: __('An embed-style block, customized to display and align content from Facebook and Instagram by inputting the URL.', 'planet4-blocks-backend'),
   icon: 'share',
   category: 'planet4-blocks',
   attributes: {

--- a/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
@@ -228,6 +228,14 @@ export const SocialMediaEditor = ({
           onChange={toAttribute('alignment_class')}
         />
       </PanelBody>
+      <PanelBody title={__('Learn more about this block', 'planet4-blocks-backend')} initialOpen={false}>
+        <p className="components-base-control__help">
+          <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/socials/" rel="noreferrer">
+          P4 Handbook Meta Block 
+          </a>
+          {' '} &#129331;
+        </p>
+      </PanelBody>
     </InspectorControls>
   );
 

--- a/assets/src/blocks/Submenu/SubmenuBlock.js
+++ b/assets/src/blocks/Submenu/SubmenuBlock.js
@@ -11,7 +11,7 @@ export const registerSubmenuBlock = () => {
 
   registerBlockType(BLOCK_NAME, {
     title: 'Submenu',
-    description: 'Insert text, media, and other content in an ordered list of clickable headings corresponding to the content sections on the page.',
+    description: __('Insert text, media, and other content in an ordered list of clickable headings corresponding to the content sections on the page.', 'planet4-blocks-backend'),
     icon: 'welcome-widgets-menus',
     category: 'planet4-blocks',
     attributes: {

--- a/assets/src/blocks/Submenu/SubmenuBlock.js
+++ b/assets/src/blocks/Submenu/SubmenuBlock.js
@@ -11,6 +11,7 @@ export const registerSubmenuBlock = () => {
 
   registerBlockType(BLOCK_NAME, {
     title: 'Submenu',
+    description: 'Insert text, media, and other content in an ordered list of clickable headings corresponding to the content sections on the page.',
     icon: 'welcome-widgets-menus',
     category: 'planet4-blocks',
     attributes: {

--- a/assets/src/blocks/Submenu/SubmenuEditor.js
+++ b/assets/src/blocks/Submenu/SubmenuEditor.js
@@ -81,6 +81,14 @@ const renderEdit = (attributes, setAttributes) => {
           {__('Remove level', 'planet4-blocks-backend')}
         </Button>
       </PanelBody>
+      <PanelBody title={__('Learn more about this block', 'planet4-blocks-backend')} initialOpen={false}>
+        <p className="components-base-control__help">
+          <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/table-of-contents/" rel="noreferrer">
+            P4 Handbook P4 Table of Contents
+          </a>
+          {' '} &#128203;
+        </p>
+      </PanelBody>
     </InspectorControls>
   );
 };

--- a/assets/src/blocks/Timeline/TimelineBlock.js
+++ b/assets/src/blocks/Timeline/TimelineBlock.js
@@ -38,6 +38,7 @@ export const registerTimelineBlock = () => {
 
   registerBlockType(BLOCK_NAME, {
     title: 'Timeline',
+    description: 'A type of graphic that arranges a chain of events, activities, and milestones in chronological order.',
     icon: 'clock',
     category: 'planet4-blocks',
     supports: {

--- a/assets/src/blocks/Timeline/TimelineBlock.js
+++ b/assets/src/blocks/Timeline/TimelineBlock.js
@@ -35,10 +35,11 @@ const attributes = {
 export const registerTimelineBlock = () => {
   const {registerBlockType} = wp.blocks;
   const {RawHTML} = wp.element;
+  const {__} = wp.i18n;
 
   registerBlockType(BLOCK_NAME, {
     title: 'Timeline',
-    description: 'A type of graphic that arranges a chain of events, activities, and milestones in chronological order.',
+    description: __('A type of graphic that arranges a chain of events, activities, and milestones in chronological order.', 'planet4-blocks-backend'),
     icon: 'clock',
     category: 'planet4-blocks',
     supports: {

--- a/assets/src/blocks/Timeline/TimelineEditorScript.js
+++ b/assets/src/blocks/Timeline/TimelineEditorScript.js
@@ -82,6 +82,14 @@ const renderEdit = (
         />
 
       </PanelBody>
+      <PanelBody title={__('Learn more about this block', 'planet4-blocks-backend')} initialOpen={false}>
+        <p className="components-base-control__help">
+          <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/timeline/" rel="noreferrer">
+            P4 Handbook Timeline
+          </a>
+          {' '} &#8987;
+        </p>
+      </PanelBody>
     </InspectorControls>
   );
 };


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7220

<hr>

**DESCRIPTION:**
Based on [this mockup](https://www.figma.com/design/87AqKGnduB2Uq5fVkIcdcg/Handbook-Links-in-Backend?node-id=1-437&node-type=FRAME&t=bzJp6zu3cilsg1wU-0), this PR adds a description to some of the blocks in the P4 plugin and an additional collapsible panel body in the editor with a link to the P4 Handbook.

<hr>

**RELATED PR:**
https://github.com/greenpeace/planet4-master-theme/pull/2371