### PR TITLE
PLANET-7501 Show image credits in the editor even when no caption

### DIFF
--- a/assets/src/components/Image/ImageBlockEdit.js
+++ b/assets/src/components/Image/ImageBlockEdit.js
@@ -1,5 +1,3 @@
-const {useSelect} = wp.data;
-
 /**
  * Return an editable image block
  *
@@ -15,16 +13,18 @@ export const ImageBlockEdit = BlockEdit => {
     }
 
     const {attributes, clientId} = props;
-    const {id, caption, className = ''} = attributes;
+    const {id, className = ''} = attributes;
 
     // Get image data
-    const image = useSelect(select => id ? select('core').getMedia(id) : null);
+    const image = wp.data.useSelect(select => id ? select('core').getMedia(id) : null);
     const credits = image?.meta?._credit_text;
+    const captionText = image?.caption?.raw;
     // Compile data for insertion
-    // eslint-disable-next-line no-nested-ternary
-    const image_credits = credits && credits.length > 0 && (!caption || !caption.includes(credits)) ?
-      (credits.includes('©') ? credits : `© ${credits}`) :
-      null;
+    let image_credits = null;
+    if (credits && credits.length > 0 && (!captionText || !captionText.includes(credits))) {
+      image_credits = credits.includes('©') ? credits : `© ${credits}`;
+    }
+
     const block_id = clientId ? `block-${clientId}` : null;
 
     // Update width and height when sized rounded styles are selected
@@ -45,12 +45,14 @@ export const ImageBlockEdit = BlockEdit => {
     return (
       <>
         <BlockEdit {...props} />
-        { block_id && image_credits &&
-          <style dangerouslySetInnerHTML={{__html:
-            `#${block_id} figcaption::after { content: " ${image_credits}"; }`,
-          }}>
-          </style>
-        }
+        {block_id && image_credits && (
+          captionText ?
+            <style dangerouslySetInnerHTML={{
+              __html: `#${block_id} figcaption::after { content: " ${image_credits}"; }`,
+            }}>
+            </style> :
+            <figcaption style={{marginTop: -24}}>{image_credits}</figcaption>
+        )}
       </>
     );
   };


### PR DESCRIPTION
### Description

See [PLANET-7501](https://jira.greenpeace.org/browse/PLANET-7501)

This is to be consistent with the frontend.

### Testing

You can check all use cases in the editor for [this page](https://www-dev.greenpeace.org/test-nix/image-tests/) for example.