### PR TITLE
PLANET-7560 Remove mandatory featured image check for patterns

### DIFF
--- a/assets/src/BlockEditorValidation.js
+++ b/assets/src/BlockEditorValidation.js
@@ -12,6 +12,7 @@ export const blockEditorValidation = () => {
   subscribe(() => {
     const title = select('core/editor').getEditedPostAttribute('title');
     const featuredImage = select('core/editor').getEditedPostAttribute('featured_media');
+    const postType = select('core/editor').getCurrentPostType();
     const postContent = select('core/editor').getEditedPostContent();
     const blocks = select('core/block-editor').getBlocks();
     const currentMessages = [];
@@ -22,7 +23,9 @@ export const blockEditorValidation = () => {
     }
 
     const hasImageInContent = /<img.+wp-image-(\d+).*>/i.test(postContent);
-    if (!featuredImage && !hasImageInContent) {
+    // If postType === 'wp_block' it's a pattern creation, and these don't have featured images.
+    const needsFeaturedImage = postType !== 'wp_block' && !featuredImage && !hasImageInContent;
+    if (needsFeaturedImage) {
       currentMessages.push('Featured image is required.');
     }
 
@@ -52,7 +55,7 @@ export const blockEditorValidation = () => {
     }, []);
     invalidBlocks.forEach(block => currentMessages.push(...block.messages));
 
-    const currentlyValid = (0 === invalidBlocks.length) && !invalidTitle && (featuredImage || hasImageInContent);
+    const currentlyValid = (0 === invalidBlocks.length) && !invalidTitle && !needsFeaturedImage;
     messages = currentMessages;
 
     if (canPublish === currentlyValid) {

--- a/assets/src/BlockEditorValidation.js
+++ b/assets/src/BlockEditorValidation.js
@@ -10,11 +10,14 @@ let canPublish = true;
 
 export const blockEditorValidation = () => {
   subscribe(() => {
-    const title = select('core/editor').getEditedPostAttribute('title');
-    const featuredImage = select('core/editor').getEditedPostAttribute('featured_media');
-    const postType = select('core/editor').getCurrentPostType();
-    const postContent = select('core/editor').getEditedPostContent();
-    const blocks = select('core/block-editor').getBlocks();
+    const {getEditedPostAttribute, getCurrentPostType, getEditedPostContent} = select('core/editor');
+    const {getBlocks} = select('core/block-editor');
+
+    const title = getEditedPostAttribute('title');
+    const featuredImage = getEditedPostAttribute('featured_media');
+    const postType = getCurrentPostType();
+    const postContent = getEditedPostContent();
+    const blocks = getBlocks();
     const currentMessages = [];
 
     const invalidTitle = !title || title.trim().length <= 0;

--- a/assets/src/BlockEditorValidation.js
+++ b/assets/src/BlockEditorValidation.js
@@ -8,6 +8,8 @@ const blockValidations = {};
 let messages = [];
 let canPublish = true;
 
+const POST_TYPES_WITH_REQUIRED_FEATURED_IMAGE = ['p4_action', 'post', 'page', 'campaign'];
+
 export const blockEditorValidation = () => {
   subscribe(() => {
     const {getEditedPostAttribute, getCurrentPostType, getEditedPostContent} = select('core/editor');
@@ -26,8 +28,10 @@ export const blockEditorValidation = () => {
     }
 
     const hasImageInContent = /<img.+wp-image-(\d+).*>/i.test(postContent);
-    // If postType === 'wp_block' it's a pattern creation, and these don't have featured images.
-    const needsFeaturedImage = postType !== 'wp_block' && !featuredImage && !hasImageInContent;
+    const needsFeaturedImage = POST_TYPES_WITH_REQUIRED_FEATURED_IMAGE.includes(postType) &&
+      !featuredImage &&
+      !hasImageInContent;
+
     if (needsFeaturedImage) {
       currentMessages.push('Featured image is required.');
     }


### PR DESCRIPTION
### Description

See [PLANET-7560](https://jira.greenpeace.org/browse/PLANET-7560)

### Testing 

It should now be possible to publish patterns from `Blocks > All reusable blocks > Add new pattern`.