### PR TITLE
PLANET-7584 Remove our custom editor layout margin values

### DIFF
--- a/assets/src/styles/editorStyle.scss
+++ b/assets/src/styles/editorStyle.scss
@@ -27,18 +27,3 @@
 @import "components/HTMLSidebarHelp";
 @import "components/ImageHoverButtons";
 @import "editorFonts";
-
-.block-edit-mode-warning {
-  padding: $sp-2;
-  margin: 0;
-}
-
-.block-editor-block-list__layout > * {
-  margin-top: $sp-1;
-  margin-bottom: $sp-2;
-
-  @include large-and-up {
-    margin-top: $sp-2;
-    margin-bottom: $sp-4;
-  }
-}


### PR DESCRIPTION
### Description

These seem to not be needed anymore, and sometimes they even break our designs in the editor (see [PLANET-7584](https://jira.greenpeace.org/browse/PLANET-7584) and the [corresponding PR](https://github.com/greenpeace/planet4-master-theme/pull/2374))

### Testing

Check out several Pages/Posts/Actions in the editor with the plugin activated, and make sure everything still looks fine.

I've asked Houssam to test this out as well, if he wants to keep the margins then the solution would be to move them to the master theme instead.